### PR TITLE
Implement heredoc support via preprocessor transformation (fixes #41)

### DIFF
--- a/app.pl
+++ b/app.pl
@@ -16,6 +16,7 @@ if ( !caller ) {
     my $grammar_module = "Perl";  # default grammar module
     my $semiring_type = "SPPF";   # default semiring
     my $syntax_check_mode = 0;    # -c flag for syntax checking
+    my $preprocess_enabled = 0;   # --preprocess flag for heredoc preprocessing
     my @remaining_args;
 
     my $i = 0;
@@ -29,6 +30,9 @@ if ( !caller ) {
         } elsif ($ARGV[$i] eq '-c') {
             $syntax_check_mode = 1;
             $semiring_type = "Boolean";  # -c implies Boolean semiring
+            $i++;
+        } elsif ($ARGV[$i] eq '--preprocess') {
+            $preprocess_enabled = 1;  # Enable heredoc preprocessing
             $i++;
         } else {
             push @remaining_args, $ARGV[$i];
@@ -105,7 +109,8 @@ if ( !caller ) {
         # Create parser with grammar and semiring
         my $parser = Chalk::Parser->new(
             grammar => $chalk_grammar,
-            semiring => $semiring
+            semiring => $semiring,
+            preprocess => $preprocess_enabled
         );
 
         # Parse the input

--- a/app.pl
+++ b/app.pl
@@ -16,7 +16,7 @@ if ( !caller ) {
     my $grammar_module = "Perl";  # default grammar module
     my $semiring_type = "SPPF";   # default semiring
     my $syntax_check_mode = 0;    # -c flag for syntax checking
-    my $preprocess_enabled = 0;   # --preprocess flag for heredoc preprocessing
+    my $preprocess = [];          # arrayref of preprocessor class names
     my @remaining_args;
 
     my $i = 0;
@@ -32,7 +32,7 @@ if ( !caller ) {
             $semiring_type = "Boolean";  # -c implies Boolean semiring
             $i++;
         } elsif ($ARGV[$i] eq '--preprocess') {
-            $preprocess_enabled = 1;  # Enable heredoc preprocessing
+            $preprocess = ['Chalk::Preprocessor::Heredoc'];  # Enable heredoc preprocessing
             $i++;
         } else {
             push @remaining_args, $ARGV[$i];
@@ -110,7 +110,7 @@ if ( !caller ) {
         my $parser = Chalk::Parser->new(
             grammar => $chalk_grammar,
             semiring => $semiring,
-            preprocess => $preprocess_enabled
+            preprocess => $preprocess
         );
 
         # Parse the input

--- a/lib/Chalk/Grammar/Perl.pm
+++ b/lib/Chalk/Grammar/Perl.pm
@@ -842,6 +842,9 @@ our $chalk_grammar = Chalk::Grammar->build_grammar(
     [ 'Identifier'   => [qr/[a-zA-Z_][a-zA-Z0-9_]*/] ],
     [ 'Number'       => [qr/(?:0[bB][01]+|0[xX][0-9a-fA-F]+|0[oO][0-7]+|0[0-7]+|\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/] ],
     [ 'QuotedString' => [qr/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/] ],
+    # q{} and qq{} quote operators (for heredoc preprocessor support)
+    [ 'QuotedString' => [qr/q\{(?:[^}]|\n)*\}/] ],   # q{} single-quote equivalent
+    [ 'QuotedString' => [qr/qq\{(?:[^}]|\n)*\}/] ],  # qq{} double-quote equivalent
 
     # Punctuation
     [ 'PackageSeparator' => ['::'] ],

--- a/lib/Chalk/Parser.pm
+++ b/lib/Chalk/Parser.pm
@@ -122,13 +122,19 @@ class Chalk::EarleyChart {
 class Chalk::Parser {
     field $semiring :param = Chalk::Semiring::SPPFViterbiSemiring->new();
     field $grammar :param;
-    field $preprocess :param = 0;  # Enable heredoc preprocessing
+    field $preprocess :param = ['Chalk::Preprocessor::Heredoc'];  # Arrayref of preprocessor class names
 
     method parse_string($input_string) {
-        # Apply preprocessing if enabled
-        if ($preprocess) {
-            require Chalk::Preprocessor;
-            my $preprocessor = Chalk::Preprocessor->new(input => $input_string);
+        # Apply preprocessors in sequence
+        for my $preprocessor_class (@$preprocess) {
+            next unless defined $preprocessor_class;
+
+            # Load the preprocessor module
+            (my $file = $preprocessor_class) =~ s{::}{/}g;
+            require "$file.pm";
+
+            # Apply preprocessing
+            my $preprocessor = $preprocessor_class->new(input => $input_string);
             $preprocessor->transform();
             $input_string = $preprocessor->output;
         }

--- a/lib/Chalk/Parser.pm
+++ b/lib/Chalk/Parser.pm
@@ -122,7 +122,7 @@ class Chalk::EarleyChart {
 class Chalk::Parser {
     field $semiring :param = Chalk::Semiring::SPPFViterbiSemiring->new();
     field $grammar :param;
-    field $preprocess :param = ['Chalk::Preprocessor::Heredoc'];  # Arrayref of preprocessor class names
+    field $preprocess :param = [];  # Arrayref of preprocessor class names
 
     method parse_string($input_string) {
         # Apply preprocessors in sequence

--- a/lib/Chalk/Parser.pm
+++ b/lib/Chalk/Parser.pm
@@ -122,8 +122,17 @@ class Chalk::EarleyChart {
 class Chalk::Parser {
     field $semiring :param = Chalk::Semiring::SPPFViterbiSemiring->new();
     field $grammar :param;
+    field $preprocess :param = 0;  # Enable heredoc preprocessing
 
     method parse_string($input_string) {
+        # Apply preprocessing if enabled
+        if ($preprocess) {
+            require Chalk::Preprocessor;
+            my $preprocessor = Chalk::Preprocessor->new(input => $input_string);
+            $preprocessor->transform();
+            $input_string = $preprocessor->output;
+        }
+
         my $chart = Chalk::EarleyChart->new( semiring => $semiring );
 
        # Initialize chart by predicting all rules for start symbol at position 0

--- a/lib/Chalk/Preprocessor.pm
+++ b/lib/Chalk/Preprocessor.pm
@@ -1,0 +1,83 @@
+# ABOUTME: Preprocessor for Chalk::Parser to transform heredoc syntax to q{}/qq{}
+# ABOUTME: Enables heredoc support without complex grammar rules via source transformation
+package Chalk::Preprocessor;
+use 5.42.0;
+use experimental qw(class builtin keyword_any keyword_all);
+
+class Chalk::Preprocessor {
+    field $input :param :reader;
+    field $output :reader = '';
+    field @line_map :reader;  # Maps output lines to input lines
+
+    method transform() {
+        $self->transform_heredocs();
+    }
+
+    method transform_heredocs() {
+        my @lines = split /\n/, $input, -1;
+        my @output_lines;
+        my %line_mapping;
+        my $input_line_num = 0;
+        my $output_line_num = 0;
+
+        # Process each line looking for heredoc declarations
+        for (my $i = 0; $i < @lines; $i++) {
+            $input_line_num = $i + 1;
+            my $line = $lines[$i];
+
+            # Check for single-quoted heredoc: <<'DELIMITER'
+            if ($line =~ /^(.*?)(<<'([^']+)')(.*)$/) {
+                my ($prefix, $heredoc_marker, $delimiter, $suffix) = ($1, $2, $3, $4);
+
+                # Collect heredoc content until we find the terminator
+                my @heredoc_content;
+                my $j = $i + 1;
+                my $found_terminator = 0;
+
+                while ($j < @lines) {
+                    if ($lines[$j] eq $delimiter) {
+                        $found_terminator = 1;
+                        last;
+                    }
+                    push @heredoc_content, $lines[$j];
+                    $j++;
+                }
+
+                if ($found_terminator) {
+                    # Transform to q{...}
+                    my $content = join("\n", @heredoc_content);
+                    my $transformed = "${prefix}q{${content}}${suffix}";
+
+                    push @output_lines, $transformed;
+                    $line_mapping{$output_line_num} = $input_line_num;
+                    $output_line_num++;
+
+                    # Skip the heredoc content and terminator
+                    $i = $j;
+                } else {
+                    # No terminator found, keep line as-is
+                    push @output_lines, $line;
+                    $line_mapping{$output_line_num} = $input_line_num;
+                    $output_line_num++;
+                }
+            } else {
+                # Not a heredoc line, keep as-is
+                push @output_lines, $line;
+                $line_mapping{$output_line_num} = $input_line_num;
+                $output_line_num++;
+            }
+        }
+
+        # Join output lines
+        $output = join("\n", @output_lines);
+
+        # Store line mapping
+        @line_map = map { $line_mapping{$_} // $_ } 0..$#output_lines;
+    }
+
+    method map_line($output_line) {
+        return $line_map[$output_line] // $output_line;
+    }
+}
+
+1;

--- a/lib/Chalk/Preprocessor.pm
+++ b/lib/Chalk/Preprocessor.pm
@@ -25,10 +25,32 @@ class Chalk::Preprocessor {
             $input_line_num = $i + 1;
             my $line = $lines[$i];
 
+            my $matched = 0;
+            my $is_single_quoted = 0;
+            my $prefix = '';
+            my $delimiter = '';
+            my $suffix = '';
+
             # Check for single-quoted heredoc: <<'DELIMITER'
             if ($line =~ /^(.*?)(<<'([^']+)')(.*)$/) {
-                my ($prefix, $heredoc_marker, $delimiter, $suffix) = ($1, $2, $3, $4);
+                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
+                $is_single_quoted = 1;
+                $matched = 1;
+            }
+            # Check for double-quoted heredoc: <<"DELIMITER"
+            elsif ($line =~ /^(.*?)(<<"([^"]+)")(.*)$/) {
+                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
+                $is_single_quoted = 0;
+                $matched = 1;
+            }
+            # Check for bare heredoc: <<DELIMITER
+            elsif ($line =~ /^(.*?)(<<(\w+))(.*)$/) {
+                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
+                $is_single_quoted = 0;
+                $matched = 1;
+            }
 
+            if ($matched) {
                 # Collect heredoc content until we find the terminator
                 my @heredoc_content;
                 my $j = $i + 1;
@@ -44,9 +66,10 @@ class Chalk::Preprocessor {
                 }
 
                 if ($found_terminator) {
-                    # Transform to q{...}
+                    # Transform to q{...} or qq{...}
                     my $content = join("\n", @heredoc_content);
-                    my $transformed = "${prefix}q{${content}}${suffix}";
+                    my $quote_op = $is_single_quoted ? 'q' : 'qq';
+                    my $transformed = "${prefix}${quote_op}{${content}}${suffix}";
 
                     push @output_lines, $transformed;
                     $line_mapping{$output_line_num} = $input_line_num;

--- a/lib/Chalk/Preprocessor.pm
+++ b/lib/Chalk/Preprocessor.pm
@@ -25,98 +25,136 @@ class Chalk::Preprocessor {
             $input_line_num = $i + 1;
             my $line = $lines[$i];
 
-            my $matched = 0;
-            my $is_single_quoted = 0;
-            my $is_indented = 0;
-            my $prefix = '';
-            my $delimiter = '';
-            my $suffix = '';
+            # Collect all heredoc declarations on this line
+            my @heredocs;
+            my $working_line = $line;
 
-            # Check for indented single-quoted heredoc: <<~'DELIMITER'
-            if ($line =~ /^(.*?)(<<~'([^']+)')(.*)$/) {
-                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
-                $is_single_quoted = 1;
-                $is_indented = 1;
-                $matched = 1;
-            }
-            # Check for indented double-quoted heredoc: <<~"DELIMITER"
-            elsif ($line =~ /^(.*?)(<<~"([^"]+)")(.*)$/) {
-                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
-                $is_single_quoted = 0;
-                $is_indented = 1;
-                $matched = 1;
-            }
-            # Check for indented bare heredoc: <<~DELIMITER
-            elsif ($line =~ /^(.*?)(<<~(\w+))(.*)$/) {
-                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
-                $is_single_quoted = 0;
-                $is_indented = 1;
-                $matched = 1;
-            }
-            # Check for single-quoted heredoc: <<'DELIMITER'
-            elsif ($line =~ /^(.*?)(<<'([^']+)')(.*)$/) {
-                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
-                $is_single_quoted = 1;
-                $matched = 1;
-            }
-            # Check for double-quoted heredoc: <<"DELIMITER"
-            elsif ($line =~ /^(.*?)(<<"([^"]+)")(.*)$/) {
-                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
-                $is_single_quoted = 0;
-                $matched = 1;
-            }
-            # Check for bare heredoc: <<DELIMITER
-            elsif ($line =~ /^(.*?)(<<(\w+))(.*)$/) {
-                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
-                $is_single_quoted = 0;
-                $matched = 1;
-            }
+            # Keep finding heredocs until none remain
+            while (1) {
+                my $matched = 0;
+                my $is_single_quoted = 0;
+                my $is_indented = 0;
+                my $prefix = '';
+                my $delimiter = '';
+                my $heredoc_marker = '';
 
-            if ($matched) {
-                # Collect heredoc content until we find the terminator
-                my @heredoc_content;
-                my $j = $i + 1;
-                my $found_terminator = 0;
-
-                while ($j < @lines) {
-                    # For indented heredocs, the terminator can have leading whitespace
-                    # For non-indented heredocs, terminator must be exact match
-                    my $line_matches_delimiter = 0;
-                    if ($is_indented) {
-                        # Match terminator with optional leading whitespace
-                        $line_matches_delimiter = ($lines[$j] =~ /^\s*\Q$delimiter\E$/);
-                    } else {
-                        # Exact match only
-                        $line_matches_delimiter = ($lines[$j] eq $delimiter);
-                    }
-
-                    if ($line_matches_delimiter) {
-                        $found_terminator = 1;
-                        last;
-                    }
-                    push @heredoc_content, $lines[$j];
-                    $j++;
+                # Check for indented single-quoted heredoc: <<~'DELIMITER'
+                if ($working_line =~ /^(.*?)(<<~'([^']+)')(.*)$/) {
+                    ($prefix, $heredoc_marker, $delimiter) = ($1, $2, $3);
+                    $is_single_quoted = 1;
+                    $is_indented = 1;
+                    $matched = 1;
+                }
+                # Check for indented double-quoted heredoc: <<~"DELIMITER"
+                elsif ($working_line =~ /^(.*?)(<<~"([^"]+)")(.*)$/) {
+                    ($prefix, $heredoc_marker, $delimiter) = ($1, $2, $3);
+                    $is_single_quoted = 0;
+                    $is_indented = 1;
+                    $matched = 1;
+                }
+                # Check for indented bare heredoc: <<~DELIMITER
+                elsif ($working_line =~ /^(.*?)(<<~(\w+))(.*)$/) {
+                    ($prefix, $heredoc_marker, $delimiter) = ($1, $2, $3);
+                    $is_single_quoted = 0;
+                    $is_indented = 1;
+                    $matched = 1;
+                }
+                # Check for single-quoted heredoc: <<'DELIMITER'
+                elsif ($working_line =~ /^(.*?)(<<'([^']+)')(.*)$/) {
+                    ($prefix, $heredoc_marker, $delimiter) = ($1, $2, $3);
+                    $is_single_quoted = 1;
+                    $matched = 1;
+                }
+                # Check for double-quoted heredoc: <<"DELIMITER"
+                elsif ($working_line =~ /^(.*?)(<<"([^"]+)")(.*)$/) {
+                    ($prefix, $heredoc_marker, $delimiter) = ($1, $2, $3);
+                    $is_single_quoted = 0;
+                    $matched = 1;
+                }
+                # Check for bare heredoc: <<DELIMITER
+                elsif ($working_line =~ /^(.*?)(<<(\w+))(.*)$/) {
+                    ($prefix, $heredoc_marker, $delimiter) = ($1, $2, $3);
+                    $is_single_quoted = 0;
+                    $matched = 1;
                 }
 
-                if ($found_terminator) {
-                    # Handle indentation stripping if <<~ was used
-                    if ($is_indented) {
-                        @heredoc_content = $self->strip_indentation(@heredoc_content);
+                if ($matched) {
+                    push @heredocs, {
+                        delimiter => $delimiter,
+                        is_single_quoted => $is_single_quoted,
+                        is_indented => $is_indented,
+                        prefix => $prefix,
+                        marker => $heredoc_marker,
+                    };
+                    # Replace the heredoc marker with a placeholder to continue searching
+                    $working_line =~ s/\Q$heredoc_marker\E/__HEREDOC_PLACEHOLDER__/;
+                } else {
+                    last;
+                }
+            }
+
+            if (@heredocs) {
+                # Collect content for each heredoc in order
+                my $j = $i + 1;
+                my @transformed_parts;
+                my $current_prefix = '';
+
+                for my $hd (@heredocs) {
+                    my @heredoc_content;
+                    my $found_terminator = 0;
+
+                    while ($j < @lines) {
+                        my $line_matches_delimiter = 0;
+                        if ($hd->{is_indented}) {
+                            $line_matches_delimiter = ($lines[$j] =~ /^\s*\Q$hd->{delimiter}\E$/);
+                        } else {
+                            $line_matches_delimiter = ($lines[$j] eq $hd->{delimiter});
+                        }
+
+                        if ($line_matches_delimiter) {
+                            $found_terminator = 1;
+                            $j++;  # Move past terminator
+                            last;
+                        }
+                        push @heredoc_content, $lines[$j];
+                        $j++;
                     }
 
-                    # Transform to q{...} or qq{...}
-                    my $content = join("\n", @heredoc_content);
-                    my $quote_op = $is_single_quoted ? 'q' : 'qq';
-                    my $transformed = "${prefix}${quote_op}{${content}}${suffix}";
+                    if ($found_terminator) {
+                        # Handle indentation stripping if <<~ was used
+                        if ($hd->{is_indented}) {
+                            @heredoc_content = $self->strip_indentation(@heredoc_content);
+                        }
+
+                        # Transform to q{...} or qq{...}
+                        my $content = join("\n", @heredoc_content);
+                        my $quote_op = $hd->{is_single_quoted} ? 'q' : 'qq';
+                        push @transformed_parts, {
+                            marker => $hd->{marker},
+                            replacement => "${quote_op}{${content}}",
+                        };
+                    } else {
+                        # If we couldn't find terminator, abandon transformation
+                        @transformed_parts = ();
+                        last;
+                    }
+                }
+
+                if (@transformed_parts) {
+                    # Replace all heredoc markers with their transformations
+                    my $transformed = $line;
+                    for my $part (@transformed_parts) {
+                        $transformed =~ s/\Q$part->{marker}\E/$part->{replacement}/;
+                    }
 
                     push @output_lines, $transformed;
                     $line_mapping{$output_line_num} = $input_line_num;
                     $output_line_num++;
 
-                    # Skip the heredoc content and terminator
-                    $i = $j;
+                    # Skip the heredoc content lines
+                    $i = $j - 1;  # -1 because for loop will increment
                 } else {
-                    # No terminator found, keep line as-is
+                    # Transformation failed, keep original
                     push @output_lines, $line;
                     $line_mapping{$output_line_num} = $input_line_num;
                     $output_line_num++;

--- a/lib/Chalk/Preprocessor.pm
+++ b/lib/Chalk/Preprocessor.pm
@@ -27,12 +27,34 @@ class Chalk::Preprocessor {
 
             my $matched = 0;
             my $is_single_quoted = 0;
+            my $is_indented = 0;
             my $prefix = '';
             my $delimiter = '';
             my $suffix = '';
 
+            # Check for indented single-quoted heredoc: <<~'DELIMITER'
+            if ($line =~ /^(.*?)(<<~'([^']+)')(.*)$/) {
+                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
+                $is_single_quoted = 1;
+                $is_indented = 1;
+                $matched = 1;
+            }
+            # Check for indented double-quoted heredoc: <<~"DELIMITER"
+            elsif ($line =~ /^(.*?)(<<~"([^"]+)")(.*)$/) {
+                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
+                $is_single_quoted = 0;
+                $is_indented = 1;
+                $matched = 1;
+            }
+            # Check for indented bare heredoc: <<~DELIMITER
+            elsif ($line =~ /^(.*?)(<<~(\w+))(.*)$/) {
+                ($prefix, $delimiter, $suffix) = ($1, $3, $4);
+                $is_single_quoted = 0;
+                $is_indented = 1;
+                $matched = 1;
+            }
             # Check for single-quoted heredoc: <<'DELIMITER'
-            if ($line =~ /^(.*?)(<<'([^']+)')(.*)$/) {
+            elsif ($line =~ /^(.*?)(<<'([^']+)')(.*)$/) {
                 ($prefix, $delimiter, $suffix) = ($1, $3, $4);
                 $is_single_quoted = 1;
                 $matched = 1;
@@ -57,7 +79,18 @@ class Chalk::Preprocessor {
                 my $found_terminator = 0;
 
                 while ($j < @lines) {
-                    if ($lines[$j] eq $delimiter) {
+                    # For indented heredocs, the terminator can have leading whitespace
+                    # For non-indented heredocs, terminator must be exact match
+                    my $line_matches_delimiter = 0;
+                    if ($is_indented) {
+                        # Match terminator with optional leading whitespace
+                        $line_matches_delimiter = ($lines[$j] =~ /^\s*\Q$delimiter\E$/);
+                    } else {
+                        # Exact match only
+                        $line_matches_delimiter = ($lines[$j] eq $delimiter);
+                    }
+
+                    if ($line_matches_delimiter) {
                         $found_terminator = 1;
                         last;
                     }
@@ -66,6 +99,11 @@ class Chalk::Preprocessor {
                 }
 
                 if ($found_terminator) {
+                    # Handle indentation stripping if <<~ was used
+                    if ($is_indented) {
+                        @heredoc_content = $self->strip_indentation(@heredoc_content);
+                    }
+
                     # Transform to q{...} or qq{...}
                     my $content = join("\n", @heredoc_content);
                     my $quote_op = $is_single_quoted ? 'q' : 'qq';
@@ -96,6 +134,45 @@ class Chalk::Preprocessor {
 
         # Store line mapping
         @line_map = map { $line_mapping{$_} // $_ } 0..$#output_lines;
+    }
+
+    method strip_indentation(@lines) {
+        return () unless @lines;
+
+        # Find minimum indentation (count leading whitespace)
+        my $min_indent = undef;
+        for my $line (@lines) {
+            # Skip empty lines when calculating minimum indentation
+            next if $line =~ /^\s*$/;
+
+            if ($line =~ /^(\s+)/) {
+                my $indent = length($1);
+                $min_indent = $indent if !defined($min_indent) || $indent < $min_indent;
+            } else {
+                # Line with no leading whitespace means min_indent is 0
+                $min_indent = 0;
+                last;
+            }
+        }
+
+        # If all lines were empty or no indentation found, return as-is
+        return @lines unless defined($min_indent) && $min_indent > 0;
+
+        # Strip the minimum indentation from all lines
+        my @stripped;
+        for my $line (@lines) {
+            if ($line =~ /^\s*$/) {
+                # Keep empty lines as-is
+                push @stripped, $line;
+            } else {
+                # Remove exactly $min_indent characters from the beginning
+                my $stripped_line = $line;
+                $stripped_line =~ s/^\s{$min_indent}//;
+                push @stripped, $stripped_line;
+            }
+        }
+
+        return @stripped;
     }
 
     method map_line($output_line) {

--- a/lib/Chalk/Preprocessor/Heredoc.pm
+++ b/lib/Chalk/Preprocessor/Heredoc.pm
@@ -1,10 +1,10 @@
 # ABOUTME: Preprocessor for Chalk::Parser to transform heredoc syntax to q{}/qq{}
 # ABOUTME: Enables heredoc support without complex grammar rules via source transformation
-package Chalk::Preprocessor;
+package Chalk::Preprocessor::Heredoc;
 use 5.42.0;
 use experimental qw(class builtin keyword_any keyword_all);
 
-class Chalk::Preprocessor {
+class Chalk::Preprocessor::Heredoc {
     field $input :param :reader;
     field $output :reader = '';
     field @line_map :reader;  # Maps output lines to input lines

--- a/t/grammar/quote-operators.t
+++ b/t/grammar/quote-operators.t
@@ -1,0 +1,85 @@
+#!/usr/bin/env perl
+# ABOUTME: Test q{}/qq{} quote operator parsing support in Chalk grammar
+# ABOUTME: Verify preprocessed heredocs can be parsed successfully
+use 5.42.0;
+use Test2::V0;
+use FindBin qw($RealBin);
+use experimental qw(defer);
+defer { done_testing() }
+
+require "$RealBin/../chalk";
+
+subtest 'Single q{} operator parsing' => sub {
+    my $grammar = Grammar->build_grammar(
+        [ 'Statement' => ['my', 'Variable', '=', 'QuotedString', ';'] ],
+        [ 'Variable' => ['$text'] ],
+        [ 'QuotedString' => [qr/q\{[^}]*\}/] ],
+    );
+
+    my $parser = Parser->new(grammar => $grammar);
+    my $result = $parser->parse_string('my$text=q{HelloWorld};');
+    ok $result, 'Parse q{} operator';
+};
+
+subtest 'Single qq{} operator parsing' => sub {
+    my $grammar = Grammar->build_grammar(
+        [ 'Statement' => ['my', 'Variable', '=', 'QuotedString', ';'] ],
+        [ 'Variable' => ['$text'] ],
+        [ 'QuotedString' => [qr/qq\{[^}]*\}/] ],
+    );
+
+    my $parser = Parser->new(grammar => $grammar);
+    my $result = $parser->parse_string('my$text=qq{HelloWorld};');
+    ok $result, 'Parse qq{} operator';
+};
+
+subtest 'Mixed quote operators' => sub {
+    my $grammar = Grammar->build_grammar(
+        [ 'Statement' => ['my', 'Variable', '=', 'QuotedString', ';'] ],
+        [ 'Variable' => ['$text'] ],
+        [ 'QuotedString' => [qr/q\{[^}]*\}/] ],
+        [ 'QuotedString' => [qr/qq\{[^}]*\}/] ],
+    );
+
+    my $parser = Parser->new(grammar => $grammar);
+
+    my $result = $parser->parse_string('my$text=q{singlequoted};');
+    ok $result, 'Parse q{} in mixed grammar';
+
+    $result = $parser->parse_string('my$text=qq{doublequoted};');
+    ok $result, 'Parse qq{} in mixed grammar';
+};
+
+subtest 'Empty quote operators' => sub {
+    my $grammar = Grammar->build_grammar(
+        [ 'Statement' => ['my', 'Variable', '=', 'QuotedString', ';'] ],
+        [ 'Variable' => ['$text'] ],
+        [ 'QuotedString' => [qr/q\{[^}]*\}/] ],
+        [ 'QuotedString' => [qr/qq\{[^}]*\}/] ],
+    );
+
+    my $parser = Parser->new(grammar => $grammar);
+
+    my $result = $parser->parse_string('my$text=q{};');
+    ok $result, 'Parse empty q{}';
+
+    $result = $parser->parse_string('my$text=qq{};');
+    ok $result, 'Parse empty qq{}';
+};
+
+subtest 'Quote operators with newlines' => sub {
+    my $grammar = Grammar->build_grammar(
+        [ 'Statement' => ['my', 'Variable', '=', 'QuotedString', ';'] ],
+        [ 'Variable' => ['$text'] ],
+        [ 'QuotedString' => [qr/q\{(?:[^}]|\n)*\}/] ],
+        [ 'QuotedString' => [qr/qq\{(?:[^}]|\n)*\}/] ],
+    );
+
+    my $parser = Parser->new(grammar => $grammar);
+
+    my $result = $parser->parse_string("my\$text=q{line1\nline2};");
+    ok $result, 'Parse q{} with newline';
+
+    $result = $parser->parse_string("my\$text=qq{line1\nline2};");
+    ok $result, 'Parse qq{} with newline';
+};

--- a/t/parser/with-preprocessor.t
+++ b/t/parser/with-preprocessor.t
@@ -1,0 +1,111 @@
+#!/usr/bin/env perl
+# ABOUTME: Integration test for Parser with heredoc preprocessor
+# ABOUTME: Verify full heredoc->q{}/qq{} transformation and parsing pipeline
+use 5.42.0;
+use Test2::V0;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use experimental qw(defer);
+defer { done_testing() }
+
+use Chalk::Grammar::Perl qw($chalk_grammar);
+use Chalk::Parser;
+use Chalk::Semiring::Boolean;
+
+subtest 'Parse simple heredoc with preprocessing' => sub {
+    my $code = q{my $text = <<'EOF';
+Hello World
+EOF
+};
+
+    my $parser = Chalk::Parser->new(
+        grammar => $chalk_grammar,
+        preprocess => 1,
+        semiring => Chalk::Semiring::Boolean->new(),
+    );
+
+    my $result = $parser->parse_string($code);
+    ok $result, 'Parse single-quoted heredoc';
+};
+
+subtest 'Parse double-quoted heredoc with preprocessing' => sub {
+    my $code = q{my $text = <<EOF;
+Hello World
+EOF
+};
+
+    my $parser = Chalk::Parser->new(
+        grammar => $chalk_grammar,
+        preprocess => 1,
+        semiring => Chalk::Semiring::Boolean->new(),
+    );
+
+    my $result = $parser->parse_string($code);
+    ok $result, 'Parse double-quoted heredoc';
+};
+
+subtest 'Parse indented heredoc with preprocessing' => sub {
+    my $code = q{my $text = <<~'EOF';
+    Indented content
+    More content
+EOF
+};
+
+    my $parser = Chalk::Parser->new(
+        grammar => $chalk_grammar,
+        preprocess => 1,
+        semiring => Chalk::Semiring::Boolean->new(),
+    );
+
+    my $result = $parser->parse_string($code);
+    ok $result, 'Parse indented heredoc';
+};
+
+subtest 'Parse multiple heredocs with preprocessing' => sub {
+    my $code = q{my ($a, $b) = (<<'EOF1', <<'EOF2');
+First heredoc
+EOF1
+Second heredoc
+EOF2
+};
+
+    my $parser = Chalk::Parser->new(
+        grammar => $chalk_grammar,
+        preprocess => 1,
+        semiring => Chalk::Semiring::Boolean->new(),
+    );
+
+    my $result = $parser->parse_string($code);
+    ok $result, 'Parse multiple heredocs';
+};
+
+subtest 'Parse mixed code and heredoc' => sub {
+    my $code = q{my $x = 42;
+my $text = <<'EOF';
+Some heredoc content
+EOF
+my $y = $x + 10;};
+
+    my $parser = Chalk::Parser->new(
+        grammar => $chalk_grammar,
+        preprocess => 1,
+        semiring => Chalk::Semiring::Boolean->new(),
+    );
+
+    my $result = $parser->parse_string($code);
+    ok $result, 'Parse mixed code with heredoc';
+};
+
+subtest 'Preprocessing disabled should not transform' => sub {
+    my $code = q{my $text = q{Hello World};};
+
+    # Without preprocessing
+    my $parser = Chalk::Parser->new(
+        grammar => $chalk_grammar,
+        preprocess => 0,
+        semiring => Chalk::Semiring::Boolean->new(),
+    );
+
+    my $result = $parser->parse_string($code);
+    ok $result, 'Parse q{} without preprocessing';
+};

--- a/t/parser/with-preprocessor.t
+++ b/t/parser/with-preprocessor.t
@@ -20,7 +20,7 @@ EOF
 
     my $parser = Chalk::Parser->new(
         grammar => $chalk_grammar,
-        preprocess => 1,
+        preprocess => ['Chalk::Preprocessor::Heredoc'],
         semiring => Chalk::Semiring::Boolean->new(),
     );
 
@@ -36,7 +36,7 @@ EOF
 
     my $parser = Chalk::Parser->new(
         grammar => $chalk_grammar,
-        preprocess => 1,
+        preprocess => ['Chalk::Preprocessor::Heredoc'],
         semiring => Chalk::Semiring::Boolean->new(),
     );
 
@@ -53,7 +53,7 @@ EOF
 
     my $parser = Chalk::Parser->new(
         grammar => $chalk_grammar,
-        preprocess => 1,
+        preprocess => ['Chalk::Preprocessor::Heredoc'],
         semiring => Chalk::Semiring::Boolean->new(),
     );
 
@@ -71,7 +71,7 @@ EOF2
 
     my $parser = Chalk::Parser->new(
         grammar => $chalk_grammar,
-        preprocess => 1,
+        preprocess => ['Chalk::Preprocessor::Heredoc'],
         semiring => Chalk::Semiring::Boolean->new(),
     );
 
@@ -88,7 +88,7 @@ my $y = $x + 10;};
 
     my $parser = Chalk::Parser->new(
         grammar => $chalk_grammar,
-        preprocess => 1,
+        preprocess => ['Chalk::Preprocessor::Heredoc'],
         semiring => Chalk::Semiring::Boolean->new(),
     );
 
@@ -102,7 +102,7 @@ subtest 'Preprocessing disabled should not transform' => sub {
     # Without preprocessing
     my $parser = Chalk::Parser->new(
         grammar => $chalk_grammar,
-        preprocess => 0,
+        preprocess => [],
         semiring => Chalk::Semiring::Boolean->new(),
     );
 

--- a/t/preprocessor/heredoc.t
+++ b/t/preprocessor/heredoc.t
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# ABOUTME: Test Chalk::Preprocessor heredoc transformation to q{}/qq{}
+# ABOUTME: Test Chalk::Preprocessor::Heredoc transformation to q{}/qq{}
 # ABOUTME: Verify single-quoted, double-quoted, and indented heredoc support
 use 5.42.0;
 use Test2::V0;
@@ -8,7 +8,7 @@ use experimental qw(defer);
 defer { done_testing() }
 
 use lib "$RealBin/../../lib";
-use Chalk::Preprocessor;
+use Chalk::Preprocessor::Heredoc;
 
 subtest 'Single-quoted heredoc transformation' => sub {
     my $input = q{my $text = <<'EOF';
@@ -17,7 +17,7 @@ This is a test
 EOF
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -34,7 +34,7 @@ subtest 'Empty single-quoted heredoc' => sub {
 EOF
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -51,7 +51,7 @@ Line with \n escapes
 END
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -69,7 +69,7 @@ This is a test
 EOF
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -88,7 +88,7 @@ This is a test
 EOF
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -105,7 +105,7 @@ subtest 'Empty double-quoted heredoc' => sub {
 EOF
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -121,7 +121,7 @@ subtest 'Indented heredoc with single quotes' => sub {
     EOF
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -142,7 +142,7 @@ subtest 'Indented heredoc with double quotes' => sub {
     EOF
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -161,7 +161,7 @@ subtest 'Indented heredoc bare' => sub {
     EOF
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -181,7 +181,7 @@ subtest 'Indented heredoc with mixed indentation' => sub {
     EOF
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -205,7 +205,7 @@ Second heredoc
 EOF2
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -223,7 +223,7 @@ Third line (blank in between)
 EOF
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 
@@ -238,7 +238,7 @@ Still going
 DELIM
 };
 
-    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    my $preprocessor = Chalk::Preprocessor::Heredoc->new(input => $input);
     $preprocessor->transform();
     my $output = $preprocessor->output;
 

--- a/t/preprocessor/heredoc.t
+++ b/t/preprocessor/heredoc.t
@@ -112,3 +112,87 @@ EOF
     like $output, qr/qq\{\}/, 'Transformed to empty qq{}';
     unlike $output, qr/<<EOF/, 'Removed heredoc syntax';
 };
+
+subtest 'Indented heredoc with single quotes' => sub {
+    my $input = q{    my $text = <<~'EOF';
+        Hello World
+        This is indented
+        Another line
+    EOF
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    like $output, qr/q\{/, 'Transformed to q{}';
+    like $output, qr/Hello World/, 'Contains heredoc content';
+    unlike $output, qr/<<~'EOF'/, 'Removed heredoc syntax';
+    unlike $output, qr/^    EOF$/m, 'Removed terminator';
+
+    # Check that leading indentation is stripped
+    unlike $output, qr/\n        Hello/, 'Indentation stripped from content';
+    like $output, qr/Hello World\nThis is indented\nAnother line/, 'Content properly dedented';
+};
+
+subtest 'Indented heredoc with double quotes' => sub {
+    my $input = q{    my $text = <<~"EOF";
+        Hello World
+        This is indented
+    EOF
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    like $output, qr/qq\{/, 'Transformed to qq{}';
+    like $output, qr/Hello World/, 'Contains heredoc content';
+    unlike $output, qr/<<~"EOF"/, 'Removed heredoc syntax';
+
+    # Check that leading indentation is stripped
+    unlike $output, qr/\n        Hello/, 'Indentation stripped from content';
+};
+
+subtest 'Indented heredoc bare' => sub {
+    my $input = q{    my $text = <<~EOF;
+        Hello World
+        This is indented
+    EOF
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    like $output, qr/qq\{/, 'Transformed to qq{}';
+    like $output, qr/Hello World/, 'Contains heredoc content';
+    unlike $output, qr/<<~EOF/, 'Removed heredoc syntax';
+
+    # Check that leading indentation is stripped
+    unlike $output, qr/\n        Hello/, 'Indentation stripped from content';
+};
+
+subtest 'Indented heredoc with mixed indentation' => sub {
+    my $input = q{    my $text = <<~'EOF';
+        First line
+            More indented
+        Back to normal
+    EOF
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    like $output, qr/q\{/, 'Transformed to q{}';
+
+    # First line should have no leading spaces (stripped)
+    like $output, qr/First line/, 'First line dedented';
+
+    # More indented line should retain relative indentation (4 extra spaces)
+    like $output, qr/\n    More indented/, 'Relative indentation preserved';
+
+    # Third line back to baseline
+    like $output, qr/\nBack to normal/, 'Back to baseline dedented';
+};

--- a/t/preprocessor/heredoc.t
+++ b/t/preprocessor/heredoc.t
@@ -61,3 +61,54 @@ END
     like $output, qr/%hashes/, 'Contains percent signs';
     like $output, qr/\\n/, 'Contains backslash-n literally';
 };
+
+subtest 'Double-quoted heredoc transformation (bare)' => sub {
+    my $input = q{my $text = <<EOF;
+Hello World
+This is a test
+EOF
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    # Should transform to qq{...}
+    like $output, qr/qq\{/, 'Transformed to qq{}';
+    like $output, qr/Hello World/, 'Contains heredoc content';
+    like $output, qr/This is a test/, 'Contains all heredoc lines';
+    unlike $output, qr/<<EOF/, 'Removed heredoc syntax';
+    unlike $output, qr/^EOF$/m, 'Removed terminator';
+};
+
+subtest 'Double-quoted heredoc transformation (quoted)' => sub {
+    my $input = q{my $text = <<"EOF";
+Hello World
+This is a test
+EOF
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    # Should transform to qq{...}
+    like $output, qr/qq\{/, 'Transformed to qq{}';
+    like $output, qr/Hello World/, 'Contains heredoc content';
+    like $output, qr/This is a test/, 'Contains all heredoc lines';
+    unlike $output, qr/<<"EOF"/, 'Removed heredoc syntax';
+    unlike $output, qr/^EOF$/m, 'Removed terminator';
+};
+
+subtest 'Empty double-quoted heredoc' => sub {
+    my $input = q{my $text = <<EOF;
+EOF
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    like $output, qr/qq\{\}/, 'Transformed to empty qq{}';
+    unlike $output, qr/<<EOF/, 'Removed heredoc syntax';
+};

--- a/t/preprocessor/heredoc.t
+++ b/t/preprocessor/heredoc.t
@@ -196,3 +196,53 @@ subtest 'Indented heredoc with mixed indentation' => sub {
     # Third line back to baseline
     like $output, qr/\nBack to normal/, 'Back to baseline dedented';
 };
+
+subtest 'Multiple heredocs on same line' => sub {
+    my $input = q{my ($a, $b) = (<<'EOF1', <<'EOF2');
+First heredoc
+EOF1
+Second heredoc
+EOF2
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    like $output, qr/q\{First heredoc\}/, 'First heredoc transformed';
+    like $output, qr/q\{Second heredoc\}/, 'Second heredoc transformed';
+    unlike $output, qr/<<'EOF1'/, 'First heredoc syntax removed';
+    unlike $output, qr/<<'EOF2'/, 'Second heredoc syntax removed';
+};
+
+subtest 'Edge case: Empty lines in heredoc' => sub {
+    my $input = q{my $text = <<'EOF';
+First line
+
+Third line (blank in between)
+EOF
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    like $output, qr/First line\n\nThird line/, 'Empty line preserved';
+};
+
+subtest 'Edge case: Heredoc delimiter appears in content' => sub {
+    my $input = q{my $text = <<'DELIM';
+This line mentions DELIM but not at start
+  DELIM with leading space
+Still going
+DELIM
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    like $output, qr/mentions DELIM/, 'DELIM in content preserved';
+    like $output, qr/DELIM with leading space/, 'DELIM with space preserved';
+    unlike $output, qr/^DELIM$/m, 'Only terminator DELIM removed';
+};

--- a/t/preprocessor/heredoc.t
+++ b/t/preprocessor/heredoc.t
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl
+# ABOUTME: Test Chalk::Preprocessor heredoc transformation to q{}/qq{}
+# ABOUTME: Verify single-quoted, double-quoted, and indented heredoc support
+use 5.42.0;
+use Test2::V0;
+use FindBin qw($RealBin);
+use experimental qw(defer);
+defer { done_testing() }
+
+use lib "$RealBin/../../lib";
+use Chalk::Preprocessor;
+
+subtest 'Single-quoted heredoc transformation' => sub {
+    my $input = q{my $text = <<'EOF';
+Hello World
+This is a test
+EOF
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    # Should transform to q{...}
+    like $output, qr/q\{/, 'Transformed to q{}';
+    like $output, qr/Hello World/, 'Contains heredoc content';
+    like $output, qr/This is a test/, 'Contains all heredoc lines';
+    unlike $output, qr/<<'EOF'/, 'Removed heredoc syntax';
+    unlike $output, qr/^EOF$/m, 'Removed terminator';
+};
+
+subtest 'Empty single-quoted heredoc' => sub {
+    my $input = q{my $text = <<'EOF';
+EOF
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    like $output, qr/q\{\}/, 'Transformed to empty q{}';
+    unlike $output, qr/<<'EOF'/, 'Removed heredoc syntax';
+};
+
+subtest 'Single-quoted heredoc with special characters' => sub {
+    my $input = q{my $text = <<'END';
+Line with $variables that shouldn't expand
+Line with @arrays
+Line with %hashes
+Line with \n escapes
+END
+};
+
+    my $preprocessor = Chalk::Preprocessor->new(input => $input);
+    $preprocessor->transform();
+    my $output = $preprocessor->output;
+
+    like $output, qr/q\{/, 'Transformed to q{}';
+    like $output, qr/\$variables/, 'Contains dollar signs';
+    like $output, qr/\@arrays/, 'Contains at signs';
+    like $output, qr/%hashes/, 'Contains percent signs';
+    like $output, qr/\\n/, 'Contains backslash-n literally';
+};


### PR DESCRIPTION
## Summary

This PR implements heredoc support for Chalk::Parser via preprocessor transformation to q{}/qq{} quote operators. The implementation uses an arrayref-based preprocessor architecture that allows for future extensibility with additional preprocessors (POD stripping, comment removal, etc.).

### Key Changes

- **New Chalk::Preprocessor::Heredoc class** (lib/Chalk/Preprocessor/Heredoc.pm)
  - Transforms heredoc syntax to equivalent q{}/qq{} before parsing
  - Line mapping support for accurate error reporting
  - 221 lines of clean, well-tested code

- **Grammar extensions** (lib/Chalk/Grammar/Perl.pm)
  - Added q{} and qq{} quote operator recognition
  - Supports newlines in quoted content

- **Parser integration** (lib/Chalk/Parser.pm)
  - Arrayref-based `preprocess` parameter (defaults to `[]`)
  - Supports chaining multiple preprocessors in sequence
  - Preprocessing is opt-in via explicit configuration

- **CLI support** (app.pl)
  - `--preprocess` flag enables heredoc preprocessing
  - Sets `preprocess => ['Chalk::Preprocessor::Heredoc']`

### Heredoc Types Supported

✅ Single-quoted: `<<'EOF'` → `q{...}`
✅ Double-quoted: `<<EOF`, `<<"EOF"` → `qq{...}`
✅ Indented: `<<~'EOF'`, `<<~EOF`, `<<~"EOF"` (auto-strips indentation)
✅ Multiple heredocs on same line
✅ Edge cases: empty heredocs, delimiters in content, special characters

### Test Coverage

**19 tests passing at 100%** across 2 test files:

- `t/preprocessor/heredoc.t` (13 tests) - Comprehensive transformation tests
- `t/parser/with-preprocessor.t` (6 tests) - End-to-end integration tests

### Implementation Approach

Following strict TDD methodology, each feature was developed with:
1. Failing test written first
2. Minimal implementation to pass
3. Verification of 100% test pass rate
4. 9 focused commits building incrementally

### Architecture Benefits

- ✅ Simpler grammar - no heredoc-specific rules needed
- ✅ Reuses existing quote operator support
- ✅ Easier to test and maintain
- ✅ **Extensible**: Arrayref design allows chaining preprocessors
- ✅ **Opt-in**: Preprocessing enabled explicitly, not by default
- ✅ **Future-ready**: Can add POD stripping, comment removal, etc.
- ✅ Fixes #37 (lex.t parsing capability)

### Usage Examples

```perl
# Enable heredoc preprocessing
my $parser = Chalk::Parser->new(
    grammar => $grammar,
    preprocess => ['Chalk::Preprocessor::Heredoc']
);

# No preprocessing (default)
my $parser = Chalk::Parser->new(
    grammar => $grammar
);

# Future: Chain multiple preprocessors
my $parser = Chalk::Parser->new(
    grammar => $grammar,
    preprocess => [
        'Chalk::Preprocessor::POD',
        'Chalk::Preprocessor::Heredoc',
    ]
);
```

### Acceptance Criteria Status

- ✅ Chalk::Preprocessor::Heredoc class created
- ✅ Heredoc transformation implemented
- ✅ Handles single-quoted, double-quoted, and indented forms
- ✅ Preserves line numbers for error reporting
- ✅ Integrated into Chalk::Parser with arrayref architecture
- ✅ Tests for various heredoc forms
- ✅ All tests pass at 100%

## Test Plan

Run the test suite:
```bash
prove -lv t/preprocessor/heredoc.t t/parser/with-preprocessor.t
```

All 19 tests should pass.

## Closes

Fixes #41
Related to #37