### PR TITLE
Standardize Phi Node Representation in Sea of Nodes IR

### DIFF
--- a/lib/Chalk/IR/Node.pm
+++ b/lib/Chalk/IR/Node.pm
@@ -235,7 +235,11 @@ class Chalk::IR::Node {
                 my $region = $graph->get_node($region_id);
                 if (defined($region) && $region->op eq 'Region') {
                     my @region_inputs = $region->inputs->@*;
-                    my $alternatives = $attributes->{alternatives} || [];
+
+                    # Get alternatives from inputs array (skip first element which is region control)
+                    # Standardized representation: inputs => [region_id, alt1, alt2, ...]
+                    my @phi_inputs = $inputs->@*;
+                    my @alternatives = @phi_inputs[1 .. $#phi_inputs];  # Skip region at index 0
 
                     # Find live alternatives (where corresponding Region input is not ~Ctrl)
                     my @live_values;
@@ -254,19 +258,17 @@ class Chalk::IR::Node {
                         }
 
                         # If control is live, keep this alternative
-                        if (!$is_dead && $i < scalar( $alternatives->@* )) {
-                            push @live_values, $alternatives->[$i];
+                        if (!$is_dead && $i < scalar( @alternatives )) {
+                            push @live_values, $alternatives[$i];
                         }
                     }
 
                     # If only one live value, replace Phi with that value
                     if (scalar( @live_values ) == 1) {
-                        my $value_ref = $live_values[0];
-                        if ($value_ref->{op} eq 'NodeRef') {
-                            my $value_node = $graph->get_node($value_ref->{node_id});
-                            if (defined($value_node)) {
-                                return $value_node;
-                            }
+                        my $value_id = $live_values[0];
+                        my $value_node = $graph->get_node($value_id);
+                        if (defined($value_node)) {
+                            return $value_node;
                         }
                     }
                 }

--- a/lib/Chalk/IR/Validator.pm
+++ b/lib/Chalk/IR/Validator.pm
@@ -444,20 +444,11 @@ class Chalk::IR::Validator {
                     my $region_preds = $region_node->inputs;
                     my $expected_alternatives = scalar( $region_preds->@* );
 
-                    # Count phi alternatives - check both inputs array and attributes
-                    # Phi nodes can store alternatives in two ways:
-                    # 1. In inputs array (after control input): inputs => [ctrl, val1, val2, ...]
-                    # 2. In attributes: attributes => { alternatives => [...] }
+                    # Count phi alternatives from standardized inputs array
+                    # Phi nodes use inputs array: inputs => [ctrl, val1, val2, ...]
+                    # This is the standardized representation as per GitHub Issue #80
                     my $phi_inputs = $node->inputs;
                     my $actual_alternatives = scalar( $phi_inputs->@* ) - 1;  # Subtract control input
-
-                    # If alternatives not in inputs, check attributes
-                    if ($actual_alternatives == 0) {
-                        my $alt_attr = $node->attributes->{alternatives};
-                        if (defined($alt_attr) && ref($alt_attr) eq 'ARRAY') {
-                            $actual_alternatives = scalar( $alt_attr->@* );
-                        }
-                    }
 
                     if ($actual_alternatives != $expected_alternatives) {
                         push @errors, "Phi node $node_id in node $region_id expects $expected_alternatives value inputs ($expected_alternatives predecessors) but has $actual_alternatives";

--- a/t/ir/invalid-phi.t
+++ b/t/ir/invalid-phi.t
@@ -21,16 +21,23 @@ subtest 'Phi node without Region control' => sub {
     );
     $graph->add_node($start);
 
+    # Create constant node for the Phi alternative
+    my $const1 = Chalk::IR::Node->new(
+        id => 'const_1',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 10, type => 'Int' }
+    );
+    $graph->add_node($const1);
+
     # Invalid: Phi directly connected to Start (not a Region)
     my $phi = Chalk::IR::Node->new(
         id => 'node_1',
         op => 'Phi',
-        inputs => ['node_0'],
+        inputs => ['node_0', 'const_1'],
         attributes => {
+            region_id => 'node_0',
             variable => '$x',
-            alternatives => [
-                { op => 'Constant', value => 10, type => 'Int' }
-            ]
         }
     );
     $graph->add_node($phi);
@@ -72,18 +79,39 @@ subtest 'Phi node with excess alternatives' => sub {
     );
     $graph->add_node($region);
 
+    # Create constant nodes for the Phi alternatives
+    my $const1 = Chalk::IR::Node->new(
+        id => 'const_1',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 10, type => 'Int' }
+    );
+    $graph->add_node($const1);
+
+    my $const2 = Chalk::IR::Node->new(
+        id => 'const_2',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 20, type => 'Int' }
+    );
+    $graph->add_node($const2);
+
+    my $const3 = Chalk::IR::Node->new(
+        id => 'const_3',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 30, type => 'Int' }
+    );
+    $graph->add_node($const3);
+
     # Invalid: Phi with 3 alternatives but Region has only 2 predecessors
     my $phi = Chalk::IR::Node->new(
         id => 'node_2',
         op => 'Phi',
-        inputs => ['node_1'],
+        inputs => ['node_1', 'const_1', 'const_2', 'const_3'],  # Extra!
         attributes => {
+            region_id => 'node_1',
             variable => '$x',
-            alternatives => [
-                { op => 'Constant', value => 10, type => 'Int' },
-                { op => 'Constant', value => 20, type => 'Int' },
-                { op => 'Constant', value => 30, type => 'Int' }  # Extra!
-            ]
         }
     );
     $graph->add_node($phi);
@@ -125,18 +153,32 @@ subtest 'Phi node with insufficient alternatives' => sub {
     );
     $graph->add_node($region);
 
+    # Create constant nodes for the Phi alternatives
+    my $const1 = Chalk::IR::Node->new(
+        id => 'const_1',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 10, type => 'Int' }
+    );
+    $graph->add_node($const1);
+
+    my $const2 = Chalk::IR::Node->new(
+        id => 'const_2',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 20, type => 'Int' }
+    );
+    $graph->add_node($const2);
+
     # Invalid: Phi with 2 alternatives but Region has 3 predecessors
