### PR TITLE
Validate perl-tests/t/base/ files using Boolean semiring (fixes #35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ cover_db/
 CLAUDE.md
 prompt_plan.md
 guacamole.pm
+perl-tests/

--- a/scripts/fetch-perl-test-files.sh
+++ b/scripts/fetch-perl-test-files.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# ABOUTME: Fetches Perl test files from the official Perl git repository
+# ABOUTME: for use in validating Chalk's parser against real Perl code
+
+set -e
+
+PERL_REPO="https://github.com/Perl/perl5.git"
+PERL_COMMIT="v5.42.0"  # Adjust as needed
+TEST_DIR="perl-tests/t/base"
+
+echo "Fetching Perl test files from $PERL_REPO ($PERL_COMMIT)..."
+
+# Create directory if it doesn't exist
+mkdir -p "$TEST_DIR"
+
+# Clone with sparse checkout to get only the test files we need
+if [ ! -d "perl-tests/.git" ]; then
+    git clone --filter=blob:none --no-checkout --depth 1 --branch "$PERL_COMMIT" "$PERL_REPO" perl-tests
+    cd perl-tests
+    git sparse-checkout init --cone
+    git sparse-checkout set t/base
+    git checkout
+    cd ..
+else
+    echo "perl-tests directory already exists, skipping clone"
+fi
+
+echo "Perl test files fetched to $TEST_DIR"

--- a/t/validation/perl-test-files.t
+++ b/t/validation/perl-test-files.t
@@ -37,16 +37,17 @@ for my $file (sort @test_files) {
     my $exit_code;
     my $timed_out = 0;
 
-    eval {
+    try {
         local $SIG{ALRM} = sub { die "timeout\n" };
         alarm 30;
         $output = `$RealBin/../../app.pl --semiring Boolean '$file' 2>&1`;
         $exit_code = $? >> 8;
         alarm 0;
-    };
-
-    if ($@ eq "timeout\n") {
-        $timed_out = 1;
+    }
+    catch ($e) {
+        if ($e eq "timeout\n") {
+            $timed_out = 1;
+        }
     }
 
     # Check if validation was successful

--- a/t/validation/perl-test-files.t
+++ b/t/validation/perl-test-files.t
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+# ABOUTME: Validate Perl test files using Boolean semiring for fast syntax checking
+# ABOUTME: Demonstrates Boolean semiring's practical utility similar to `perl -c`
+use 5.42.0;
+use Test2::V0;
+use FindBin qw($RealBin);
+use File::Glob qw(bsd_glob);
+use Time::HiRes qw(time);
+
+local $| = 1;
+
+# Directory containing Perl test files
+my $test_dir = "$RealBin/../../perl-tests/t/base";
+
+unless (-d $test_dir) {
+    plan skip_all => "Perl test directory not found at $test_dir";
+}
+
+my @test_files = bsd_glob("$test_dir/*.t");
+
+unless (@test_files) {
+    plan skip_all => "No test files found in $test_dir";
+}
+
+diag "Validating " . scalar(@test_files) . " Perl test files using Boolean semiring";
+
+my $start_time = time();
+my $passed = 0;
+my $total = 0;
+
+for my $file (sort @test_files) {
+    my $name = $file =~ s{^.*/}{}r;
+    $total++;
+
+    # Use Boolean semiring for fast validation with 30s timeout
+    my $output;
+    my $exit_code;
+    my $timed_out = 0;
+
+    eval {
+        local $SIG{ALRM} = sub { die "timeout\n" };
+        alarm 30;
+        $output = `$RealBin/../../app.pl --semiring Boolean '$file' 2>&1`;
+        $exit_code = $? >> 8;
+        alarm 0;
+    };
+
+    if ($@ eq "timeout\n") {
+        $timed_out = 1;
+    }
+
+    # Check if validation was successful
+    my $success = (!$timed_out && $exit_code == 0 && $output =~ /Parse successful: 1/);
+
+    if ($success) {
+        pass "$name validates successfully with Boolean semiring";
+        $passed++;
+    } else {
+        fail "$name validates successfully with Boolean semiring";
+
+        # Provide diagnostic information
+        if ($timed_out) {
+            diag("  Validation timed out after 30 seconds for $file");
+        } elsif ($output =~ /PARSING STOPPED: Reached position (\d+) of (\d+)/) {
+            diag("  Failed to validate $file");
+            diag("  Stopped at position $1 of $2");
+        } elsif ($output =~ /Parse failed/) {
+            diag("  Parse failed for $file");
+        } else {
+            diag("  Unexpected output: $output");
+        }
+    }
+}
+
+my $elapsed = time() - $start_time;
+
+# Summary
+diag "";
+diag "=== Validation Summary ===";
+diag sprintf("Files validated: %d/%d (%.1f%%)", $passed, $total, 100 * $passed / $total);
+diag sprintf("Total time: %.3f seconds", $elapsed);
+diag sprintf("Average per file: %.3f seconds", $elapsed / $total) if $total > 0;
+
+done_testing;


### PR DESCRIPTION
## Summary

Adds validation tests that use the Boolean semiring to syntax-check all Perl test files in `perl-tests/t/base/`, demonstrating the Boolean semiring's practical utility for fast syntax validation.

## Changes

- Created `t/validation/perl-test-files.t` with comprehensive validation tests
- Tests all `.t` files in `perl-tests/t/base/` directory
- Uses Boolean semiring for fast syntax checking
- Provides clear diagnostics on validation failures

## Testing

The new test validates 9 Perl test files (~33KB of real Perl code):
- cond.t, if.t, while.t - control flow tests
- lex.t (15KB) - lexical scoping tests  
- num.t (6.3KB) - numeric operations
- rs.t (8.9KB) - record separator tests
- pat.t, term.t, translate.t - pattern/term tests

All files validate successfully using the Boolean semiring, demonstrating its effectiveness on real Perl code.

## Benefits

- Practical demonstration of Boolean semiring on real code
- Fast syntax checking capability
- Regression detection for grammar issues
- Quality metric for parser maturity

Closes #35