### PR TITLE
Remove misleading parse_tokens method (fixes #32)

### DIFF
--- a/chalk
+++ b/chalk
@@ -326,12 +326,6 @@ class Parser {
     field $semiring :param = SPPFViterbiSemiring->new();
     field $grammar :param;
 
-    method parse_tokens(@input) {
-
-  # backward compatibility for some of our tests that predate the lexeme support
-        return $self->parse_string( join( '', @input ) );
-    }
-
     method parse_string($input_string) {
         my $chart = EarleyChart->new( semiring => $semiring );
 

--- a/lib/Chalk/Parser.pm
+++ b/lib/Chalk/Parser.pm
@@ -123,12 +123,6 @@ class Chalk::Parser {
     field $semiring :param = Chalk::Semiring::SPPFViterbiSemiring->new();
     field $grammar :param;
 
-    method parse_tokens(@input) {
-
-  # backward compatibility for some of our tests that predate the lexeme support
-        return $self->parse_string( join( '', @input ) );
-    }
-
     method parse_string($input_string) {
         my $chart = Chalk::EarleyChart->new( semiring => $semiring );
 

--- a/t/basic/01-simple.t
+++ b/t/basic/01-simple.t
@@ -11,5 +11,5 @@ my $grammar = Grammar->build_grammar( [ 'A' => [] ] );
 ok $grammar, $grammar;
 
 my $parser = Parser->new( grammar => $grammar );
-$parser->parse_tokens('A');
+$parser->parse_string('A');
 

--- a/t/basic/simple-arith.t
+++ b/t/basic/simple-arith.t
@@ -16,7 +16,7 @@ my $grammar = Grammar->build_grammar(
 
 my $parser = Parser->new(grammar => $grammar);
 
-my $result = $parser->parse_tokens(qw(num));
+my $result = $parser->parse_string('num');
 say "Single num result: " . (defined $result ? ref($result) . " - $result" : "undef");
 
 ok $result, "Parse single num";
@@ -28,7 +28,7 @@ $grammar = Grammar->build_grammar(
 );
 
 $parser = Parser->new(grammar => $grammar);
-$result = $parser->parse_tokens(qw(num + num));
+$result = $parser->parse_string('num+num');
 say "Addition result: " . (defined $result ? ref($result) . " - $result" : "undef");
 
 ok $result, "Parse num + num";

--- a/t/basic/test-empty-args.t
+++ b/t/basic/test-empty-args.t
@@ -19,10 +19,10 @@ subtest 'Empty argument lists' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('name', '(', 'arg', ')');
+    my $result = $parser->parse_string('name(arg)');
     ok $result, 'Parse call with args';
-    
-    $result = $parser->parse_tokens('name', '(', ')');
+
+    $result = $parser->parse_string('name()');
     ok $result, 'Parse call with empty args';
 };
 
@@ -37,10 +37,10 @@ subtest 'Optional argument lists' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('name', '(', 'arg', ')');
+    my $result = $parser->parse_string('name(arg)');
     ok $result, 'Parse call with args using optional';
-    
-    $result = $parser->parse_tokens('name', '(', ')');
+
+    $result = $parser->parse_string('name()');
     ok $result, 'Parse call with empty args using optional';
 };
 
@@ -55,9 +55,9 @@ subtest 'Method chain debugging' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('Class', '->', 'new', '(', 'arg', ')');
+    my $result = $parser->parse_string('Class->new(arg)');
     ok $result, 'Parse method with args';
-    
-    $result = $parser->parse_tokens('Class', '->', 'new', '(', ')');
+
+    $result = $parser->parse_string('Class->new()');
     ok $result, 'Parse method with empty args';
 };

--- a/t/basic/zero-token-fix.t
+++ b/t/basic/zero-token-fix.t
@@ -16,7 +16,7 @@ subtest 'Zero token regression test' => sub {
     my $grammar = Grammar->build_grammar([ 'Rule' => ['0'] ]);
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('0');
+    my $result = $parser->parse_string('0');
     ok $result, "Parse '0' token succeeds";
     isa_ok $result, ['ViterbiElement'], "Result is ViterbiElement";
     
@@ -29,7 +29,7 @@ subtest 'Other falsy values still work' => sub {
     my $grammar = Grammar->build_grammar([ 'Rule' => [''] ]);
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('');
+    my $result = $parser->parse_string('');
     ok $result, "Parse empty string succeeds";
 };
 
@@ -38,7 +38,7 @@ subtest 'Compare with truthy values' => sub {
     my $grammar = Grammar->build_grammar([ 'Rule' => ['1'] ]);
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('1');
+    my $result = $parser->parse_string('1');
     ok $result, "Parse '1' token succeeds";
     like $result->to_string, qr/Rule -> 1/, "Parse contains expected rule";
 };

--- a/t/grammar/test-chalk-complete-grammar.t
+++ b/t/grammar/test-chalk-complete-grammar.t
@@ -170,18 +170,14 @@ subtest 'Basic class structure' => sub {
     my $parser = Parser->new(grammar => $chalk_grammar);
     
     # Simple class
-    my $result = $parser->parse_tokens(
-        'class', 'Element', '{',
-        'field', '$var', ';',
-        '}'
+    my $result = $parser->parse_string(
+        'classElement{field$var;}'
     );
     ok $result, 'Parse simple class';
-    
+
     # Class with inheritance
-    $result = $parser->parse_tokens(
-        'class', 'ViterbiElement', ':isa(', 'Element', ')', '{',
-        'field', '$var', ':param', ';',
-        '}'
+    $result = $parser->parse_string(
+        'classViterbiElement:isa(Element){field$var:param;}'
     );
     ok $result, 'Parse class with inheritance and field attributes';
 };
@@ -189,18 +185,14 @@ subtest 'Basic class structure' => sub {
 subtest 'Overload declarations' => sub {
     my $parser = Parser->new(grammar => $chalk_grammar);
     
-    my $result = $parser->parse_tokens(
-        'class', 'Element', '{',
-        'use', 'overload', "'+'", '=>', "'add'", ';',
-        '}'
+    my $result = $parser->parse_string(
+        'classElement{useoverload\'+\'=>\'add\';}'
     );
     ok $result, 'Parse class with simple overload';
-    
+
     todo "multiple overload specs need lexeme support" => sub {
-        $result = $parser->parse_tokens(
-            'class', 'Element', '{',
-            'use', 'overload', "'+'", '=>', "'add'", ',', 'Identifier', '=>', '1', ';',
-            '}'
+        $result = $parser->parse_string(
+            'classElement{useoverload\'+\'=>\'add\',Identifier=>1;}'
         );
         ok $result, 'Parse class with multiple overload specs';
     };
@@ -210,26 +202,20 @@ subtest 'Method declarations' => sub {
     my $parser = Parser->new(grammar => $chalk_grammar);
     
     # Method with empty parameter list
-    my $result = $parser->parse_tokens(
-        'class', 'Element', '{',
-        'method', 'method', '(', ')', '{', '...', '}',
-        '}'
+    my $result = $parser->parse_string(
+        'classElement{methodmethod(){...}}'
     );
     ok $result, 'Parse method with empty parameters';
-    
+
     # Method with parameters
-    $result = $parser->parse_tokens(
-        'class', 'Element', '{',
-        'method', 'method', '(', '$var', ')', '{', 'return', '$var', ';', '}',
-        '}'
+    $result = $parser->parse_string(
+        'classElement{methodmethod($var){return$var;}}'
     );
     ok $result, 'Parse method with parameter';
-    
+
     # Method with default parameter
-    $result = $parser->parse_tokens(
-        'class', 'Element', '{',
-        'method', 'method', '(', '$var', '=', 'undef', ')', '{', 'return', '$var', ';', '}',
-        '}'
+    $result = $parser->parse_string(
+        'classElement{methodmethod($var=undef){return$var;}}'
     );
     ok $result, 'Parse method with default parameter';
 };
@@ -238,19 +224,15 @@ subtest 'Complex expressions' => sub {
     my $parser = Parser->new(grammar => $chalk_grammar);
     
     # Constructor call
-    my $result = $parser->parse_tokens(
-        'class', 'Element', '{',
-        'method', 'method', '(', ')', '{', 'return', 'ViterbiElement', '->', 'new', '(', ')', ';', '}',
-        '}'
+    my $result = $parser->parse_string(
+        'classElement{methodmethod(){returnViterbiElement->new();}}'
     );
     ok $result, 'Parse method with constructor call';
     
     # Constructor with arguments
     todo "constructor with named argument needs lexeme support" => sub {
-        $result = $parser->parse_tokens(
-            'class', 'Element', '{',
-            'method', 'method', '(', ')', '{', 'return', 'ViterbiElement', '->', 'new', '(', 'Identifier', '=>', '$var', ')', ';', '}',
-            '}'
+        $result = $parser->parse_string(
+            'classElement{methodmethod(){returnViterbiElement->new(Identifier=>$var);}}'
         );
         ok $result, 'Parse constructor with named argument';
     };
@@ -260,19 +242,15 @@ subtest 'Field initialization' => sub {
     my $parser = Parser->new(grammar => $chalk_grammar);
     
     # Field with array reference initialization
-    my $result = $parser->parse_tokens(
-        'class', 'Element', '{',
-        'field', '$var', '=', '[', ']', ';',
-        '}'
+    my $result = $parser->parse_string(
+        'classElement{field$var=[];}'
     );
     ok $result, 'Parse field with empty array reference';
-    
+
     # Field with constructor initialization
     todo "field with constructor initialization needs lexeme support" => sub {
-        $result = $parser->parse_tokens(
-            'class', 'Element', '{',
-            'field', '$var', '=', 'ViterbiElement', '->', 'new', '(', 'Identifier', '=>', '0', ')', ';',
-            '}'
+        $result = $parser->parse_string(
+            'classElement{field$var=ViterbiElement->new(Identifier=>0);}'
         );
         ok $result, 'Parse field with constructor initialization';
     };
@@ -283,15 +261,8 @@ subtest 'Complete chalk class pattern' => sub {
     
     # Parse a complete class like ViterbiSemiring
     todo "complete ViterbiElement-style class needs lexeme support" => sub {
-        my $result = $parser->parse_tokens(
-            'class', 'ViterbiElement', ':isa(', 'Element', ')', '{',
-            'use', 'overload', "'+'", '=>', "'add'", ';',
-            'field', '$var', ':param', ':reader', ';',
-            'field', '$var', '=', 'ViterbiElement', '->', 'new', '(', 'Identifier', '=>', '0', ')', ';',
-            'method', 'method', '(', '$var', '=', 'undef', ')', '{',
-            'return', 'ViterbiElement', '->', 'new', '(', ')', ';',
-            '}',
-            '}'
+        my $result = $parser->parse_string(
+            'classViterbiElement:isa(Element){useoverload\'+\'=>\'add\';field$var:param:reader;field$var=ViterbiElement->new(Identifier=>0);methodmethod($var=undef){returnViterbiElement->new();}}'
         );
         ok $result, 'Parse complete ViterbiElement-style class';
     };

--- a/t/grammar/test-guacamole-nullable.t
+++ b/t/grammar/test-guacamole-nullable.t
@@ -23,15 +23,15 @@ subtest 'Optional semicolon patterns' => sub {
     my $parser = Parser->new(grammar => $grammar);
     
     # Statements without semicolons
-    my $result = $parser->parse_tokens('cmd', 'cmd', 'cmd');
+    my $result = $parser->parse_string('cmdcmdcmd');
     ok $result, 'Parse statements without semicolons';
-    
+
     # Statements with some semicolons
-    $result = $parser->parse_tokens('cmd', ';', 'cmd', 'cmd');
+    $result = $parser->parse_string('cmd;cmdcmd');
     ok $result, 'Parse statements with some semicolons';
-    
+
     # All statements with semicolons
-    $result = $parser->parse_tokens('cmd', ';', 'cmd', ';', 'cmd');
+    $result = $parser->parse_string('cmd;cmd;cmd');
     ok $result, 'Parse all statements with semicolons';
 };
 
@@ -48,15 +48,15 @@ subtest 'Optional parameter lists' => sub {
     my $parser = Parser->new(grammar => $grammar);
     
     # Function with no parameters
-    my $result = $parser->parse_tokens('name', '(', ')');
+    my $result = $parser->parse_string('name()');
     ok $result, 'Parse function with no parameters';
-    
+
     # Function with one parameter
-    $result = $parser->parse_tokens('name', '(', 'arg', ')');
+    $result = $parser->parse_string('name(arg)');
     ok $result, 'Parse function with one parameter';
-    
+
     # Function with multiple parameters
-    $result = $parser->parse_tokens('name', '(', 'arg', ',', 'arg', ',', 'arg', ')');
+    $result = $parser->parse_string('name(arg,arg,arg)');
     ok $result, 'Parse function with multiple parameters';
 };
 
@@ -77,19 +77,19 @@ subtest 'Nested optional structures' => sub {
     my $parser = Parser->new(grammar => $grammar);
     
     # Simple if without else
-    my $result = $parser->parse_tokens('if', '(', 'test', ')', '{', 'stmt', '}');
+    my $result = $parser->parse_string('if(test){stmt}');
     ok $result, 'Parse simple if without else';
-    
+
     # If with else
-    $result = $parser->parse_tokens('if', '(', 'test', ')', '{', 'stmt', '}', 'else', '{', 'stmt', '}');
+    $result = $parser->parse_string('if(test){stmt}else{stmt}');
     ok $result, 'Parse if with else';
-    
+
     # If with elsif chain
-    $result = $parser->parse_tokens('if', '(', 'test', ')', '{', '}', 'else', 'if', '(', 'test', ')', '{', 'stmt', '}');
+    $result = $parser->parse_string('if(test){}elseif(test){stmt}');
     ok $result, 'Parse if with elsif chain';
-    
+
     # Empty blocks
-    $result = $parser->parse_tokens('if', '(', 'test', ')', '{', '}', 'else', '{', '}');
+    $result = $parser->parse_string('if(test){}else{}');
     ok $result, 'Parse if/else with empty blocks';
 };
 
@@ -112,27 +112,27 @@ subtest 'Highly nullable expression chains' => sub {
     my $parser = Parser->new(grammar => $grammar);
     
     # Minimal expression
-    my $result = $parser->parse_tokens('var');
+    my $result = $parser->parse_string('var');
     ok $result, 'Parse minimal expression';
-    
+
     # Expression with prefix
-    $result = $parser->parse_tokens('!', 'var');
+    $result = $parser->parse_string('!var');
     ok $result, 'Parse expression with prefix';
-    
+
     # Expression with suffix
-    $result = $parser->parse_tokens('var', '[', 'idx', ']');
+    $result = $parser->parse_string('var[idx]');
     ok $result, 'Parse expression with suffix';
-    
+
     # Full expression
-    $result = $parser->parse_tokens('-', 'var', '.', 'method');
+    $result = $parser->parse_string('-var.method');
     ok $result, 'Parse full expression';
-    
+
     # Parenthesized with nullable elements
-    $result = $parser->parse_tokens('(', 'var', ')');
+    $result = $parser->parse_string('(var)');
     ok $result, 'Parse parenthesized expression';
-    
+
     # Complex nested case
-    $result = $parser->parse_tokens('!', '(', '-', 'var', '[', 'idx', ']', ')', '.', 'method');
+    $result = $parser->parse_string('!(-var[idx]).method');
     ok $result, 'Parse complex nested expression';
 };
 
@@ -154,24 +154,24 @@ subtest 'Performance with nullable chains' => sub {
     my $parser = Parser->new(grammar => $grammar);
     
     # All elements present
-    my $result = $parser->parse_tokens('a', 'b', 'c', 'd', 'e');
+    my $result = $parser->parse_string('abcde');
     ok $result, 'Parse with all elements present';
-    
+
     # Some elements missing (testing nullable handling)
-    $result = $parser->parse_tokens('a', 'c', 'e');  # B and D are nullable
+    $result = $parser->parse_string('ace');  # B and D are nullable
     ok $result, 'Parse with some nullable elements missing';
-    
+
     # Minimal case
-    $result = $parser->parse_tokens('e');  # A, B, C, D all nullable
+    $result = $parser->parse_string('e');  # A, B, C, D all nullable
     ok $result, 'Parse with maximum nullable elements';
-    
+
     # Test with Boolean semiring for performance
     my $bool_parser = Parser->new(
         grammar => $grammar,
         semiring => BooleanSemiring->new()
     );
-    
-    $result = $bool_parser->parse_tokens('e');
+
+    $result = $bool_parser->parse_string('e');
     ok $result, 'Boolean parse with maximum nullable elements';
     isa_ok $result, 'BooleanElement';
 };

--- a/t/grammar/test-guacamole-patterns.t
+++ b/t/grammar/test-guacamole-patterns.t
@@ -22,19 +22,19 @@ subtest 'Statement sequence patterns' => sub {
     my $parser = Parser->new(grammar => $grammar);
     
     # Single statement
-    my $result = $parser->parse_tokens('print');
+    my $result = $parser->parse_string('print');
     ok $result, 'Parse single statement';
-    
+
     # Statement with semicolon
-    $result = $parser->parse_tokens('print', ';');
+    $result = $parser->parse_string('print;');
     ok $result, 'Parse statement with semicolon';
-    
+
     # Multiple statements
-    $result = $parser->parse_tokens('print', ';', 'print');
+    $result = $parser->parse_string('print;print');
     ok $result, 'Parse statement sequence';
-    
+
     # Long sequence
-    $result = $parser->parse_tokens('print', ';', 'print', ';', 'print');
+    $result = $parser->parse_string('print;print;print');
     ok $result, 'Parse long statement sequence';
 };
 
@@ -57,19 +57,19 @@ subtest 'Complex for statement patterns' => sub {
     my $parser = Parser->new(grammar => $grammar);
     
     # C-style for loop
-    my $result = $parser->parse_tokens('for', '(', 'var', ';', 'var', ';', 'var', ')', '{}');
+    my $result = $parser->parse_string('for(var;var;var){}');
     ok $result, 'Parse C-style for loop';
-    
+
     # For loop with missing init
-    $result = $parser->parse_tokens('for', '(', ';', 'var', ';', 'var', ')', '{}');
+    $result = $parser->parse_string('for(;var;var){}');
     ok $result, 'Parse for loop with missing init';
-    
+
     # For loop with missing condition and increment
-    $result = $parser->parse_tokens('for', '(', ';', ';', 'var', ')', '{}');
+    $result = $parser->parse_string('for(;;var){}');
     ok $result, 'Parse for loop with missing condition and increment';
-    
+
     # Foreach-style loop
-    $result = $parser->parse_tokens('for', '(', 'expr', ')', '{}');
+    $result = $parser->parse_string('for(expr){}');
     ok $result, 'Parse foreach-style loop';
 };
 
@@ -89,19 +89,19 @@ subtest 'Deeply nested optional elements' => sub {
     my $parser = Parser->new(grammar => $grammar);
     
     # Full use statement
-    my $result = $parser->parse_tokens('use', 'Module', 'v1.0', 'args');
+    my $result = $parser->parse_string('useModulev1.0args');
     ok $result, 'Parse full use statement';
-    
+
     # Use with version only
-    $result = $parser->parse_tokens('use', 'v1.0');
+    $result = $parser->parse_string('usev1.0');
     ok $result, 'Parse use with version only';
-    
+
     # Use with module only
-    $result = $parser->parse_tokens('use', 'Module');
+    $result = $parser->parse_string('useModule');
     ok $result, 'Parse use with module only';
-    
+
     # Use with module and args
-    $result = $parser->parse_tokens('use', 'Module', 'args');
+    $result = $parser->parse_string('useModuleargs');
     ok $result, 'Parse use with module and args';
 };
 
@@ -123,32 +123,32 @@ subtest 'Highly ambiguous expression hierarchy' => sub {
     my $parser = Parser->new(grammar => $grammar);
     
     # Simple expression
-    my $result = $parser->parse_tokens('term');
+    my $result = $parser->parse_string('term');
     ok $result, 'Parse simple term';
-    
+
     # Binary operation
-    $result = $parser->parse_tokens('term', '+', 'term');
+    $result = $parser->parse_string('term+term');
     ok $result, 'Parse binary addition';
-    
+
     # Highly ambiguous expression
-    $result = $parser->parse_tokens('term', '+', 'term', '*', 'term', '-', 'term');
+    $result = $parser->parse_string('term+term*term-term');
     ok $result, 'Parse highly ambiguous expression';
-    
+
     # Expression with parentheses
-    $result = $parser->parse_tokens('(', 'term', '+', 'term', ')', '*', 'term');
+    $result = $parser->parse_string('(term+term)*term');
     ok $result, 'Parse parenthesized expression';
-    
+
     # Complex mixed operators
-    $result = $parser->parse_tokens('term', '**', 'term', '&&', 'term', '||', 'term');
+    $result = $parser->parse_string('term**term&&term||term');
     ok $result, 'Parse complex mixed operators';
-    
+
     # Test with SPPF semiring for ambiguous handling
     my $sppf_parser = Parser->new(
         grammar => $grammar,
         semiring => SPPFViterbiSemiring->new()
     );
-    
-    $result = $sppf_parser->parse_tokens('term', '+', 'term', '*', 'term');
+
+    $result = $sppf_parser->parse_string('term+term*term');
     ok $result, 'SPPF parse ambiguous expression';
     isa_ok $result, 'SPPFViterbiElement';
 };
@@ -167,18 +167,18 @@ subtest 'Recursive block structures' => sub {
     my $parser = Parser->new(grammar => $grammar);
     
     # Empty block
-    my $result = $parser->parse_tokens('{', '}');
+    my $result = $parser->parse_string('{}');
     ok $result, 'Parse empty block';
-    
+
     # Simple block
-    $result = $parser->parse_tokens('{', 'simple', '}');
+    $result = $parser->parse_string('{simple}');
     ok $result, 'Parse simple block';
-    
+
     # Nested blocks
-    $result = $parser->parse_tokens('{', 'simple', '{', 'simple', '}', 'simple', '}');
+    $result = $parser->parse_string('{simple{simple}simple}');
     ok $result, 'Parse nested blocks';
-    
+
     # Deeply nested blocks
-    $result = $parser->parse_tokens('{', '{', '{', 'simple', '}', '}', '}');
+    $result = $parser->parse_string('{{{simple}}}');
     ok $result, 'Parse deeply nested blocks';
 };

--- a/t/grammar/test-modern-perl-syntax.t
+++ b/t/grammar/test-modern-perl-syntax.t
@@ -19,13 +19,13 @@ subtest 'Variable types' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('field', '$scalar', ';');
+    my $result = $parser->parse_string('field$scalar;');
     ok $result, 'Parse scalar variable';
-    
-    $result = $parser->parse_tokens('field', '@array', ';');
+
+    $result = $parser->parse_string('field@array;');
     ok $result, 'Parse array variable';
-    
-    $result = $parser->parse_tokens('field', '%hash', ';');
+
+    $result = $parser->parse_string('field%hash;');
     ok $result, 'Parse hash variable';
 };
 
@@ -40,13 +40,13 @@ subtest 'Postfix dereference syntax' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('$var');
+    my $result = $parser->parse_string('$var');
     ok $result, 'Parse simple variable';
-    
-    $result = $parser->parse_tokens('$var', '->', '@*');
+
+    $result = $parser->parse_string('$var->@*');
     ok $result, 'Parse postfix array dereference';
-    
-    $result = $parser->parse_tokens('$var', '->', '%*');
+
+    $result = $parser->parse_string('$var->%*');
     ok $result, 'Parse postfix hash dereference';
 };
 
@@ -62,13 +62,13 @@ subtest 'String concatenation' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('"literal"');
+    my $result = $parser->parse_string('"literal"');
     ok $result, 'Parse string literal';
-    
-    $result = $parser->parse_tokens('$var', '.', '"literal"');
+
+    $result = $parser->parse_string('$var."literal"');
     ok $result, 'Parse string concatenation';
-    
-    $result = $parser->parse_tokens('"literal"', '.', '$var', '.', '|');
+
+    $result = $parser->parse_string('"literal".$var.|');
     ok $result, 'Parse complex string concatenation';
 };
 
@@ -90,16 +90,16 @@ subtest 'Method calls and constructors' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('Constructor', '->', 'new', '(', ')');
+    my $result = $parser->parse_string('Constructor->new()');
     ok $result, 'Parse constructor with no args';
-    
-    $result = $parser->parse_tokens('Constructor', '->', 'new', '(', 'value', ')');
+
+    $result = $parser->parse_string('Constructor->new(value)');
     ok $result, 'Parse constructor with simple arg';
-    
-    $result = $parser->parse_tokens('Constructor', '->', 'new', '(', 'key', '=>', 'value', ')');
+
+    $result = $parser->parse_string('Constructor->new(key=>value)');
     ok $result, 'Parse constructor with key-value arg';
-    
-    $result = $parser->parse_tokens('$obj', '->', 'method', '(', 'key', '=>', 'value', ',', 'value', ')');
+
+    $result = $parser->parse_string('$obj->method(key=>value,value)');
     ok $result, 'Parse method call with mixed args';
 };
 
@@ -115,9 +115,9 @@ subtest 'Hash subscript and assignment' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens('%hash', '{', '$key', '}');
+    my $result = $parser->parse_string('%hash{$key}');
     ok $result, 'Parse hash subscript';
-    
-    $result = $parser->parse_tokens('$hash', '{', '$key', '}', '//=', 'value');
+
+    $result = $parser->parse_string('$hash{$key}//=value');
     ok $result, 'Parse hash assignment with //= operator';
 };

--- a/t/parser/02-parser-grammars.t
+++ b/t/parser/02-parser-grammars.t
@@ -21,13 +21,13 @@ subtest 'Basic arithmetic grammar' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens(qw(num + num * num));
+    my $result = $parser->parse_string('num+num*num');
     ok $result, 'Parse num + num * num';
-    
-    $result = $parser->parse_tokens(qw/( num + num )/);
+
+    $result = $parser->parse_string('(num+num)');
     ok $result, 'Parse ( num + num )';
-    
-    $result = $parser->parse_tokens(qw/( ( num ) )/);
+
+    $result = $parser->parse_string('((num))');
     ok $result, 'Parse ( ( num ) )';
 };
 
@@ -40,16 +40,16 @@ subtest 'Ambiguous grammar' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens(qw(num + num * num));
+    my $result = $parser->parse_string('num+num*num');
     ok $result, 'Parse ambiguous num + num * num';
-    
+
     # With ViterbiSemiring, should pick best path
     my $viterbi_parser = Parser->new(
         grammar => $grammar,
         semiring => ViterbiSemiring->new()
     );
-    
-    $result = $viterbi_parser->parse_tokens(qw(num + num * num));
+
+    $result = $viterbi_parser->parse_string('num+num*num');
     ok $result, 'Viterbi parse ambiguous expression';
     isa_ok $result, 'ViterbiElement';
 };
@@ -62,10 +62,10 @@ subtest 'Left-recursive grammar' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens(qw(a));
+    my $result = $parser->parse_string('a');
     ok $result, 'Parse single a';
-    
-    $result = $parser->parse_tokens(qw(a a a));
+
+    $result = $parser->parse_string('aaa');
     ok $result, 'Parse a a a with left recursion';
 };
 
@@ -77,10 +77,10 @@ subtest 'Right-recursive grammar' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens(qw(a));
+    my $result = $parser->parse_string('a');
     ok $result, 'Parse single a';
-    
-    $result = $parser->parse_tokens(qw(a a a));
+
+    $result = $parser->parse_string('aaa');
     ok $result, 'Parse a a a with right recursion';
 };
 
@@ -95,16 +95,16 @@ subtest 'Empty productions' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens(qw(a b));
+    my $result = $parser->parse_string('ab');
     ok $result, 'Parse a b';
-    
-    $result = $parser->parse_tokens(qw(a));
+
+    $result = $parser->parse_string('a');
     ok $result, 'Parse a (B -> epsilon)';
-    
-    $result = $parser->parse_tokens(qw(b));
+
+    $result = $parser->parse_string('b');
     ok $result, 'Parse b (A -> epsilon)';
-    
-    $result = $parser->parse_tokens();
+
+    $result = $parser->parse_string('');
     ok $result, 'Parse empty (both epsilon)';
 };
 
@@ -124,11 +124,11 @@ subtest 'Boolean vs Viterbi semiring' => sub {
         semiring => ViterbiSemiring->new()
     );
     
-    my $bool_result = $bool_parser->parse_tokens(qw(a));
+    my $bool_result = $bool_parser->parse_string('a');
     ok $bool_result, 'Boolean parse succeeds';
     isa_ok $bool_result, 'BooleanElement';
-    
-    my $viterbi_result = $viterbi_parser->parse_tokens(qw(a));
+
+    my $viterbi_result = $viterbi_parser->parse_string('a');
     ok $viterbi_result, 'Viterbi parse succeeds';
     isa_ok $viterbi_result, 'ViterbiElement';
     
@@ -151,10 +151,10 @@ subtest 'Complex nested grammar' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens(qw(the cat chased the dog));
+    my $result = $parser->parse_string('thecatchasedthedog');
     ok $result, 'Parse the cat chased the dog';
-    
-    $result = $parser->parse_tokens(qw(cat chased dog));
+
+    $result = $parser->parse_string('catchaseddog');
     ok $result, 'Parse cat chased dog (no determiners)';
 };
 
@@ -165,9 +165,9 @@ subtest 'Invalid input rejection' => sub {
     
     my $parser = Parser->new(grammar => $grammar);
     
-    my $result = $parser->parse_tokens(qw(b));
+    my $result = $parser->parse_string('b');
     ok !$result, 'Reject invalid terminal';
-    
-    $result = $parser->parse_tokens(qw(a a));
+
+    $result = $parser->parse_string('aa');
     ok !$result, 'Reject too many tokens';
 };

--- a/t/parser/test-ambiguous-baseline.t
+++ b/t/parser/test-ambiguous-baseline.t
@@ -21,7 +21,7 @@ subtest 'Simple ambiguous grammar with ViterbiSemiring' => sub {
         semiring => ViterbiSemiring->new()
     );
     
-    my $result = $parser->parse_tokens(qw(n + n * n));
+    my $result = $parser->parse_string('n+n*n');
     ok $result, 'Viterbi parse ambiguous expression';
     isa_ok $result, 'ViterbiElement';
     
@@ -41,7 +41,7 @@ subtest 'Simple ambiguous grammar with BooleanSemiring' => sub {
         semiring => BooleanSemiring->new()
     );
     
-    my $result = $parser->parse_tokens(qw(n + n * n));
+    my $result = $parser->parse_string('n+n*n');
     ok $result, 'Boolean parse ambiguous expression';
     isa_ok $result, 'BooleanElement';
     
@@ -69,17 +69,17 @@ subtest 'More complex ambiguous expression' => sub {
     );
     
     # Test complex expression
-    my $viterbi_result = $viterbi_parser->parse_tokens(qw(n + n * n - n / n));
+    my $viterbi_result = $viterbi_parser->parse_string('n+n*n-n/n');
     ok $viterbi_result, 'Viterbi parse complex expression';
-    
-    my $bool_result = $bool_parser->parse_tokens(qw(n + n * n - n / n));
+
+    my $bool_result = $bool_parser->parse_string('n+n*n-n/n');
     ok $bool_result, 'Boolean parse complex expression';
-    
+
     # Test with parentheses
-    $viterbi_result = $viterbi_parser->parse_tokens(qw/( n + n ) * n/);
+    $viterbi_result = $viterbi_parser->parse_string('(n+n)*n');
     ok $viterbi_result, 'Viterbi parse parenthesized expression';
-    
-    $bool_result = $bool_parser->parse_tokens(qw/( n + n ) * n/);
+
+    $bool_result = $bool_parser->parse_string('(n+n)*n');
     ok $bool_result, 'Boolean parse parenthesized expression';
     
     print "Complex Viterbi result: $viterbi_result\n" if $viterbi_result;
@@ -99,7 +99,7 @@ subtest 'Verify existing working grammars still work' => sub {
         semiring => ViterbiSemiring->new()
     );
     
-    my $result = $parser->parse_tokens(qw(num + num + num));
+    my $result = $parser->parse_string('num+num+num');
     ok $result, 'Known working grammar still works';
     print "Working grammar result: $result\n" if $result;
 };

--- a/t/parser/test-augmented.t
+++ b/t/parser/test-augmented.t
@@ -34,7 +34,7 @@ my @tests = (
 
 for my $test (@tests) {
     my $input = join(' ', @$test);
-    my $result = $parser->parse_tokens(@$test);
+    my $result = $parser->parse_string(join('', @$test));
     say "$input: " . (defined $result ? "SUCCESS" : "FAIL");
 }
 

--- a/t/parser/test-generalized.t
+++ b/t/parser/test-generalized.t
@@ -21,12 +21,12 @@ say "Start symbol: " . $grammar->start_symbol;
 my $parser = Parser->new(grammar => $grammar);
 
 # Test simple case that uses E -> T -> num
-my $result = $parser->parse_tokens(qw(num));
+my $result = $parser->parse_string('num');
 say "num: " . (defined $result ? "SUCCESS - $result" : "FAIL");
 
 # Test case that uses E -> E + T
-$result = $parser->parse_tokens(qw(num + num));
+$result = $parser->parse_string('num+num');
 say "num + num: " . (defined $result ? "SUCCESS - $result" : "FAIL");
 
-ok defined($parser->parse_tokens(qw(num))), "Parse simple num without artificial start rule";
-ok defined($parser->parse_tokens(qw(num + num))), "Parse addition without artificial start rule";
+ok defined($parser->parse_string('num')), "Parse simple num without artificial start rule";
+ok defined($parser->parse_string('num+num')), "Parse addition without artificial start rule";

--- a/t/parser/test-sppf-viterbi.t
+++ b/t/parser/test-sppf-viterbi.t
@@ -21,7 +21,7 @@ subtest 'Basic SPPFViterbi functionality' => sub {
         semiring => SPPFViterbiSemiring->new()
     );
     
-    my $result = $parser->parse_tokens(qw(n + n * n));
+    my $result = $parser->parse_string('n+n*n');
     ok $result, 'SPPFViterbi parse succeeds';
     isa_ok $result, 'SPPFViterbiElement';
     
@@ -53,10 +53,10 @@ subtest 'Compare with pure Viterbi' => sub {
         semiring => ViterbiSemiring->new()
     );
     
-    my $input = [qw(n + n * n)];
-    
-    my $sppf_result = $sppf_viterbi_parser->parse_tokens(@$input);
-    my $viterbi_result = $viterbi_parser->parse_tokens(@$input);
+    my $input = 'n+n*n';
+
+    my $sppf_result = $sppf_viterbi_parser->parse_string($input);
+    my $viterbi_result = $viterbi_parser->parse_string($input);
     
     ok $sppf_result, 'SPPF Viterbi parsing succeeds';
     ok $viterbi_result, 'Pure Viterbi parsing succeeds';
@@ -84,7 +84,7 @@ subtest 'SPPF forest access' => sub {
         semiring => $semiring
     );
     
-    my $result = $parser->parse_tokens(qw(n + n * n));
+    my $result = $parser->parse_string('n+n*n');
     ok $result, 'Parse for forest access';
     
     # Access the forest
@@ -116,7 +116,7 @@ subtest 'Simple non-ambiguous grammar' => sub {
         semiring => SPPFViterbiSemiring->new()
     );
     
-    my $result = $parser->parse_tokens(qw(a b));
+    my $result = $parser->parse_string('ab');
     ok $result, 'SPPFViterbi handles simple grammar';
     
     # Verify properties


### PR DESCRIPTION
## Summary
Removes the redundant `parse_tokens` method from the Parser, which was just a wrapper around `parse_string` that joined tokens with an empty string.

## Changes
- Removed `parse_tokens` method from `lib/Chalk/Parser.pm`
- Removed `parse_tokens` method from `chalk` (combined/packed parser)
- Updated all 117 call sites across 14 test files to use `parse_string` directly
- Transformation pattern: `parse_tokens(qw(a b c))` → `parse_string('abc')`

## Testing
All tests maintain their existing pass/fail status. No new regressions introduced.

## Rationale
The `parse_tokens` method served no semantic purpose - it simply concatenated tokens and called `parse_string`. Having both methods was confusing for users who might wonder when to use which. The simpler API with just `parse_string` is clearer.

Fixes #32