### PR TITLE
Implement string concatenation operator and string literals (Issue #110)

### DIFF
--- a/lib/Chalk/Grammar/Chalk/Rule/Concatenation.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Concatenation.pm
@@ -1,16 +1,44 @@
-# ABOUTME: Semantic action for Concatenation - pass through child value or build concatenation operation
-# ABOUTME: Concatenation is a wrapper, return child when no . operator present
+# ABOUTME: Semantic action for Concatenation - pass through child value or build string concatenation
+# ABOUTME: Concatenation handles '.' operator, building StrConcat IR nodes
 
 use 5.42.0;
 use experimental 'class';
+use builtin qw(blessed);
 
 class Chalk::Grammar::Chalk::Rule::Concatenation :isa(Chalk::GrammarRule) {
     method evaluate($context) {
         # Concatenation -> Additive (pass-through)
-        # Concatenation -> Concatenation WS_OPT '.' WS_OPT Additive (TODO: implement)
+        # Concatenation -> Concatenation WS_OPT '.' WS_OPT Additive
 
-        # For now, just pass through the Additive child
-        return $context->child(0);
+        # Count children to determine which alternative matched
+        my @children = $context->children->@*;
+
+        if (@children == 1) {
+            # First alternative: just pass through Additive
+            return $context->child(0);
+        }
+
+        # For binary operation: check child(2) for the operator
+        # Grammar is: Concatenation WS_OPT '.' WS_OPT Additive
+        # So operator is at index 2
+        my $op_child = $children[2]->extract;
+        return $context->child(0) unless defined $op_child && !ref($op_child);
+
+        my $operator = $op_child;
+        return $context->child(0) unless $operator eq '.';
+
+        my $builder = $context->env->{ir_builder};
+        return $context->child(0) unless $builder;
+
+        # Get left (child 0) and right (child 4)
+        my $left = $context->child(0);
+        my $right = $context->child(4);
+
+        # Validate that we got IR nodes
+        return $left unless (blessed($left) && $left->can('id'));
+        return $left unless (blessed($right) && $right->can('id'));
+
+        return $builder->build_str_concat_node($left, $right);
     }
 }
 

--- a/lib/Chalk/Grammar/Chalk/Rule/String.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/String.pm
@@ -1,0 +1,29 @@
+# ABOUTME: Semantic action for String - builds Constant IR node for string literals
+# ABOUTME: Converts string literals to Constant nodes with type 'String'
+
+use 5.42.0;
+use experimental 'class';
+
+class Chalk::Grammar::Chalk::Rule::String :isa(Chalk::GrammarRule) {
+    method evaluate($context) {
+        # String -> %STRING%  (double-quoted string literal)
+        # String -> %SQSTRING%  (single-quoted string literal)
+        # Child [0] contains the matched string literal with quotes
+
+        my $builder = $context->env->{ir_builder};
+        return undef unless $builder;
+
+        my $string_with_quotes = $context->child(0);
+
+        # Strip surrounding quotes (both " and ')
+        my $value = $string_with_quotes;
+        if ($value =~ /^["'](.*)["']$/s) {
+            $value = $1;
+        }
+
+        # Build and return Constant IR node with type 'String'
+        return $builder->build_constant_node($value, 'String');
+    }
+}
+
+1;

--- a/lib/Chalk/Grammar/Chalk/Rule/String.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/String.pm
@@ -17,8 +17,8 @@ class Chalk::Grammar::Chalk::Rule::String :isa(Chalk::GrammarRule) {
 
         # Strip surrounding quotes (both " and ')
         my $value = $string_with_quotes;
-        if ($value =~ /^["'](.*)["']$/s) {
-            $value = $1;
+        if (length($value) >= 2) {
+            $value = substr($value, 1, length($value) - 2);
         }
 
         # Build and return Constant IR node with type 'String'

--- a/t/sea-of-nodes/string-concatenation.t
+++ b/t/sea-of-nodes/string-concatenation.t
@@ -1,0 +1,126 @@
+#!/usr/bin/env perl
+# ABOUTME: Test IR generation for string concatenation operator (.) - Issue #110
+# ABOUTME: Verifies semantic action creates StrConcat nodes when parsing string concatenation
+use 5.42.0;
+use experimental qw(class builtin keyword_any keyword_all);
+use utf8;
+use lib 'lib';
+use lib 'tools';
+use Test::More;
+
+# Test that IR Builder generates StrConcat nodes for string concatenation
+{
+    use Chalk::Parser;
+    use Chalk::Grammar;
+    use Chalk::IR::Builder;
+    use Chalk::Semiring::Semantic;
+
+    # Load Chalk grammar with semantic actions
+    open my $fh, '<:utf8', 'grammar/chalk.bnf' or die "Cannot open chalk.bnf: $!";
+    my $content = do { local $/; <$fh> };
+    close $fh;
+    my $grammar = Chalk::Grammar->build_from_bnf($content, 'Program', 'Chalk');
+
+    # Create IR Builder
+    my $builder = Chalk::IR::Builder->new();
+
+    # Create Semantic semiring with Builder in environment
+    my $semiring = Chalk::Semiring::Semantic->new(
+        grammar => $grammar,
+        env => { ir_builder => $builder }
+    );
+
+    # Create parser
+    my $parser = Chalk::Parser->new(
+        grammar => $grammar,
+        semiring => $semiring,
+        preprocess => ['Chalk::Preprocessor::Heredoc']
+    );
+
+    # Test basic string concatenation: "foo" . "bar"
+    my $program = q{
+        use 5.42.0;
+        my $greeting = "Hello" . " " . "World";
+    };
+
+    # Parse the program
+    my $result = $parser->parse_string($program);
+    ok($result, 'String concatenation program parses successfully');
+
+    # Get the IR graph
+    my $graph = $builder->graph;
+    ok($graph, 'Builder has a graph');
+
+    # Check for StrConcat nodes
+    my $nodes = $graph->nodes;
+    my @str_concat_nodes = grep { $_->op eq 'StrConcat' } values %$nodes;
+
+    ok(scalar(@str_concat_nodes) > 0, 'Graph contains at least one StrConcat node');
+    cmp_ok(scalar(@str_concat_nodes), '>=', 2, 'Graph contains at least 2 StrConcat nodes for chained concatenation');
+
+    # Verify a StrConcat node has correct structure
+    my $concat_node = $str_concat_nodes[0];
+    ok($concat_node->inputs, 'StrConcat node has inputs');
+    is(scalar(@{$concat_node->inputs}), 3, 'StrConcat node has 3 inputs (control, left, right)');
+
+    # Verify attributes structure
+    ok($concat_node->attributes, 'StrConcat node has attributes');
+    ok($concat_node->attributes->{left}, 'StrConcat has left attribute');
+    ok($concat_node->attributes->{right}, 'StrConcat has right attribute');
+    is($concat_node->attributes->{left}{op}, 'NodeRef', 'Left attribute is a NodeRef');
+    is($concat_node->attributes->{right}{op}, 'NodeRef', 'Right attribute is a NodeRef');
+}
+
+# Test chained concatenation
+{
+    use Chalk::Parser;
+    use Chalk::Grammar;
+    use Chalk::IR::Builder;
+    use Chalk::Semiring::Semantic;
+
+    # Load Chalk grammar
+    open my $fh, '<:utf8', 'grammar/chalk.bnf' or die "Cannot open chalk.bnf: $!";
+    my $content = do { local $/; <$fh> };
+    close $fh;
+    my $grammar = Chalk::Grammar->build_from_bnf($content, 'Program', 'Chalk');
+
+    # Create IR Builder
+    my $builder = Chalk::IR::Builder->new();
+
+    # Create Semantic semiring
+    my $semiring = Chalk::Semiring::Semantic->new(
+        grammar => $grammar,
+        env => { ir_builder => $builder }
+    );
+
+    # Create parser
+    my $parser = Chalk::Parser->new(
+        grammar => $grammar,
+        semiring => $semiring,
+        preprocess => ['Chalk::Preprocessor::Heredoc']
+    );
+
+    # Test chained concatenation
+    my $program = q{
+        use 5.42.0;
+        my $a = "foo";
+        my $b = "bar";
+        my $c = "baz";
+        my $result = $a . $b . $c;
+    };
+
+    # Parse the program
+    my $result = $parser->parse_string($program);
+    ok($result, 'Chained concatenation program parses successfully');
+
+    # Get the IR graph
+    my $graph = $builder->graph;
+
+    # Check for StrConcat nodes
+    my $nodes = $graph->nodes;
+    my @str_concat_nodes = grep { $_->op eq 'StrConcat' } values %$nodes;
+
+    cmp_ok(scalar(@str_concat_nodes), '>=', 2, 'Chained concatenation creates at least 2 StrConcat nodes');
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

Implements IR generation for Perl's string concatenation operator (`.`) by adding semantic actions and string literal support to the Chalk compiler's Sea of Nodes IR system.

## Changes

### New Files
- **lib/Chalk/Grammar/Chalk/Rule/String.pm** - Semantic action that converts string literals to Constant IR nodes
- **t/sea-of-nodes/string-concatenation.t** - Comprehensive tests for string concatenation IR generation (13 tests)

### Modified Files
- **lib/Chalk/Grammar/Chalk/Rule/Concatenation.pm** - Updated to handle the `.` operator and build StrConcat IR nodes

## Implementation Details

The implementation follows TDD methodology:

1. **String Literal Support**: Created `String.pm` semantic action to transform `%STRING%` and `%SQSTRING%` tokens into Constant IR nodes with type 'String', following the pattern from `Number.pm`

2. **Concatenation Operator**: Updated `Concatenation.pm` to detect the `.` operator in binary expressions and call `build_str_concat_node()` to create StrConcat IR nodes with proper left/right operands

3. **Left-Associative Chaining**: Properly handles chained concatenation like `$a . $b . $c`, creating nested StrConcat nodes

## Test Coverage

All 13 tests passing:
- Basic string concatenation with literals
- Chained concatenation (multiple `.` operators)
- StrConcat node structure validation
- Proper attribute setup (left/right NodeRefs)

## Test Results

Full test suite: **All tests successful** (22 files, 486 tests)

## Related Issues

Closes #110

---

**Files changed:** 3 files (+157 lines)
- 1 file modified
- 2 files added