### PR TITLE
Add module support to Sea of Nodes IR (Issue #98 Phase 5)

### DIFF
--- a/lib/Chalk/IR/Builder.pm
+++ b/lib/Chalk/IR/Builder.pm
@@ -786,6 +786,33 @@ class Chalk::IR::Builder {
         return $str_substr;
     }
 
+    # Module system support (Issue #98 Phase 5)
+    method build_use_statement_node($type, $module, $imports) {
+        # Create UseStatement node for capturing use statement metadata
+        # $type: 'version', 'pragma', 'module', or 'external'
+        # $module: module name (e.g., '5.42.0', 'experimental', 'Chalk::IR::Node')
+        # $imports: arrayref of imported symbols (empty for full import)
+
+        my $graph = $self->graph;
+        my $current_control = $self->current_control;
+
+        my $attributes = {
+            type => $type,
+            module => $module,
+            imports => $imports
+        };
+
+        my $node_id = $self->next_node_id();
+        my $use_stmt = Chalk::IR::Node->new(
+            id => $node_id,
+            op => 'UseStatement',
+            inputs => [$current_control],
+            attributes => $attributes
+        );
+        $graph->add_node($use_stmt);
+        return $use_stmt;
+    }
+
 }
 
 1;

--- a/lib/Chalk/IR/Validator.pm
+++ b/lib/Chalk/IR/Validator.pm
@@ -22,6 +22,7 @@ class Chalk::IR::Validator {
         push @all_errors, $self->validate_array_nodes($graph);
         push @all_errors, $self->validate_hash_nodes($graph);
         push @all_errors, $self->validate_string_nodes($graph);
+        push @all_errors, $self->validate_module_nodes($graph);
 
         my $success = scalar( @all_errors ) == 0 ? 1 : 0;
         return ($success, \@all_errors);
@@ -1145,6 +1146,57 @@ class Chalk::IR::Validator {
                     elsif (!exists($nodes->{$length_ref->{node_id}})) {
                         push @errors, "StrSubstr node $node_id references non-existent length node " . $length_ref->{node_id};
                     }
+                }
+            }
+        }
+
+        return @errors;
+    }
+
+    # Validate module/use statement nodes (Issue #98 Phase 5)
+    method validate_module_nodes($graph) {
+        my @errors;
+        my $nodes = $graph->nodes;
+
+        for my $node_id (keys($nodes->%*)) {
+            my $node = $nodes->{$node_id};
+            my $op = $node->op;
+
+            # Validate UseStatement nodes
+            if ($op eq 'UseStatement') {
+                my $attrs = $node->attributes;
+
+                # Validate 'type' attribute
+                if (!exists($attrs->{type})) {
+                    push @errors, "UseStatement node $node_id missing 'type' attribute";
+                }
+                else {
+                    my $type = $attrs->{type};
+                    my %valid_types = (
+                        version => 1,
+                        pragma => 1,
+                        module => 1,
+                        external => 1
+                    );
+                    if (!exists($valid_types{$type})) {
+                        push @errors, "UseStatement node $node_id has invalid type '$type' (must be version, pragma, module, or external)";
+                    }
+                }
+
+                # Validate 'module' attribute
+                if (!exists($attrs->{module})) {
+                    push @errors, "UseStatement node $node_id missing 'module' attribute";
+                }
+                elsif (!defined($attrs->{module}) || $attrs->{module} eq '') {
+                    push @errors, "UseStatement node $node_id has empty or undefined 'module' attribute";
+                }
+
+                # Validate 'imports' attribute
+                if (!exists($attrs->{imports})) {
+                    push @errors, "UseStatement node $node_id missing 'imports' attribute";
+                }
+                elsif (ref($attrs->{imports}) ne 'ARRAY') {
+                    push @errors, "UseStatement node $node_id 'imports' attribute must be an array reference";
                 }
             }
         }

--- a/t/sea-of-nodes/module-support.t
+++ b/t/sea-of-nodes/module-support.t
@@ -1,0 +1,191 @@
+# ABOUTME: Test for Sea of Nodes IR generation - Module support (Issue #98 Phase 5)
+# ABOUTME: Validates IR generation for use statement metadata capture
+
+use v5.42;
+use Test::More;
+use Test::Deep;
+
+# Test that we can load the IR modules
+use_ok('Chalk::IR::Node');
+use_ok('Chalk::IR::Graph');
+use_ok('Chalk::IR::Builder');
+
+# Test manual IR graph construction for use statement metadata
+# This tests the IR infrastructure for Phase 5: Module Support
+subtest 'Manual IR graph construction for use statements' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Create Start node (entry point)
+    my $start = Chalk::IR::Node->new(
+        id => 'node_0',
+        op => 'Start',
+        inputs => [],
+        attributes => { function => 'main' }
+    );
+    $graph->add_node($start);
+
+    # Create UseStatement node for: use 5.42.0;
+    my $use_version = Chalk::IR::Node->new(
+        id => 'node_1',
+        op => 'UseStatement',
+        inputs => ['node_0'],  # Control dependency
+        attributes => {
+            type => 'version',
+            module => '5.42.0',
+            imports => []
+        }
+    );
+    $graph->add_node($use_version);
+
+    # Create UseStatement node for: use experimental qw(class builtin);
+    my $use_pragma = Chalk::IR::Node->new(
+        id => 'node_2',
+        op => 'UseStatement',
+        inputs => ['node_0'],
+        attributes => {
+            type => 'pragma',
+            module => 'experimental',
+            imports => ['class', 'builtin']
+        }
+    );
+    $graph->add_node($use_pragma);
+
+    # Create UseStatement node for: use utf8;
+    my $use_encoding = Chalk::IR::Node->new(
+        id => 'node_3',
+        op => 'UseStatement',
+        inputs => ['node_0'],
+        attributes => {
+            type => 'pragma',
+            module => 'utf8',
+            imports => []
+        }
+    );
+    $graph->add_node($use_encoding);
+
+    # Create UseStatement node for: use Chalk::IR::Node;
+    my $use_module = Chalk::IR::Node->new(
+        id => 'node_4',
+        op => 'UseStatement',
+        inputs => ['node_0'],
+        attributes => {
+            type => 'module',
+            module => 'Chalk::IR::Node',
+            imports => []  # Full import (no import list specified)
+        }
+    );
+    $graph->add_node($use_module);
+
+    # Create UseStatement node for: use builtin qw(blessed reftype);
+    my $use_external = Chalk::IR::Node->new(
+        id => 'node_5',
+        op => 'UseStatement',
+        inputs => ['node_0'],
+        attributes => {
+            type => 'external',
+            module => 'builtin',
+            imports => ['blessed', 'reftype']
+        }
+    );
+    $graph->add_node($use_external);
+
+    # Create Return node
+    my $return = Chalk::IR::Node->new(
+        id => 'node_6',
+        op => 'Return',
+        inputs => ['node_0'],
+        attributes => {}
+    );
+    $graph->add_node($return);
+
+    # Verify graph structure
+    is($graph->entry, 'node_0', 'Entry node is Start');
+    is($graph->node_count, 7, 'Graph has 7 nodes');
+
+    # Verify version use statement
+    my $version_node = $graph->get_node('node_1');
+    ok($version_node, 'UseStatement node for version exists');
+    is($version_node->op, 'UseStatement', 'Version use has correct op');
+    is($version_node->attributes->{type}, 'version', 'Version use has correct type');
+    is($version_node->attributes->{module}, '5.42.0', 'Version use has correct module');
+    is(scalar(@{$version_node->attributes->{imports}}), 0, 'Version use has no imports');
+
+    # Verify pragma use statement
+    my $pragma_node = $graph->get_node('node_2');
+    ok($pragma_node, 'UseStatement node for pragma exists');
+    is($pragma_node->op, 'UseStatement', 'Pragma use has correct op');
+    is($pragma_node->attributes->{type}, 'pragma', 'Pragma use has correct type');
+    is($pragma_node->attributes->{module}, 'experimental', 'Pragma use has correct module');
+    cmp_deeply($pragma_node->attributes->{imports}, ['class', 'builtin'], 'Pragma use has correct imports');
+
+    # Verify encoding pragma
+    my $encoding_node = $graph->get_node('node_3');
+    ok($encoding_node, 'UseStatement node for encoding exists');
+    is($encoding_node->op, 'UseStatement', 'Encoding use has correct op');
+    is($encoding_node->attributes->{type}, 'pragma', 'Encoding use has correct type');
+    is($encoding_node->attributes->{module}, 'utf8', 'Encoding use has correct module');
+
+    # Verify module use statement
+    my $module_node = $graph->get_node('node_4');
+    ok($module_node, 'UseStatement node for module exists');
+    is($module_node->op, 'UseStatement', 'Module use has correct op');
+    is($module_node->attributes->{type}, 'module', 'Module use has correct type');
+    is($module_node->attributes->{module}, 'Chalk::IR::Node', 'Module use has correct module name');
+    is(scalar(@{$module_node->attributes->{imports}}), 0, 'Module use has no specific imports (full import)');
+
+    # Verify external module use statement
+    my $external_node = $graph->get_node('node_5');
+    ok($external_node, 'UseStatement node for external exists');
+    is($external_node->op, 'UseStatement', 'External use has correct op');
+    is($external_node->attributes->{type}, 'external', 'External use has correct type');
+    is($external_node->attributes->{module}, 'builtin', 'External use has correct module');
+    cmp_deeply($external_node->attributes->{imports}, ['blessed', 'reftype'], 'External use has correct imports');
+};
+
+# Test IR Builder methods for use statements
+subtest 'IR Builder methods for module support' => sub {
+    use_ok('Chalk::IR::Builder');
+
+    my $builder = Chalk::IR::Builder->new();
+    my $graph = $builder->graph;
+
+    # Build Start node
+    my $start = $builder->build_start_node('main');
+    is($start->op, 'Start', 'Builder creates Start node');
+
+    # Build version use statement
+    my $use_version = $builder->build_use_statement_node('version', '5.42.0', []);
+    ok($use_version, 'Builder creates UseStatement for version');
+    is($use_version->op, 'UseStatement', 'Version use has correct op');
+    is($use_version->attributes->{type}, 'version', 'Version use has correct type');
+    is($use_version->attributes->{module}, '5.42.0', 'Version use has correct module');
+
+    # Build pragma use statement with imports
+    my $use_pragma = $builder->build_use_statement_node('pragma', 'experimental', ['class', 'builtin']);
+    ok($use_pragma, 'Builder creates UseStatement for pragma');
+    is($use_pragma->op, 'UseStatement', 'Pragma use has correct op');
+    is($use_pragma->attributes->{type}, 'pragma', 'Pragma use has correct type');
+    cmp_deeply($use_pragma->attributes->{imports}, ['class', 'builtin'], 'Pragma use has correct imports');
+
+    # Build module use statement
+    my $use_module = $builder->build_use_statement_node('module', 'Chalk::IR::Node', []);
+    ok($use_module, 'Builder creates UseStatement for module');
+    is($use_module->op, 'UseStatement', 'Module use has correct op');
+    is($use_module->attributes->{type}, 'module', 'Module use has correct type');
+    is($use_module->attributes->{module}, 'Chalk::IR::Node', 'Module use has correct module name');
+
+    # Build external module use statement
+    my $use_external = $builder->build_use_statement_node('external', 'builtin', ['blessed', 'reftype']);
+    ok($use_external, 'Builder creates UseStatement for external');
+    is($use_external->op, 'UseStatement', 'External use has correct op');
+    is($use_external->attributes->{type}, 'external', 'External use has correct type');
+    cmp_deeply($use_external->attributes->{imports}, ['blessed', 'reftype'], 'External use has correct imports');
+
+    # Verify all nodes are in the graph
+    ok($graph->get_node($use_version->id), 'Version UseStatement in graph');
+    ok($graph->get_node($use_pragma->id), 'Pragma UseStatement in graph');
+    ok($graph->get_node($use_module->id), 'Module UseStatement in graph');
+    ok($graph->get_node($use_external->id), 'External UseStatement in graph');
+};
+
+done_testing();


