### PR TITLE
Replace Scalar::Util with builtin::blessed and remove Data::Dumper

### DIFF
--- a/lib/Chalk/Grammar/Chalk/Rule/Assignment.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Assignment.pm
@@ -3,7 +3,7 @@
 
 use 5.42.0;
 use experimental 'class';
-use Scalar::Util qw(blessed);
+use builtin qw(blessed);
 
 # IR Quality Heuristic: Pick best parse based on IR completeness
 # Prefer parses with more defined structure (more nodes in subtree)

--- a/lib/Chalk/Grammar/Chalk/Rule/Block.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Block.pm
@@ -3,7 +3,7 @@
 
 use 5.42.0;
 use experimental 'class';
-use Scalar::Util qw(blessed);
+use builtin qw(blessed);
 
 class Chalk::Grammar::Chalk::Rule::Block :isa(Chalk::GrammarRule) {
     # Helper to recursively flatten arrays and extract nodes

--- a/lib/Chalk/Grammar/Chalk/Rule/ConditionalStatement.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/ConditionalStatement.pm
@@ -3,7 +3,7 @@
 
 use 5.42.0;
 use experimental 'class';
-use Scalar::Util qw(blessed);
+use builtin qw(blessed);
 
 class Chalk::Grammar::Chalk::Rule::ConditionalStatement :isa(Chalk::GrammarRule) {
     method evaluate($context) {

--- a/lib/Chalk/Grammar/Chalk/Rule/WhileStatement.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/WhileStatement.pm
@@ -3,7 +3,7 @@
 
 use 5.42.0;
 use experimental 'class';
-use Scalar::Util qw(blessed);
+use builtin qw(blessed);
 
 class Chalk::Grammar::Chalk::Rule::WhileStatement :isa(Chalk::GrammarRule) {
     method evaluate($context) {

--- a/lib/Chalk/IR/Builder.pm
+++ b/lib/Chalk/IR/Builder.pm
@@ -82,9 +82,7 @@ class Chalk::IR::Builder {
         my $prefix = substr($ref_type, 0, 15);
         my $is_node = ($prefix eq 'Chalk::IR::Node') ? 1 : 0;
         unless ($ref_type && $is_node) {
-            use Data::Dumper;
             warn "build_return_node received non-node: $ref_type\n";
-            warn "Value: " . Dumper($value_node);
             return undef;
         }
 


### PR DESCRIPTION
## Summary

Reduces external module dependencies by leveraging Perl 5.42.0's built-in `builtin` module and eliminating unnecessary debug output.

## Changes

### Removed Scalar::Util (4 files)
Replaced `use Scalar::Util qw(blessed)` with `use builtin qw(blessed)` in:
- lib/Chalk/Grammar/Chalk/Rule/Assignment.pm
- lib/Chalk/Grammar/Chalk/Rule/Block.pm
- lib/Chalk/Grammar/Chalk/Rule/ConditionalStatement.pm
- lib/Chalk/Grammar/Chalk/Rule/WhileStatement.pm

The `builtin` module provides `blessed()` as a native function in Perl 5.42+, eliminating the need for the external Scalar::Util module while maintaining identical functionality.

### Removed Data::Dumper (1 file)
- lib/Chalk/IR/Builder.pm

Simplified error reporting in the error path to just show the reference type rather than dumping the full value. The ref type alone is sufficient for debugging and eliminates an unnecessary dependency.

## Impact

**Before:** 7 external modules in production code  
**After:** 5 external modules in production code

Production code (lib/ + app.pl) now uses only:
- FindBin, File::Basename, File::Spec (file operations in app.pl)
- Digest::MD5, Storable (GVN optimization)

All remaining dependencies are core Perl modules - zero CPAN dependencies! 🎯

## Test Results

✅ **All 145 Sea of Nodes tests pass**  
✅ **All 5 modified files parse successfully** with Chalk self-hosting parser:
- ok 21 - Chalk/Grammar/Chalk/Rule/Assignment.pm
- ok 22 - Chalk/Grammar/Chalk/Rule/Block.pm  
- ok 26 - Chalk/Grammar/Chalk/Rule/ConditionalStatement.pm
- ok 44 - Chalk/Grammar/Chalk/Rule/WhileStatement.pm
- ok 45 - Chalk/IR/Builder.pm

## Files Changed

5 files changed, 4 insertions(+), 6 deletions(-)

## Related Issues

Continues the effort to minimize external dependencies and leverage modern Perl 5.42.0 features.