+    # Missing third alternative!
     my $phi = Chalk::IR::Node->new(
         id => 'node_2',
         op => 'Phi',
-        inputs => ['node_1'],
+        inputs => ['node_1', 'const_1', 'const_2'],
         attributes => {
+            region_id => 'node_1',
             variable => '$result',
-            alternatives => [
-                { op => 'Constant', value => 10, type => 'Int' },
-                { op => 'Constant', value => 20, type => 'Int' }
-                # Missing third alternative!
-            ]
         }
     );
     $graph->add_node($phi);
@@ -169,16 +211,23 @@ subtest 'Phi node references non-existent Region' => sub {
     );
     $graph->add_node($start);
 
+    # Create constant node for the Phi alternative
+    my $const1 = Chalk::IR::Node->new(
+        id => 'const_1',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 10, type => 'Int' }
+    );
+    $graph->add_node($const1);
+
     # Invalid: Phi references node_999 which doesn't exist
     my $phi = Chalk::IR::Node->new(
         id => 'node_1',
         op => 'Phi',
-        inputs => ['node_999'],  # Non-existent!
+        inputs => ['node_999', 'const_1'],  # Non-existent!
         attributes => {
+            region_id => 'node_999',
             variable => '$x',
-            alternatives => [
-                { op => 'Constant', value => 10, type => 'Int' }
-            ]
         }
     );
     $graph->add_node($phi);
@@ -218,9 +267,6 @@ subtest 'Phi node with empty inputs' => sub {
         inputs => [],  # No control input!
         attributes => {
             variable => '$x',
-            alternatives => [
-                { op => 'Constant', value => 10, type => 'Int' }
-            ]
         }
     );
     $graph->add_node($phi);
@@ -262,17 +308,31 @@ subtest 'Valid phi node passes validation' => sub {
     );
     $graph->add_node($region);
 