### PR DESCRIPTION
## Summary

Implements UseStatement IR nodes for capturing module metadata in the Sea of Nodes intermediate representation. This provides the foundation for tracking module dependencies and imports within the IR graph.

## Changes

**New Files:**
- `t/sea-of-nodes/module-support.t` - Comprehensive tests for UseStatement nodes (191 lines, 48 tests)

**Modified Files:**
- `lib/Chalk/IR/Builder.pm` - Added `build_use_statement_node()` method (lib/Chalk/IR/Builder.pm:790-814)
- `lib/Chalk/IR/Validator.pm` - Added `validate_module_nodes()` method (lib/Chalk/IR/Validator.pm:1156-1205)

**Statistics:**
- Files changed: 3
- Lines added: 270

## UseStatement Node Structure

Supports four types of use statements:
- **version**: `use 5.42.0;`
- **pragma**: `use experimental qw(class builtin);`
- **module**: `use Chalk::IR::Node;`
- **external**: `use builtin qw(blessed reftype);`

Each UseStatement node includes:
- `type`: One of the four categories above
- `module`: Module name or version string
- `imports`: Array of imported symbols (empty for full imports)

## Test Results

✅ **All tests passing:**
- Module-support.t: 48/48 tests passed
- Self-hosting: 100% (59/59 files parse successfully)
- Total: 65 tests passed

## Technical Notes

- Used postfix dereference syntax `keys($nodes->%*)` for Chalk grammar compatibility
- Maintains 100% self-hosting requirement
- Follows established patterns from Phases 1-4 (Class, Array, Hash, String)

## Related Issues

- Closes part of #98 (Sea of Nodes IR - Phase 5: Module Support)
- Builds on #99, #100, #101, #102 (Phases 1-4)