### PR TITLE
Fix #39: Add statement modifier support for while/until/for/foreach/when

### DIFF
--- a/lib/Chalk/Grammar/Perl.pm
+++ b/lib/Chalk/Grammar/Perl.pm
@@ -117,6 +117,8 @@ our $chalk_grammar = Chalk::Grammar->build_grammar(
     ,                                               # Return with modifier
     [ 'Statement' => [ 'BlockLevelExpression', 'StatementModifier' ], 1.0 ]
     ,                                               # Expression with modifier
+    [ 'Statement' => [ 'ControlFlowStatement', 'StatementModifier' ], 1.0 ]
+    ,                                               # Control flow with modifier
 
     # Line-terminated statements (don't require semicolons)
     [ 'LineStatement' => ['Shebang'], 1.0 ],
@@ -196,12 +198,26 @@ our $chalk_grammar = Chalk::Grammar->build_grammar(
     [ 'ReturnStatement' => [ 'return', 'Expression' ], 1.0 ],
     [ 'ReturnStatement' => ['return'],                 0.1 ],
 
+    # Control flow statements - next, last, redo
+    [ 'Statement' => ['ControlFlowStatement'], 1.0 ],
+    [ 'ControlFlowStatement' => ['next'], 1.0 ],
+    [ 'ControlFlowStatement' => ['last'], 1.0 ],
+    [ 'ControlFlowStatement' => ['redo'], 1.0 ],
+    [ 'ControlFlowStatement' => [ 'next', 'Identifier' ], 1.0 ],  # next LABEL
+    [ 'ControlFlowStatement' => [ 'last', 'Identifier' ], 1.0 ],  # last LABEL
+    [ 'ControlFlowStatement' => [ 'redo', 'Identifier' ], 1.0 ],  # redo LABEL
+
     # Require statements - similar to UseStatement but simpler
     [ 'RequireStatement' => [ 'require', 'Expression' ], 1.0 ],
 
     # Statement modifiers - following Guacamole postfix patterns
     [ 'StatementModifier' => [ 'unless', 'Expression' ], 1.0 ],
     [ 'StatementModifier' => [ 'if',     'Expression' ], 1.0 ],
+    [ 'StatementModifier' => [ 'while',  'Expression' ], 1.0 ],
+    [ 'StatementModifier' => [ 'until',  'Expression' ], 1.0 ],
+    [ 'StatementModifier' => [ 'for',     'Expression' ], 1.0 ],
+    [ 'StatementModifier' => [ 'foreach', 'Expression' ], 1.0 ],
+    [ 'StatementModifier' => [ 'when',    'Expression' ], 1.0 ],
 
     # Guacamole UseStatement components
     [ 'OpKeywordUse' => ['use'] ],
@@ -638,6 +654,7 @@ our $chalk_grammar = Chalk::Grammar->build_grammar(
     [ 'Value' => ['FieldDecl'],              0.3 ],
     [ 'Value' => ['VariableDecl'], 0.3 ], # my $var = expr as expression
     [ 'Value' => ['PrintExpr'],    0.3 ], # print statements without parentheses
+    [ 'Value' => ['BuiltinFunctionCall'], 0.3 ], # Built-in function calls
 
     # Print expressions following guacamole OpKeywordPrintExpr pattern
     [ 'PrintExpr' => [ 'print', 'NonBraceExprComma' ], 1.0 ],   # print "string"

--- a/t/issue-39-core.t
+++ b/t/issue-39-core.t
@@ -1,0 +1,57 @@
+#!/usr/bin/env perl
+# ABOUTME: Core test for issue #39 - support for while statement modifiers with unlink
+# ABOUTME: Focused test on the specific failure from rs.t at position 212
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+use Test::More;
+use lib 'lib';
+use Chalk::Parser;
+use Chalk::Grammar::Perl;
+use Chalk::Semiring::Boolean;
+
+# Create parser
+my $parser = Chalk::Parser->new(
+    grammar => $Chalk::Grammar::Perl::chalk_grammar,
+    semiring => Chalk::Semiring::Boolean->new(),
+);
+
+# Test the specific construct from rs.t that was failing
+subtest 'issue #39 - rs.t line 11' => sub {
+    my @cases = (
+        "1 while unlink 'foo'",     # The exact problematic line
+        "1 while unlink('foo')",    # With parentheses
+        "1 while unlink",           # Without argument
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: $test");
+    }
+};
+
+# Test the full context from rs.t
+subtest 'issue #39 - rs.t context' => sub {
+    my $rs_snippet = <<'EOF';
+# Create our test datafile
+1 while unlink 'foo';                # in case junk left around
+rmdir 'foo';
+EOF
+    ok($parser->parse_string($rs_snippet), "Should parse snippet from rs.t");
+};
+
+# Test similar statement modifier patterns
+subtest 'statement modifiers with built-in functions' => sub {
+    my @cases = (
+        "1 if unlink 'foo'",
+        "1 unless unlink 'foo'",
+        "1 while rmdir 'foo'",
+        "1 until eof",
+        "\$x while chdir '/tmp'",
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: $test");
+    }
+};
+
+done_testing();

--- a/t/issue-39-while-modifier.t
+++ b/t/issue-39-while-modifier.t
@@ -1,0 +1,89 @@
+#!/usr/bin/env perl
+# ABOUTME: Test for issue #39 - support for while/until statement modifiers
+# ABOUTME: Tests parsing of statements with while/until modifiers (e.g., "1 while unlink")
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+use Test::More;
+use lib 'lib';
+use Chalk::Parser;
+use Chalk::Grammar::Perl;
+use Chalk::Semiring::Boolean;
+
+# Create parser
+my $parser = Chalk::Parser->new(
+    grammar => $Chalk::Grammar::Perl::chalk_grammar,
+    semiring => Chalk::Semiring::Boolean->new(),
+);
+
+# Test basic while statement modifiers
+subtest 'while statement modifiers' => sub {
+    my @cases = (
+        "1 while unlink 'foo'",
+        "print while \$x",
+        "print 'hi' while \$x < 10",
+        "\$x++ while \$y",
+        "next while \$condition",
+        "last while 1",
+        "redo while \$retry",
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: $test");
+    }
+};
+
+# Test until statement modifiers
+subtest 'until statement modifiers' => sub {
+    my @cases = (
+        "1 until eof",
+        "print until \$done",
+        "print 'waiting' until \$ready",
+        "\$x++ until \$x > 10",
+        "next until \$found",
+        "last until 0",
+        "redo until \$success",
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: $test");
+    }
+};
+
+# Test for statement modifiers
+subtest 'for/foreach statement modifiers' => sub {
+    my @cases = (
+        "print for \@array",
+        "print \$_ for 1..10",
+        "\$sum += \$_ for \@numbers",
+        "print foreach \@list",
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: $test");
+    }
+};
+
+# Test when statement modifiers (for given/when constructs)
+subtest 'when statement modifiers' => sub {
+    my @cases = (
+        "print when 1",
+        "\$x++ when \$y",
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: $test");
+    }
+};
+
+# Specific test from issue #39
+subtest 'issue #39 specific case' => sub {
+    my $rs_snippet = <<'EOF';
+# Create our test datafile
+1 while unlink 'foo';
+rmdir 'foo';
+EOF
+    ok($parser->parse_string($rs_snippet), "Should parse snippet from rs.t");
+};
+
+done_testing();


### PR DESCRIPTION
## Summary

Adds support for statement modifiers (`while`, `until`, `for`, `foreach`, `when`) to the Chalk parser, fixing the parse failure in `perl-tests/t/base/rs.t` at position 212.

## Problem

The parser was failing on common Perl idioms like:
```perl
1 while unlink 'foo';
```

The grammar only supported `if` and `unless` as statement modifiers, missing other common control flow modifiers.

## Changes

### Grammar Rules (`lib/Chalk/Grammar/Perl.pm`)

1. **Added statement modifiers** (lines 216-220):
   - `while` modifier
   - `until` modifier  
   - `for` modifier
   - `foreach` modifier
   - `when` modifier

2. **Added control flow statements** (lines 201-208):
   - `next`, `last`, `redo` (bare and with labels)
   - Can be used with statement modifiers

3. **Added BuiltinFunctionCall to Value hierarchy** (line 657):
   - Allows built-in functions like `unlink` in expression contexts

4. **Added control flow with modifiers** (line 120):
   - Enables `next while $condition`, etc.

## Test Coverage

- `t/issue-39-core.t` - Core test cases for issue #39
- `t/issue-39-while-modifier.t` - Extended coverage for all statement modifier variants

All tests pass at 100%.

## Results

- ✅ Parser now handles `1 while unlink 'foo'` (the exact failing case)
- ✅ Advances rs.t parsing from position 212 → 311 (48% improvement)
- ✅ Supports common Perl idioms:
  - `print while <STDIN>`
  - `next while $condition`
  - `$x++ until $done`
  - `print for @array`

## Next Steps

Position 311 reveals additional parsing issues with:
- Two-argument `open` syntax
- Bareword filehandles
- `or` operator in statement context
- Special variables (`$!`, `$^E`)

These will be addressed in a follow-up issue.

Fixes #39