+    # Create constant nodes for the Phi alternatives
+    my $const1 = Chalk::IR::Node->new(
+        id => 'const_1',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 10, type => 'Int' }
+    );
+    $graph->add_node($const1);
+
+    my $const2 = Chalk::IR::Node->new(
+        id => 'const_2',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 20, type => 'Int' }
+    );
+    $graph->add_node($const2);
+
     # Valid: Phi with correct number of alternatives
     my $phi = Chalk::IR::Node->new(
         id => 'node_2',
         op => 'Phi',
-        inputs => ['node_1'],
+        inputs => ['node_1', 'const_1', 'const_2'],
         attributes => {
+            region_id => 'node_1',
             variable => '$x',
-            alternatives => [
-                { op => 'Constant', value => 10, type => 'Int' },
-                { op => 'Constant', value => 20, type => 'Int' }
-            ]
         }
     );
     $graph->add_node($phi);
@@ -312,32 +372,60 @@ subtest 'Multiple phi nodes at same Region' => sub {
     );
     $graph->add_node($region);
 
+    # Create constant nodes for the first Phi ($x)
+    my $const_x1 = Chalk::IR::Node->new(
+        id => 'const_x1',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 10, type => 'Int' }
+    );
+    $graph->add_node($const_x1);
+
+    my $const_x2 = Chalk::IR::Node->new(
+        id => 'const_x2',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 20, type => 'Int' }
+    );
+    $graph->add_node($const_x2);
+
     # First phi: $x
     my $phi_x = Chalk::IR::Node->new(
         id => 'node_2',
         op => 'Phi',
-        inputs => ['node_1'],
+        inputs => ['node_1', 'const_x1', 'const_x2'],
         attributes => {
+            region_id => 'node_1',
             variable => '$x',
-            alternatives => [
-                { op => 'Constant', value => 10, type => 'Int' },
-                { op => 'Constant', value => 20, type => 'Int' }
-            ]
         }
     );
     $graph->add_node($phi_x);
+
+    # Create constant nodes for the second Phi ($y)
+    my $const_y1 = Chalk::IR::Node->new(
+        id => 'const_y1',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 100, type => 'Int' }
+    );
+    $graph->add_node($const_y1);
+
+    my $const_y2 = Chalk::IR::Node->new(
+        id => 'const_y2',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 200, type => 'Int' }
+    );
+    $graph->add_node($const_y2);
 
     # Second phi: $y (both valid)
     my $phi_y = Chalk::IR::Node->new(
         id => 'node_3',
         op => 'Phi',
-        inputs => ['node_1'],
+        inputs => ['node_1', 'const_y1', 'const_y2'],
         attributes => {
+            region_id => 'node_1',
             variable => '$y',
-            alternatives => [
-                { op => 'Constant', value => 100, type => 'Int' },
-                { op => 'Constant', value => 200, type => 'Int' }
-            ]
         }
     );
     $graph->add_node($phi_y);

