### PR TITLE
Fix #40: Add file test operator support in expression contexts

### DIFF
--- a/lib/Chalk/Grammar/Perl.pm
+++ b/lib/Chalk/Grammar/Perl.pm
@@ -384,10 +384,13 @@ our $chalk_grammar = Chalk::Grammar->build_grammar(
 
     # NonBrace unary expressions
     [ 'NonBraceExprUnaryR' => [ 'OpUnary', 'NonBraceExprUnaryR' ], 0.8 ],
+    [ 'NonBraceExprUnaryR' => [ 'FileTestOp', 'NonBraceExprUnaryR' ], 0.8 ],
     [ 'NonBraceExprUnaryR' => ['NonBraceExprPowerR'], 0.3 ],
     [ 'NonBraceExprUnary0' => [ 'OpUnary', 'NonBraceExprUnary0' ], 0.8 ],
+    [ 'NonBraceExprUnary0' => [ 'FileTestOp', 'NonBraceExprUnary0' ], 0.8 ],
     [ 'NonBraceExprUnary0' => ['NonBraceExprPower0'], 0.3 ],
     [ 'NonBraceExprUnaryU' => [ 'OpUnary', 'NonBraceExprUnaryU' ], 0.8 ],
+    [ 'NonBraceExprUnaryU' => [ 'FileTestOp', 'NonBraceExprUnaryU' ], 0.8 ],
     [ 'NonBraceExprUnaryU' => ['NonBraceExprPowerU'], 0.3 ],
 
     # NonBrace power expressions
@@ -440,8 +443,9 @@ our $chalk_grammar = Chalk::Grammar->build_grammar(
     [ 'NonBraceValue'      => ['UnaryExpression'],     0.3 ],
     [ 'NonBraceValue'      => ['QuotedString'],        0.3 ],
 
-    # Unary expressions (for things like -1e10, !$flag, etc.)
+    # Unary expressions (for things like -1e10, !$flag, -d 't', etc.)
     [ 'UnaryExpression' => [ 'OpUnary', 'NonBraceValue' ], 1.0 ],
+    [ 'UnaryExpression' => [ 'FileTestOp', 'NonBraceValue' ], 1.0 ],
     [ 'NonBraceValue'   => [ '(', 'Expression', ')' ],     0.3 ],
     [ 'NonBraceValue'   => ['ArrayRef'],                   0.3 ],
     [ 'NonBraceValue'   => ['FunctionCall'],               0.3 ],
@@ -569,12 +573,16 @@ our $chalk_grammar = Chalk::Grammar->build_grammar(
     [ 'ExprRegexU' => ['ExprUnaryU'],                            0.3 ],
 
     [ 'ExprUnaryR' => [ 'OpUnary', 'ExprUnaryR' ], 0.8 ],
+    [ 'ExprUnaryR' => [ 'FileTestOp', 'ExprUnaryR' ], 0.8 ],
     [ 'ExprUnaryR' => ['ExprPowerR'],              0.3 ],
     [ 'ExprUnaryL' => [ 'OpUnary', 'ExprUnaryL' ], 0.8 ],
+    [ 'ExprUnaryL' => [ 'FileTestOp', 'ExprUnaryL' ], 0.8 ],
     [ 'ExprUnaryL' => ['ExprPowerL'],              0.3 ],
     [ 'ExprUnary0' => [ 'OpUnary', 'ExprUnary0' ], 0.8 ],
+    [ 'ExprUnary0' => [ 'FileTestOp', 'ExprUnary0' ], 0.8 ],
     [ 'ExprUnary0' => ['ExprPower0'],              0.3 ],
     [ 'ExprUnaryU' => [ 'OpUnary', 'ExprUnaryU' ], 0.8 ],
+    [ 'ExprUnaryU' => [ 'FileTestOp', 'ExprUnaryU' ], 0.8 ],
     [ 'ExprUnaryU' => ['ExprPowerU'],              0.3 ],
 
     [ 'ExprPowerR' => [ 'ExprIncU', 'OpPower', 'ExprUnaryR' ], 0.8 ],
@@ -735,6 +743,8 @@ our $chalk_grammar = Chalk::Grammar->build_grammar(
     [ 'NonBraceExprMulL' => ['NonBraceExprRegexL'], 0.3 ],
     
     [ 'NonBraceExprRegexL'  => ['NonBraceExprUnaryL'],  0.3 ],
+    [ 'NonBraceExprUnaryL'  => [ 'OpUnary', 'NonBraceExprUnaryL' ], 0.8 ],
+    [ 'NonBraceExprUnaryL'  => [ 'FileTestOp', 'NonBraceExprUnaryL' ], 0.8 ],
     [ 'NonBraceExprUnaryL'  => ['NonBraceExprPowerL'],  0.3 ],
     [ 'NonBraceExprPowerL'  => ['NonBraceExprIncL'],    0.3 ],
     [ 'NonBraceExprIncL' => [ 'OpInc', 'NonBraceExprIncL' ], 0.8 ],      # Pre-increment
@@ -898,6 +908,7 @@ our $chalk_grammar = Chalk::Grammar->build_grammar(
     ,                                                           # key => value
 
     # File test operators - unary operators that test file properties
+    [ 'FileTestOp' => [qr/-[rwxoRWXOezsfdlpSbctugkTBMAC]/] ],
     [ 'OpUnaryKeywordExpr' => [qr/-[rwxoRWXOezsfdlpSbctugkTBMAC]/] ],  # File test operators
     
     # Keyword expressions - termination points for Expression chain

--- a/t/issue-40-begin-block.t
+++ b/t/issue-40-begin-block.t
@@ -1,0 +1,100 @@
+#!/usr/bin/env perl
+# ABOUTME: Test for issue #40 - support for BEGIN/END blocks
+# ABOUTME: Tests parsing of BEGIN and END blocks which are fundamental Perl constructs
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+use Test::More;
+use lib 'lib';
+use Chalk::Parser;
+use Chalk::Grammar::Perl;
+use Chalk::Semiring::Boolean;
+
+# Create parser
+my $parser = Chalk::Parser->new(
+    grammar => $Chalk::Grammar::Perl::chalk_grammar,
+    semiring => Chalk::Semiring::Boolean->new(),
+);
+
+# Test basic BEGIN blocks
+subtest 'basic BEGIN blocks' => sub {
+    my @cases = (
+        "BEGIN { }",                                    # Empty BEGIN block
+        "BEGIN { 1; }",                                 # Simple statement
+        "BEGIN { \$x = 1; }",                           # Variable assignment
+        "BEGIN { chdir 't'; }",                         # Function call
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: $test") or diag("Failed to parse: $test");
+    }
+};
+
+# Test BEGIN blocks with statement modifiers (from term.t)
+subtest 'BEGIN blocks with statement modifiers' => sub {
+    my @cases = (
+        "BEGIN { chdir 't' if -d 't'; }",               # if modifier
+        "BEGIN { chdir 't' unless \$done; }",           # unless modifier
+        "BEGIN { 1 while unlink 'foo'; }",              # while modifier
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: $test") or diag("Failed to parse: $test");
+    }
+};
+
+# Test END blocks
+subtest 'basic END blocks' => sub {
+    my @cases = (
+        "END { }",                                      # Empty END block
+        "END { print 'cleanup'; }",                     # Print in END
+        "END { close \$fh; }",                          # Close filehandle
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: $test") or diag("Failed to parse: $test");
+    }
+};
+
+# Test the exact construct from term.t (issue #40)
+subtest 'issue #40 - term.t BEGIN block' => sub {
+    # The exact code that was failing
+    my $term_snippet = <<'EOF';
+#!./perl
+
+BEGIN {
+    chdir 't' if -d 't';
+}
+EOF
+
+    ok($parser->parse_string($term_snippet), "Should parse term.t BEGIN block snippet")
+        or diag("Failed to parse term.t snippet");
+};
+
+# Test BEGIN/END blocks in program context
+subtest 'BEGIN/END in full programs' => sub {
+    my @cases = (
+        "BEGIN { \$x = 1; }\n\$x++;",                   # BEGIN then statement
+        "\$x = 1;\nEND { print \$x; }",                 # Statement then END
+        "BEGIN { \$x = 1; }\n\$y = 2;\nEND { }",        # BEGIN, statement, END
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: " . substr($test, 0, 30) . "...")
+            or diag("Failed to parse: $test");
+    }
+};
+
+# Test multiple BEGIN/END blocks
+subtest 'multiple BEGIN/END blocks' => sub {
+    my @cases = (
+        "BEGIN { \$x = 1; }\nBEGIN { \$y = 2; }",       # Multiple BEGINs
+        "END { }\nEND { }",                             # Multiple ENDs
+    );
+
+    for my $test (@cases) {
+        ok($parser->parse_string($test), "Should parse: $test") or diag("Failed to parse: $test");
+    }
+};
+
+done_testing();


### PR DESCRIPTION
## Summary
Fixes parsing of file test operators (`-d`, `-e`, `-f`, etc.) in statement modifiers and expression contexts.

## Changes
- Added `FileTestOp` terminal for all file test operators (`-[rwxoRWXOezsfdlpSbctugkTBMAC]`)
- Integrated file test operators into all `ExprUnary*` rule variants (R, L, 0, U)
- Integrated file test operators into all `NonBraceExprUnary*` rule variants
- Added comprehensive test coverage in `t/issue-40-begin-block.t`

## Test Results
✅ All tests pass for `t/issue-40-begin-block.t` (6/6 subtests)
✅ Self-hosting test passes
✅ issue-39-core tests pass

## Examples Now Working
- `BEGIN { chdir 't' if -d 't'; }` (the original failing case from term.t)
- `chdir 't' if -d 't'` (file test in statement modifier)
- Any file test operator in expression contexts

Closes #40