--- a/t/ir/phi-standardization.t
+++ b/t/ir/phi-standardization.t
@@ -1,0 +1,149 @@
+#!/usr/bin/env perl
+# ABOUTME: Test that Phi nodes use standardized inputs array representation
+# ABOUTME: Verifies peephole optimizer and validator both use inputs array (not alternatives attribute)
+
+use v5.42;
+use Test::More;
+use Chalk::IR::Graph;
+use Chalk::IR::Node;
+use Chalk::IR::Validator;
+
+# Test that peephole optimizer correctly processes Phi nodes using inputs array
+# This test ensures the fix for GitHub Issue #80 works correctly
+
+subtest 'Phi node with dead control path uses inputs array' => sub {
+    my $graph = Chalk::IR::Graph->new;
+
+    # Create Start node
+    my $start = Chalk::IR::Node->new(
+        id => 'start',
+        op => 'Start',
+        inputs => [],
+        attributes => {}
+    );
+    $graph->add_node($start);
+
+    # Create constants for alternative values
+    my $const_true = Chalk::IR::Node->new(
+        id => 'const_42',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 42 }
+    );
+    $graph->add_node($const_true);
+
+    my $const_false = Chalk::IR::Node->new(
+        id => 'const_0',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 0 }
+    );
+    $graph->add_node($const_false);
+
+    # Create dead control marker
+    my $dead_ctrl = Chalk::IR::Node->new(
+        id => 'dead_ctrl',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => '~Ctrl' }
+    );
+    $graph->add_node($dead_ctrl);
+
+    # Create Region with one dead path
+    my $region = Chalk::IR::Node->new(
+        id => 'region',
+        op => 'Region',
+        inputs => ['start', 'dead_ctrl'],  # second input is dead
+        attributes => {}
+    );
+    $graph->add_node($region);
+
+    # Create Phi node using ONLY inputs array (standardized representation)
+    # This is the correct way - no 'alternatives' attribute
+    my $phi = Chalk::IR::Node->new(
+        id => 'phi',
+        op => 'Phi',
+        inputs => ['region', 'const_42', 'const_0'],  # control, then alternatives
+        attributes => { region_id => 'region' }
+    );
+    $graph->add_node($phi);
+
+    # Run peephole optimization on the Phi node
+    my $optimized_phi = $phi->peephole($graph);
+
+    # The optimizer should detect the dead path and simplify the Phi
+    # If it only checks 'alternatives' attribute, it will NOT optimize (current bug)
+    # After fix, it should read from inputs array and reduce to const_42
+    ok(defined($optimized_phi), 'Peephole optimizer should process Phi node');
+
+    # Before the fix, this will fail because peephole only checks alternatives attribute
+    # After the fix, the Phi should be replaced with the single live alternative (const_42)
+    if ($optimized_phi->op eq 'Constant') {
+        is($optimized_phi->attributes->{value}, 42,
+           'Phi with one dead path should be optimized to live alternative (42)');
+    } else {
+        # If not optimized to constant, the test reveals the bug
+        fail('Phi should have been optimized to constant when only one path is live');
+        diag('This indicates peephole optimizer is not reading from inputs array');
+    }
+};
+
+subtest 'Validator rejects Phi with mismatched inputs and region' => sub {
+    my $graph = Chalk::IR::Graph->new;
+
+    # Create Start node
+    my $start = Chalk::IR::Node->new(
+        id => 'start',
+        op => 'Start',
+        inputs => [],
+        attributes => {}
+    );
+    $graph->add_node($start);
+
+    # Create a second control node
+    my $start2 = Chalk::IR::Node->new(
+        id => 'start2',
+        op => 'Start',
+        inputs => [],
+        attributes => {}
+    );
+    $graph->add_node($start2);
+
+    # Create constant
+    my $const = Chalk::IR::Node->new(
+        id => 'const_42',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 42 }
+    );
+    $graph->add_node($const);
+
+    # Create Region with 2 inputs
+    my $region = Chalk::IR::Node->new(
+        id => 'region',
+        op => 'Region',
+        inputs => ['start', 'start2'],
+        attributes => {}
+    );
+    $graph->add_node($region);
+
+    # Create Phi with wrong number of alternatives (only 1, should be 2)
+    my $phi = Chalk::IR::Node->new(
+        id => 'phi',
+        op => 'Phi',
+        inputs => ['region', 'const_42'],  # Only 1 alternative, but Region has 2 predecessors
+        attributes => { region_id => 'region' }
+    );
+    $graph->add_node($phi);
+
+    # Validator should detect mismatch by checking inputs array
+    my $validator = Chalk::IR::Validator->new;
+    my @errors = $validator->validate_phi_placement($graph);
+    ok(scalar(@errors) > 0, 'Validator should detect Phi/Region mismatch using inputs array')
+        or diag("Expected validation error but got none");
+
+    like($errors[0] // '', qr/expects 2 value inputs.*but has 1/i,
+         'Error message should indicate wrong number of alternatives');
+};
+
+done_testing;

--- a/t/ir/validator.t
+++ b/t/ir/validator.t
@@ -369,18 +369,39 @@ subtest 'validate_phi_placement detects wrong number of inputs' => sub {
     );
     $graph->add_node($region);
 
+    # Create constant nodes to reference
+    my $const1 = Chalk::IR::Node->new(
+        id => 'const_1',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 10, type => 'Int' }
+    );
+    $graph->add_node($const1);
+
+    my $const2 = Chalk::IR::Node->new(
+        id => 'const_2',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 20, type => 'Int' }
+    );
+    $graph->add_node($const2);
+
+    my $const3 = Chalk::IR::Node->new(
+        id => 'const_3',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 30, type => 'Int' }
+    );
+    $graph->add_node($const3);
+
     # Phi with wrong number of alternatives (3 instead of 2)
     my $phi = Chalk::IR::Node->new(
         id => 'node_2',
         op => 'Phi',
-        inputs => ['node_1'],
+        inputs => ['node_1', 'const_1', 'const_2', 'const_3'],  # 3 alternatives but Region has only 2 inputs!
         attributes => {
+            region_id => 'node_1',
             variable => '$x',
-            alternatives => [
-                { op => 'Constant', value => 10, type => 'Int' },
-                { op => 'Constant', value => 20, type => 'Int' },
-                { op => 'Constant', value => 30, type => 'Int' }  # Extra!
-            ]
         }
     );
     $graph->add_node($phi);

--- a/t/sea-of-nodes/chapter05.t
+++ b/t/sea-of-nodes/chapter05.t
@@ -287,13 +287,9 @@ subtest 'Phi node merges values from control paths' => sub {
     my $phi = Chalk::IR::Node->new(
         id => 'node_3',
         op => 'Phi',
-        inputs => ['node_0'],  # Control input from Region
+        inputs => ['node_0', 'node_1', 'node_2'],  # Region control, then alternatives
         attributes => {
             region_id => 'node_0',
-            alternatives => [
-                { op => 'NodeRef', node_id => 'node_1' },  # true branch value
-                { op => 'NodeRef', node_id => 'node_2' }   # false branch value
-            ]
         }
     );
     $graph->add_node($phi);
@@ -302,9 +298,9 @@ subtest 'Phi node merges values from control paths' => sub {
     my $phi_node = $graph->get_node('node_3');
     ok($phi_node, 'Phi node exists');
     is($phi_node->op, 'Phi', 'Node op is Phi');
-    cmp_deeply($phi_node->inputs, ['node_0'], 'Phi has Region as control input');
+    cmp_deeply($phi_node->inputs, ['node_0', 'node_1', 'node_2'], 'Phi has Region as control input plus two alternatives');
     is($phi_node->attributes->{region_id}, 'node_0', 'Phi references Region');
-    is(scalar($phi_node->attributes->{alternatives}->@*), 2, 'Phi has two alternatives');
+    is(scalar($phi_node->inputs->@*) - 1, 2, 'Phi has two alternatives (from inputs array)');
 };
 
 # Test complete if-then-else with phi node
@@ -412,13 +408,9 @@ subtest 'Complete if-then-else: classify($x) with phi merge' => sub {
     my $phi = Chalk::IR::Node->new(
         id => 'node_10',
         op => 'Phi',
-        inputs => ['node_9'],
+        inputs => ['node_9', 'node_8', 'node_3'],  # Region control, then alternatives
         attributes => {
             region_id => 'node_9',
-            alternatives => [
-                { op => 'NodeRef', node_id => 'node_8' },  # return 1 (true)
-                { op => 'NodeRef', node_id => 'node_3' }   # return 0 (false)
-            ]
         }
     );
     $graph->add_node($phi);
@@ -446,7 +438,7 @@ subtest 'Complete if-then-else: classify($x) with phi merge' => sub {
     my $phi_check = $graph->get_node('node_10');
     is($phi_check->op, 'Phi', 'Phi merges values');
     is($phi_check->attributes->{region_id}, 'node_9', 'Phi at Region');
-    is(scalar($phi_check->attributes->{alternatives}->@*), 2, 'Phi has two alternatives');
+    is(scalar($phi_check->inputs->@*) - 1, 2, 'Phi has two alternatives (from inputs array)');
 
     my $ret_check = $graph->get_node('node_11');
     cmp_deeply($ret_check->inputs, ['node_9', 'node_10'], 'Return uses Region control and Phi value');
@@ -536,10 +528,6 @@ subtest 'Validator confirms Chapter 5 IR correctness' => sub {
         inputs => ['node_9', 'node_8', 'node_3'],  # region, value from true branch, value from false branch
         attributes => {
             region_id => 'node_9',
-            alternatives => [
-                { op => 'NodeRef', node_id => 'node_8' },
-                { op => 'NodeRef', node_id => 'node_3' }
-            ]
         }
     ));
 
@@ -592,10 +580,9 @@ subtest 'JSON serialization with If/Region/Phi' => sub {
     $graph->add_node(Chalk::IR::Node->new(
         id => 'node_3',
         op => 'Phi',
-        inputs => ['node_2'],
+        inputs => ['node_2'],  # Region control with no alternatives (empty region)
         attributes => {
             region_id => 'node_2',
-            alternatives => []
         }
     ));
 

--- a/t/sea-of-nodes/chapter06.t
+++ b/t/sea-of-nodes/chapter06.t
@@ -243,13 +243,9 @@ subtest 'Phi node simplification: single live input' => sub {
     my $phi = Chalk::IR::Node->new(
         id => 'node_5',
         op => 'Phi',
-        inputs => ['node_2', 'node_3', 'node_4'],
+        inputs => ['node_2', 'node_3', 'node_4'],  # Region control, then alternatives
         attributes => {
             region_id => 'node_2',
-            alternatives => [
-                { op => 'NodeRef', node_id => 'node_3' },  # value from live path
-                { op => 'NodeRef', node_id => 'node_4' }   # value from dead path
-            ]
         }
     );
     $graph->add_node($phi);
@@ -386,13 +382,9 @@ subtest 'Complete dead code elimination: if (1) with dead else branch' => sub {
     $graph->add_node(Chalk::IR::Node->new(
         id => 'node_9',
         op => 'Phi',
-        inputs => ['node_8', 'node_6', 'node_7'],
+        inputs => ['node_8', 'node_6', 'node_7'],  # Region control, then alternatives
         attributes => {
             region_id => 'node_8',
-            alternatives => [
-                { op => 'NodeRef', node_id => 'node_6' },  # 42 from true
-                { op => 'NodeRef', node_id => 'node_7' }   # 0 from false (dead)
-            ]
         }
     ));
 


### PR DESCRIPTION
## Summary

Standardizes Phi node representation to use only the `inputs` array, eliminating the dual representation issue identified in #80.

## Problem

The IR previously supported two different ways to represent Phi node alternatives:
1. In the `inputs` array: `inputs => [control, val1, val2, ...]`  
2. In `attributes`: `attributes => { alternatives => [...] }`

This dual representation created complexity and potential for bugs. The peephole optimizer only checked `attributes->{alternatives}` while the validator checked both, leading to potential inconsistencies.

## Solution

Standardized on the `inputs` array approach (control followed by values), which is:
- Cleaner and more consistent with how other nodes work
- Aligned with the canonical Sea of Nodes model
- What the Builder already uses

## Changes

**Core Implementation:**
- `lib/Chalk/IR/Node.pm:231-276`: Updated peephole optimizer to read alternatives from `inputs` array instead of `alternatives` attribute
- `lib/Chalk/IR/Validator.pm:447-451`: Removed fallback to `alternatives` attribute, now only validates `inputs` array

**Tests:**
- `t/ir/phi-standardization.t`: New test demonstrating correct behavior with standardized representation
- `t/sea-of-nodes/chapter05.t`: Updated 4 Phi nodes to use `inputs` array only
- `t/sea-of-nodes/chapter06.t`: Updated 2 Phi nodes to use `inputs` array only  
- `t/ir/invalid-phi.t`: Updated 7 test cases to use standardized representation
- `t/ir/validator.t`: Updated mismatch test to use `inputs` array

## Test Results

All tests pass (145 tests across 15 test files):
```
Files=15, Tests=145,  1 wallclock secs
Result: PASS
```

## Files Changed

- 7 files modified
- 324 insertions, 94 deletions
- 1 new test file added

## Related Issues

Closes #80

## Impact

**High Priority** - Addresses technical debt that would become more problematic as optimization passes are built out.