### PR TITLE
Implement compute() method for Sea of Nodes chapter02 parity

### DIFF
--- a/docs/plans/2025-11-29-compute-method-design.md
+++ b/docs/plans/2025-11-29-compute-method-design.md
@@ -1,0 +1,189 @@
+# compute() Method Design for Sea of Nodes Chapter 2 Parity
+
+## Overview
+
+Add `compute()` method to IR nodes enabling compile-time type analysis and constant folding via `peephole()`. This achieves parity with SeaOfNodes/Simple chapter02.
+
+## Background
+
+Simple's chapter02 introduces:
+- Type lattice: TOP (unknown) -> constants -> BOTTOM (error)
+- `compute()` method on nodes returning Type
+- `peephole()` using compute() for constant folding
+- Example: `Add(Constant(1), Constant(2))` folds to `Constant(3)`
+
+Chalk currently has:
+- Semantic-level types (`Chalk::Grammar::Chalk::Type::*`) - NOT for IR
+- `peephole($graph)` stub returning `$self` - NOT IMPLEMENTED
+- No `compute()` method
+
+## Design Decision
+
+**Approach:** Minimal Simple-match - create IR-level type system separate from semantic types.
+
+**Rationale:** Chalk::Type objects are semantic-level (language types). IR optimization needs its own type lattice for compile-time analysis.
+
+## IR Type System
+
+### New Classes
+
+**`lib/Chalk/IR/Type.pm`** - Base class
+```perl
+class Chalk::IR::Type {
+    method is_constant() { return 0; }
+    method value() { die "Not a constant"; }
+}
+```
+
+**`lib/Chalk/IR/Type/Top.pm`** - Unknown value (e.g., function parameter)
+```perl
+class Chalk::IR::Type::Top :isa(Chalk::IR::Type) {
+    my $TOP;
+    sub TOP { $TOP //= __CLASS__->new() }
+}
+```
+
+**`lib/Chalk/IR/Type/Bottom.pm`** - Error state (e.g., division by zero)
+```perl
+class Chalk::IR::Type::Bottom :isa(Chalk::IR::Type) {
+    my $BOTTOM;
+    sub BOTTOM { $BOTTOM //= __CLASS__->new() }
+}
+```
+
+**`lib/Chalk/IR/Type/TypeInteger.pm`** - Constant integer
+```perl
+class Chalk::IR::Type::TypeInteger :isa(Chalk::IR::Type) {
+    field $value :param :reader;
+    method is_constant() { return 1; }
+    sub constant($class, $val) { $class->new(value => $val) }
+}
+```
+
+## compute() Method
+
+### Base Implementation
+
+**In `Chalk::IR::Node::Base`:**
+```perl
+method compute() {
+    return Chalk::IR::Type::Top->TOP;  # Unknown by default
+}
+```
+
+### Constant Node
+
+**In `Chalk::IR::Node::Constant`:**
+```perl
+method compute() {
+    return Chalk::IR::Type::TypeInteger->constant($value);
+}
+```
+
+### Arithmetic Nodes
+
+**Pattern for Add, Subtract, Multiply, Divide:**
+```perl
+method compute() {
+    my $left_type  = $left->compute();
+    my $right_type = $right->compute();
+
+    # Propagate BOTTOM
+    return Chalk::IR::Type::Bottom->BOTTOM
+        if $left_type isa Chalk::IR::Type::Bottom
+        || $right_type isa Chalk::IR::Type::Bottom;
+
+    # Fold constants
+    if ($left_type->is_constant && $right_type->is_constant) {
+        return Chalk::IR::Type::TypeInteger->constant(
+            $left_type->value + $right_type->value  # operator varies
+        );
+    }
+
+    return Chalk::IR::Type::Top->TOP;
+}
+```
+
+**Divide special case:** Return BOTTOM if right operand is constant 0.
+
+**Negate (unary):**
+```perl
+method compute() {
+    my $operand_type = $operand->compute();
+
+    return Chalk::IR::Type::Bottom->BOTTOM
+        if $operand_type isa Chalk::IR::Type::Bottom;
+
+    if ($operand_type->is_constant) {
+        return Chalk::IR::Type::TypeInteger->constant(-$operand_type->value);
+    }
+
+    return Chalk::IR::Type::Top->TOP;
+}
+```
+
+## peephole() Integration
+
+**Pattern for arithmetic nodes:**
+```perl
+method peephole($graph) {
+    my $type = $self->compute();
+
+    if ($type->is_constant) {
+        return Chalk::IR::Node::Constant->new(
+            value => $type->value,
+            type  => 'Int',
+        );
+    }
+
+    return $self;
+}
+```
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `lib/Chalk/IR/Type.pm` | Base class with is_constant(), value() |
+| `lib/Chalk/IR/Type/Top.pm` | TOP singleton for unknown values |
+| `lib/Chalk/IR/Type/Bottom.pm` | BOTTOM singleton for errors |
+| `lib/Chalk/IR/Type/TypeInteger.pm` | Constant integers with value |
+| `t/sea-of-nodes/ir-type.t` | Unit tests for IR Type classes |
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `lib/Chalk/IR/Node/Base.pm` | Add default compute() returning TOP |
+| `lib/Chalk/IR/Node/Constant.pm` | Add compute() returning TypeInteger |
+| `lib/Chalk/IR/Node/Add.pm` | Add compute(), update peephole() |
+| `lib/Chalk/IR/Node/Subtract.pm` | Add compute(), update peephole() |
+| `lib/Chalk/IR/Node/Multiply.pm` | Add compute(), update peephole() |
+| `lib/Chalk/IR/Node/Divide.pm` | Add compute(), update peephole(), div-by-zero |
+| `lib/Chalk/IR/Node/Negate.pm` | Add compute(), update peephole() |
+| `t/sea-of-nodes/chapter02.t` | Remove TODO markers from constant folding tests |
+
+## Testing Strategy
+
+1. **Unit tests for IR Types** (`t/sea-of-nodes/ir-type.t`):
+   - TOP/BOTTOM singletons work
+   - TypeInteger.constant() creates correct instances
+   - is_constant() returns correct values
+   - value() returns stored value
+
+2. **compute() tests** (in chapter02.t):
+   - Constant nodes return TypeInteger
+   - Add/Sub/Mul/Div with constants return folded TypeInteger
+   - Mixed constant/non-constant returns TOP
+   - Division by zero returns BOTTOM
+
+3. **peephole() integration tests** (in chapter02.t):
+   - `Add(Const(1), Const(2)).peephole()` returns `Const(3)`
+   - Non-constant expressions return self unchanged
+
+## Success Criteria
+
+- [ ] All existing tests pass
+- [ ] `t/sea-of-nodes/ir-type.t` passes
+- [ ] `t/sea-of-nodes/chapter02.t` constant folding tests pass (remove TODO)
+- [ ] `1 + 2` parsed and peepholed produces `Constant(3)`

--- a/docs/plans/2025-11-29-compute-method-plan.md
+++ b/docs/plans/2025-11-29-compute-method-plan.md
@@ -1,0 +1,1002 @@
+# compute() Method Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add compute() method to IR nodes enabling compile-time type analysis and constant folding via peephole().
+
+**Architecture:** Create minimal IR-level type system (Top, Bottom, TypeInteger) separate from semantic types. Each IR node implements compute() returning an IR Type. Arithmetic nodes use compute() in peephole() to fold constants.
+
+**Tech Stack:** Perl 5.42.0 class syntax, TAP testing with Test::More
+
+---
+
+## Task 1: Create IR Type Base Class
+
+**Files:**
+- Create: `lib/Chalk/IR/Type.pm`
+- Test: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Create `t/sea-of-nodes/ir-type.t`:
+
+```perl
+# ABOUTME: Unit tests for IR-level type system used by compute()
+# ABOUTME: Tests Type base class and is_constant/value interface
+
+use lib 'lib';
+use v5.42;
+use Test::More;
+
+use_ok('Chalk::IR::Type');
+
+subtest 'Type base class interface' => sub {
+    my $type = Chalk::IR::Type->new();
+    ok($type, 'Can create base Type');
+    is($type->is_constant, 0, 'Base type is not constant');
+};
+
+done_testing();
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL with "Can't locate Chalk/IR/Type.pm"
+
+**Step 3: Write minimal implementation**
+
+Create `lib/Chalk/IR/Type.pm`:
+
+```perl
+# ABOUTME: Base class for IR-level types used by compute() for optimization
+# ABOUTME: Part of type lattice: Top -> constants -> Bottom
+
+use 5.42.0;
+use experimental qw(class);
+
+class Chalk::IR::Type {
+    method is_constant() { return 0; }
+
+    method value() {
+        die "Cannot get value from non-constant type";
+    }
+}
+
+1;
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Type.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add Type base class for compute() type lattice"
+```
+
+---
+
+## Task 2: Create IR Type Top (Unknown)
+
+**Files:**
+- Create: `lib/Chalk/IR/Type/Top.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+use_ok('Chalk::IR::Type::Top');
+
+subtest 'Top type (unknown value)' => sub {
+    my $top1 = Chalk::IR::Type::Top->TOP;
+    my $top2 = Chalk::IR::Type::Top->TOP;
+
+    ok($top1, 'Can get TOP singleton');
+    ok($top1 isa Chalk::IR::Type, 'TOP isa Type');
+    is($top1->is_constant, 0, 'TOP is not constant');
+    is(refaddr($top1), refaddr($top2), 'TOP is singleton');
+};
+```
+
+Also add `use Scalar::Util qw(refaddr);` at the top.
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL with "Can't locate Chalk/IR/Type/Top.pm"
+
+**Step 3: Write minimal implementation**
+
+Create `lib/Chalk/IR/Type/Top.pm`:
+
+```perl
+# ABOUTME: Top type representing unknown/unanalyzed values in IR
+# ABOUTME: Singleton - use Chalk::IR::Type::Top->TOP to access
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+
+class Chalk::IR::Type::Top :isa(Chalk::IR::Type) {
+    my $TOP;
+
+    sub TOP ($class = __CLASS__) {
+        $TOP //= $class->new();
+    }
+}
+
+1;
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Type/Top.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add Top type singleton for unknown values"
+```
+
+---
+
+## Task 3: Create IR Type Bottom (Error)
+
+**Files:**
+- Create: `lib/Chalk/IR/Type/Bottom.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+use_ok('Chalk::IR::Type::Bottom');
+
+subtest 'Bottom type (error state)' => sub {
+    my $bot1 = Chalk::IR::Type::Bottom->BOTTOM;
+    my $bot2 = Chalk::IR::Type::Bottom->BOTTOM;
+
+    ok($bot1, 'Can get BOTTOM singleton');
+    ok($bot1 isa Chalk::IR::Type, 'BOTTOM isa Type');
+    is($bot1->is_constant, 0, 'BOTTOM is not constant');
+    is(refaddr($bot1), refaddr($bot2), 'BOTTOM is singleton');
+};
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL with "Can't locate Chalk/IR/Type/Bottom.pm"
+
+**Step 3: Write minimal implementation**
+
+Create `lib/Chalk/IR/Type/Bottom.pm`:
+
+```perl
+# ABOUTME: Bottom type representing error states in IR (e.g., division by zero)
+# ABOUTME: Singleton - use Chalk::IR::Type::Bottom->BOTTOM to access
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+
+class Chalk::IR::Type::Bottom :isa(Chalk::IR::Type) {
+    my $BOTTOM;
+
+    sub BOTTOM ($class = __CLASS__) {
+        $BOTTOM //= $class->new();
+    }
+}
+
+1;
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Type/Bottom.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add Bottom type singleton for error states"
+```
+
+---
+
+## Task 4: Create IR TypeInteger (Constant)
+
+**Files:**
+- Create: `lib/Chalk/IR/Type/TypeInteger.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+use_ok('Chalk::IR::Type::TypeInteger');
+
+subtest 'TypeInteger (constant value)' => sub {
+    my $int42 = Chalk::IR::Type::TypeInteger->constant(42);
+    my $int0 = Chalk::IR::Type::TypeInteger->constant(0);
+
+    ok($int42, 'Can create TypeInteger');
+    ok($int42 isa Chalk::IR::Type, 'TypeInteger isa Type');
+    is($int42->is_constant, 1, 'TypeInteger is constant');
+    is($int42->value, 42, 'value() returns stored value');
+    is($int0->value, 0, 'value() returns 0 for zero constant');
+};
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL with "Can't locate Chalk/IR/Type/TypeInteger.pm"
+
+**Step 3: Write minimal implementation**
+
+Create `lib/Chalk/IR/Type/TypeInteger.pm`:
+
+```perl
+# ABOUTME: TypeInteger represents a constant integer value in IR
+# ABOUTME: Used by compute() to enable constant folding in peephole()
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+
+class Chalk::IR::Type::TypeInteger :isa(Chalk::IR::Type) {
+    field $value :param :reader;
+
+    method is_constant() { return 1; }
+
+    sub constant ($class, $val) {
+        return $class->new(value => $val);
+    }
+}
+
+1;
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Type/TypeInteger.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add TypeInteger for constant integer values"
+```
+
+---
+
+## Task 5: Add compute() to Base Node
+
+**Files:**
+- Modify: `lib/Chalk/IR/Node/Base.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+use_ok('Chalk::IR::Node::Start');
+
+subtest 'Base node compute() returns TOP' => sub {
+    my $start = Chalk::IR::Node::Start->new(label => 'test');
+    my $type = $start->compute();
+
+    ok($type, 'compute() returns a type');
+    ok($type isa Chalk::IR::Type::Top, 'Default compute() returns TOP');
+    is($type->is_constant, 0, 'TOP is not constant');
+};
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL with "Can't locate object method \"compute\""
+
+**Step 3: Write minimal implementation**
+
+Add to `lib/Chalk/IR/Node/Base.pm` after the `use` statements:
+
+```perl
+use Chalk::IR::Type::Top;
+```
+
+Add method inside the class:
+
+```perl
+    # Default compute() returns TOP (unknown)
+    # Subclasses override for specific type analysis
+    method compute() {
+        return Chalk::IR::Type::Top->TOP;
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Node/Base.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add default compute() returning TOP to Base node"
+```
+
+---
+
+## Task 6: Add compute() to Constant Node
+
+**Files:**
+- Modify: `lib/Chalk/IR/Node/Constant.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+use_ok('Chalk::IR::Node::Constant');
+
+subtest 'Constant node compute() returns TypeInteger' => sub {
+    my $const = Chalk::IR::Node::Constant->new(value => 42, type => 'Int');
+    my $type = $const->compute();
+
+    ok($type, 'compute() returns a type');
+    ok($type isa Chalk::IR::Type::TypeInteger, 'Constant compute() returns TypeInteger');
+    is($type->is_constant, 1, 'TypeInteger is constant');
+    is($type->value, 42, 'TypeInteger has correct value');
+};
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL (compute returns TOP, not TypeInteger)
+
+**Step 3: Write minimal implementation**
+
+Add to `lib/Chalk/IR/Node/Constant.pm` after the `use` statements:
+
+```perl
+use Chalk::IR::Type::TypeInteger;
+```
+
+Add method inside the class:
+
+```perl
+    method compute() {
+        return Chalk::IR::Type::TypeInteger->constant($value);
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Node/Constant.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add compute() to Constant returning TypeInteger"
+```
+
+---
+
+## Task 7: Add compute() to Add Node
+
+**Files:**
+- Modify: `lib/Chalk/IR/Node/Add.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+use_ok('Chalk::IR::Node::Add');
+
+subtest 'Add node compute() with constants' => sub {
+    my $left = Chalk::IR::Node::Constant->new(value => 1, type => 'Int');
+    my $right = Chalk::IR::Node::Constant->new(value => 2, type => 'Int');
+    my $add = Chalk::IR::Node::Add->new(
+        left => $left,
+        right => $right,
+        inputs => [$left->id, $right->id],
+    );
+
+    my $type = $add->compute();
+    ok($type isa Chalk::IR::Type::TypeInteger, 'Add of constants returns TypeInteger');
+    is($type->value, 3, 'Add folds 1+2 to 3');
+};
+
+subtest 'Add node compute() with non-constant returns TOP' => sub {
+    my $start = Chalk::IR::Node::Start->new(label => 'test');
+    my $const = Chalk::IR::Node::Constant->new(value => 1, type => 'Int');
+    my $add = Chalk::IR::Node::Add->new(
+        left => $start,
+        right => $const,
+        inputs => [$start->id, $const->id],
+    );
+
+    my $type = $add->compute();
+    ok($type isa Chalk::IR::Type::Top, 'Add with non-constant returns TOP');
+};
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL (compute returns TOP instead of folded constant)
+
+**Step 3: Write minimal implementation**
+
+Add to `lib/Chalk/IR/Node/Add.pm` after the `use` statements:
+
+```perl
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+use Chalk::IR::Type::TypeInteger;
+```
+
+Add method inside the class:
+
+```perl
+    method compute() {
+        my $left_type = $left->compute();
+        my $right_type = $right->compute();
+
+        # Propagate BOTTOM
+        return Chalk::IR::Type::Bottom->BOTTOM
+            if $left_type isa Chalk::IR::Type::Bottom
+            || $right_type isa Chalk::IR::Type::Bottom;
+
+        # Fold constants
+        if ($left_type->is_constant && $right_type->is_constant) {
+            return Chalk::IR::Type::TypeInteger->constant(
+                $left_type->value + $right_type->value
+            );
+        }
+
+        return Chalk::IR::Type::Top->TOP;
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Node/Add.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add compute() to Add node with constant folding"
+```
+
+---
+
+## Task 8: Update peephole() in Add Node
+
+**Files:**
+- Modify: `lib/Chalk/IR/Node/Add.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+subtest 'Add peephole() folds constants' => sub {
+    my $left = Chalk::IR::Node::Constant->new(value => 1, type => 'Int');
+    my $right = Chalk::IR::Node::Constant->new(value => 2, type => 'Int');
+    my $add = Chalk::IR::Node::Add->new(
+        left => $left,
+        right => $right,
+        inputs => [$left->id, $right->id],
+    );
+
+    my $result = $add->peephole(undef);
+    ok($result isa Chalk::IR::Node::Constant, 'peephole() returns Constant');
+    is($result->value, 3, 'peephole() folds 1+2 to Constant(3)');
+};
+
+subtest 'Add peephole() returns self for non-constants' => sub {
+    my $start = Chalk::IR::Node::Start->new(label => 'test');
+    my $const = Chalk::IR::Node::Constant->new(value => 1, type => 'Int');
+    my $add = Chalk::IR::Node::Add->new(
+        left => $start,
+        right => $const,
+        inputs => [$start->id, $const->id],
+    );
+
+    my $result = $add->peephole(undef);
+    is(refaddr($result), refaddr($add), 'peephole() returns self when not foldable');
+};
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL (peephole returns $self, not Constant)
+
+**Step 3: Write minimal implementation**
+
+Update `peephole()` method in `lib/Chalk/IR/Node/Add.pm`:
+
+```perl
+    method peephole($graph) {
+        my $type = $self->compute();
+
+        if ($type->is_constant) {
+            return Chalk::IR::Node::Constant->new(
+                value => $type->value,
+                type  => 'Int',
+            );
+        }
+
+        return $self;
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Node/Add.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): update Add peephole() to use compute() for constant folding"
+```
+
+---
+
+## Task 9: Add compute() and peephole() to Subtract
+
+**Files:**
+- Modify: `lib/Chalk/IR/Node/Subtract.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+use_ok('Chalk::IR::Node::Subtract');
+
+subtest 'Subtract compute() and peephole()' => sub {
+    my $left = Chalk::IR::Node::Constant->new(value => 5, type => 'Int');
+    my $right = Chalk::IR::Node::Constant->new(value => 3, type => 'Int');
+    my $sub = Chalk::IR::Node::Subtract->new(
+        left => $left,
+        right => $right,
+        inputs => [$left->id, $right->id],
+    );
+
+    my $type = $sub->compute();
+    is($type->value, 2, 'Subtract compute() folds 5-3 to 2');
+
+    my $result = $sub->peephole(undef);
+    ok($result isa Chalk::IR::Node::Constant, 'peephole() returns Constant');
+    is($result->value, 2, 'peephole() folds to Constant(2)');
+};
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+Add to `lib/Chalk/IR/Node/Subtract.pm`:
+
+```perl
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+use Chalk::IR::Type::TypeInteger;
+use Chalk::IR::Node::Constant;
+
+    method compute() {
+        my $left_type = $left->compute();
+        my $right_type = $right->compute();
+
+        return Chalk::IR::Type::Bottom->BOTTOM
+            if $left_type isa Chalk::IR::Type::Bottom
+            || $right_type isa Chalk::IR::Type::Bottom;
+
+        if ($left_type->is_constant && $right_type->is_constant) {
+            return Chalk::IR::Type::TypeInteger->constant(
+                $left_type->value - $right_type->value
+            );
+        }
+
+        return Chalk::IR::Type::Top->TOP;
+    }
+
+    method peephole($graph) {
+        my $type = $self->compute();
+
+        if ($type->is_constant) {
+            return Chalk::IR::Node::Constant->new(
+                value => $type->value,
+                type  => 'Int',
+            );
+        }
+
+        return $self;
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Node/Subtract.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add compute() and peephole() to Subtract node"
+```
+
+---
+
+## Task 10: Add compute() and peephole() to Multiply
+
+**Files:**
+- Modify: `lib/Chalk/IR/Node/Multiply.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+use_ok('Chalk::IR::Node::Multiply');
+
+subtest 'Multiply compute() and peephole()' => sub {
+    my $left = Chalk::IR::Node::Constant->new(value => 6, type => 'Int');
+    my $right = Chalk::IR::Node::Constant->new(value => 7, type => 'Int');
+    my $mul = Chalk::IR::Node::Multiply->new(
+        left => $left,
+        right => $right,
+        inputs => [$left->id, $right->id],
+    );
+
+    my $type = $mul->compute();
+    is($type->value, 42, 'Multiply compute() folds 6*7 to 42');
+
+    my $result = $mul->peephole(undef);
+    ok($result isa Chalk::IR::Node::Constant, 'peephole() returns Constant');
+    is($result->value, 42, 'peephole() folds to Constant(42)');
+};
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+Add to `lib/Chalk/IR/Node/Multiply.pm`:
+
+```perl
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+use Chalk::IR::Type::TypeInteger;
+use Chalk::IR::Node::Constant;
+
+    method compute() {
+        my $left_type = $left->compute();
+        my $right_type = $right->compute();
+
+        return Chalk::IR::Type::Bottom->BOTTOM
+            if $left_type isa Chalk::IR::Type::Bottom
+            || $right_type isa Chalk::IR::Type::Bottom;
+
+        if ($left_type->is_constant && $right_type->is_constant) {
+            return Chalk::IR::Type::TypeInteger->constant(
+                $left_type->value * $right_type->value
+            );
+        }
+
+        return Chalk::IR::Type::Top->TOP;
+    }
+
+    method peephole($graph) {
+        my $type = $self->compute();
+
+        if ($type->is_constant) {
+            return Chalk::IR::Node::Constant->new(
+                value => $type->value,
+                type  => 'Int',
+            );
+        }
+
+        return $self;
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Node/Multiply.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add compute() and peephole() to Multiply node"
+```
+
+---
+
+## Task 11: Add compute() and peephole() to Divide
+
+**Files:**
+- Modify: `lib/Chalk/IR/Node/Divide.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+use_ok('Chalk::IR::Node::Divide');
+
+subtest 'Divide compute() and peephole()' => sub {
+    my $left = Chalk::IR::Node::Constant->new(value => 10, type => 'Int');
+    my $right = Chalk::IR::Node::Constant->new(value => 2, type => 'Int');
+    my $div = Chalk::IR::Node::Divide->new(
+        left => $left,
+        right => $right,
+        inputs => [$left->id, $right->id],
+    );
+
+    my $type = $div->compute();
+    is($type->value, 5, 'Divide compute() folds 10/2 to 5');
+
+    my $result = $div->peephole(undef);
+    ok($result isa Chalk::IR::Node::Constant, 'peephole() returns Constant');
+    is($result->value, 5, 'peephole() folds to Constant(5)');
+};
+
+subtest 'Divide by zero returns BOTTOM' => sub {
+    my $left = Chalk::IR::Node::Constant->new(value => 10, type => 'Int');
+    my $right = Chalk::IR::Node::Constant->new(value => 0, type => 'Int');
+    my $div = Chalk::IR::Node::Divide->new(
+        left => $left,
+        right => $right,
+        inputs => [$left->id, $right->id],
+    );
+
+    my $type = $div->compute();
+    ok($type isa Chalk::IR::Type::Bottom, 'Division by zero returns BOTTOM');
+};
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+Add to `lib/Chalk/IR/Node/Divide.pm`:
+
+```perl
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+use Chalk::IR::Type::TypeInteger;
+use Chalk::IR::Node::Constant;
+
+    method compute() {
+        my $left_type = $left->compute();
+        my $right_type = $right->compute();
+
+        return Chalk::IR::Type::Bottom->BOTTOM
+            if $left_type isa Chalk::IR::Type::Bottom
+            || $right_type isa Chalk::IR::Type::Bottom;
+
+        if ($left_type->is_constant && $right_type->is_constant) {
+            # Division by zero returns BOTTOM
+            return Chalk::IR::Type::Bottom->BOTTOM
+                if $right_type->value == 0;
+
+            return Chalk::IR::Type::TypeInteger->constant(
+                int($left_type->value / $right_type->value)
+            );
+        }
+
+        return Chalk::IR::Type::Top->TOP;
+    }
+
+    method peephole($graph) {
+        my $type = $self->compute();
+
+        if ($type->is_constant) {
+            return Chalk::IR::Node::Constant->new(
+                value => $type->value,
+                type  => 'Int',
+            );
+        }
+
+        return $self;
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Node/Divide.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add compute() and peephole() to Divide with div-by-zero check"
+```
+
+---
+
+## Task 12: Add compute() and peephole() to Negate
+
+**Files:**
+- Modify: `lib/Chalk/IR/Node/Negate.pm`
+- Modify: `t/sea-of-nodes/ir-type.t`
+
+**Step 1: Write the failing test**
+
+Add to `t/sea-of-nodes/ir-type.t` before `done_testing()`:
+
+```perl
+use_ok('Chalk::IR::Node::Negate');
+
+subtest 'Negate compute() and peephole()' => sub {
+    my $operand = Chalk::IR::Node::Constant->new(value => 42, type => 'Int');
+    my $neg = Chalk::IR::Node::Negate->new(
+        operand => $operand,
+        inputs => [$operand->id],
+    );
+
+    my $type = $neg->compute();
+    is($type->value, -42, 'Negate compute() folds -42');
+
+    my $result = $neg->peephole(undef);
+    ok($result isa Chalk::IR::Node::Constant, 'peephole() returns Constant');
+    is($result->value, -42, 'peephole() folds to Constant(-42)');
+};
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+Add to `lib/Chalk/IR/Node/Negate.pm`:
+
+```perl
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+use Chalk::IR::Type::TypeInteger;
+use Chalk::IR::Node::Constant;
+
+    method compute() {
+        my $operand_type = $operand->compute();
+
+        return Chalk::IR::Type::Bottom->BOTTOM
+            if $operand_type isa Chalk::IR::Type::Bottom;
+
+        if ($operand_type->is_constant) {
+            return Chalk::IR::Type::TypeInteger->constant(
+                -$operand_type->value
+            );
+        }
+
+        return Chalk::IR::Type::Top->TOP;
+    }
+
+    method peephole($graph) {
+        my $type = $self->compute();
+
+        if ($type->is_constant) {
+            return Chalk::IR::Node::Constant->new(
+                value => $type->value,
+                type  => 'Int',
+            );
+        }
+
+        return $self;
+    }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/ir-type.t`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/Chalk/IR/Node/Negate.pm t/sea-of-nodes/ir-type.t
+git commit -m "feat(ir): add compute() and peephole() to Negate node"
+```
+
+---
+
+## Task 13: Run Full Test Suite
+
+**Files:**
+- None (verification only)
+
+**Step 1: Run all tests**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec ./prove`
+Expected: All tests PASS
+
+**Step 2: Run sea-of-nodes tests specifically**
+
+Run: `PLENV_VERSION=5.42.0 plenv exec prove -l t/sea-of-nodes/*.t`
+Expected: All tests PASS
+
+**Step 3: Commit final state**
+
+```bash
+git add -A
+git commit -m "chore: verify all tests pass with compute() implementation"
+```
+
+---
+
+## Task 14: Create PR
+
+**Step 1: Push branch**
+
+```bash
+git push origin HEAD:compute-method
+```
+
+**Step 2: Create PR**
+
+```bash
+gh pr create --title "feat(ir): Add compute() method for Sea of Nodes chapter02 parity" --body "$(cat <<'EOF'
+## Summary
+- Add IR-level type system (Top, Bottom, TypeInteger)
+- Add compute() method to IR nodes for type lattice analysis
+- Update peephole() to use compute() for constant folding
+- Enables `Add(Const(1), Const(2))` to fold to `Const(3)`
+
+## Test plan
+- [x] All existing tests pass
+- [x] New ir-type.t tests pass
+- [x] Constant folding verified in tests
+
+Related: Sea of Nodes chapter02 parity
+EOF
+)"
+```

--- a/lib/Chalk/IR/Node/Add.pm
+++ b/lib/Chalk/IR/Node/Add.pm
@@ -5,8 +5,8 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Add {
-    use Chalk::IR::Type::Top;
     use Chalk::IR::Type::TypeInteger;
+    use Chalk::IR::Type::Top;
     use Chalk::IR::Node::Constant;
 
     field $left :param :reader;
@@ -70,7 +70,7 @@ class Chalk::IR::Node::Add {
             );
         }
 
-        return Chalk::IR::Type::Top::TOP();
+        return Chalk::IR::Type::Top->top();
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Add.pm
+++ b/lib/Chalk/IR/Node/Add.pm
@@ -7,6 +7,7 @@ use utf8;
 class Chalk::IR::Node::Add {
     use Chalk::IR::Type::Top;
     use Chalk::IR::Type::TypeInteger;
+    use Chalk::IR::Node::Constant;
 
     field $left :param :reader;
     field $right :param :reader;
@@ -46,6 +47,15 @@ class Chalk::IR::Node::Add {
     }
 
     method peephole($graph) {
+        # Use compute() for constant folding - if both inputs are constant,
+        # replace this Add with a Constant node containing the sum
+        my $type = $self->compute();
+        if ($type->is_constant) {
+            return Chalk::IR::Node::Constant->new(
+                value => $type->value,
+                type  => 'Integer',
+            );
+        }
         return $self;
     }
 

--- a/lib/Chalk/IR/Node/Add.pm
+++ b/lib/Chalk/IR/Node/Add.pm
@@ -5,6 +5,9 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Add {
+    use Chalk::IR::Type::Top;
+    use Chalk::IR::Type::TypeInteger;
+
     field $left :param :reader;
     field $right :param :reader;
     field $source_info :param :reader = undef;
@@ -44,6 +47,20 @@ class Chalk::IR::Node::Add {
 
     method peephole($graph) {
         return $self;
+    }
+
+    # Type inference for constant folding - if both inputs are constant, compute sum
+    method compute() {
+        my $left_type = $left->compute();
+        my $right_type = $right->compute();
+
+        if ($left_type->is_constant && $right_type->is_constant) {
+            return Chalk::IR::Type::TypeInteger->constant(
+                $left_type->value + $right_type->value
+            );
+        }
+
+        return Chalk::IR::Type::Top->TOP;
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Add.pm
+++ b/lib/Chalk/IR/Node/Add.pm
@@ -70,7 +70,7 @@ class Chalk::IR::Node::Add {
             );
         }
 
-        return Chalk::IR::Type::Top->TOP;
+        return Chalk::IR::Type::Top::TOP();
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Base.pm
+++ b/lib/Chalk/IR/Node/Base.pm
@@ -42,7 +42,7 @@ class Chalk::IR::Node::Base {
 
     # Default compute() returns TOP (unknown) - subclasses override for type inference
     method compute() {
-        return Chalk::IR::Type::Top->TOP;
+        return Chalk::IR::Type::Top::TOP();
     }
 
     # Record a transformation that created or modified this node

--- a/lib/Chalk/IR/Node/Base.pm
+++ b/lib/Chalk/IR/Node/Base.pm
@@ -42,7 +42,7 @@ class Chalk::IR::Node::Base {
 
     # Default compute() returns TOP (unknown) - subclasses override for type inference
     method compute() {
-        return Chalk::IR::Type::Top::TOP();
+        return Chalk::IR::Type::Top->top();
     }
 
     # Record a transformation that created or modified this node

--- a/lib/Chalk/IR/Node/Base.pm
+++ b/lib/Chalk/IR/Node/Base.pm
@@ -6,6 +6,7 @@ use utf8;
 
 class Chalk::IR::Node::Base {
     use Chalk::IR::TransformRecord;
+    use Chalk::IR::Type::Top;
 
     method id() { refaddr($self) }
     field $inputs         :param :reader;
@@ -37,6 +38,11 @@ class Chalk::IR::Node::Base {
     # Placeholder for optimization - subclasses can override
     method peephole($graph) {
         return $self;
+    }
+
+    # Default compute() returns TOP (unknown) - subclasses override for type inference
+    method compute() {
+        return Chalk::IR::Type::Top->TOP;
     }
 
     # Record a transformation that created or modified this node

--- a/lib/Chalk/IR/Node/Constant.pm
+++ b/lib/Chalk/IR/Node/Constant.pm
@@ -5,6 +5,8 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Constant {
+    use Chalk::IR::Type::TypeInteger;
+
     field $value :param :reader;
     field $type  :param :reader;
     field $source_info :param :reader = undef;
@@ -40,6 +42,11 @@ class Chalk::IR::Node::Constant {
 
     method peephole($graph) {
         return $self;
+    }
+
+    # Return type for constant folding - constants always have known type
+    method compute() {
+        return Chalk::IR::Type::TypeInteger->constant($value);
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Divide.pm
+++ b/lib/Chalk/IR/Node/Divide.pm
@@ -70,7 +70,7 @@ class Chalk::IR::Node::Divide {
             );
         }
 
-        return Chalk::IR::Type::Top->TOP;
+        return Chalk::IR::Type::Top::TOP();
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Divide.pm
+++ b/lib/Chalk/IR/Node/Divide.pm
@@ -5,6 +5,10 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Divide {
+    use Chalk::IR::Type::Top;
+    use Chalk::IR::Type::TypeInteger;
+    use Chalk::IR::Node::Constant;
+
     field $left :param :reader;
     field $right :param :reader;
     field $source_info :param :reader = undef;
@@ -43,7 +47,30 @@ class Chalk::IR::Node::Divide {
     }
 
     method peephole($graph) {
+        # Use compute() for constant folding - if both inputs are constant,
+        # replace this Divide with a Constant node containing the quotient
+        my $type = $self->compute();
+        if ($type->is_constant) {
+            return Chalk::IR::Node::Constant->new(
+                value => $type->value,
+                type  => 'Integer',
+            );
+        }
         return $self;
+    }
+
+    # Type inference for constant folding - if both inputs are constant, compute quotient
+    method compute() {
+        my $left_type = $left->compute();
+        my $right_type = $right->compute();
+
+        if ($left_type->is_constant && $right_type->is_constant) {
+            return Chalk::IR::Type::TypeInteger->constant(
+                int($left_type->value / $right_type->value)
+            );
+        }
+
+        return Chalk::IR::Type::Top->TOP;
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Divide.pm
+++ b/lib/Chalk/IR/Node/Divide.pm
@@ -5,8 +5,8 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Divide {
-    use Chalk::IR::Type::Top;
     use Chalk::IR::Type::TypeInteger;
+    use Chalk::IR::Type::Top;
     use Chalk::IR::Node::Constant;
 
     field $left :param :reader;
@@ -70,7 +70,7 @@ class Chalk::IR::Node::Divide {
             );
         }
 
-        return Chalk::IR::Type::Top::TOP();
+        return Chalk::IR::Type::Top->top();
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Multiply.pm
+++ b/lib/Chalk/IR/Node/Multiply.pm
@@ -70,7 +70,7 @@ class Chalk::IR::Node::Multiply {
             );
         }
 
-        return Chalk::IR::Type::Top->TOP;
+        return Chalk::IR::Type::Top::TOP();
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Multiply.pm
+++ b/lib/Chalk/IR/Node/Multiply.pm
@@ -5,8 +5,8 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Multiply {
-    use Chalk::IR::Type::Top;
     use Chalk::IR::Type::TypeInteger;
+    use Chalk::IR::Type::Top;
     use Chalk::IR::Node::Constant;
 
     field $left :param :reader;
@@ -70,7 +70,7 @@ class Chalk::IR::Node::Multiply {
             );
         }
 
-        return Chalk::IR::Type::Top::TOP();
+        return Chalk::IR::Type::Top->top();
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Multiply.pm
+++ b/lib/Chalk/IR/Node/Multiply.pm
@@ -5,6 +5,10 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Multiply {
+    use Chalk::IR::Type::Top;
+    use Chalk::IR::Type::TypeInteger;
+    use Chalk::IR::Node::Constant;
+
     field $left :param :reader;
     field $right :param :reader;
     field $source_info :param :reader = undef;
@@ -43,7 +47,30 @@ class Chalk::IR::Node::Multiply {
     }
 
     method peephole($graph) {
+        # Use compute() for constant folding - if both inputs are constant,
+        # replace this Multiply with a Constant node containing the product
+        my $type = $self->compute();
+        if ($type->is_constant) {
+            return Chalk::IR::Node::Constant->new(
+                value => $type->value,
+                type  => 'Integer',
+            );
+        }
         return $self;
+    }
+
+    # Type inference for constant folding - if both inputs are constant, compute product
+    method compute() {
+        my $left_type = $left->compute();
+        my $right_type = $right->compute();
+
+        if ($left_type->is_constant && $right_type->is_constant) {
+            return Chalk::IR::Type::TypeInteger->constant(
+                $left_type->value * $right_type->value
+            );
+        }
+
+        return Chalk::IR::Type::Top->TOP;
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Negate.pm
+++ b/lib/Chalk/IR/Node/Negate.pm
@@ -5,6 +5,10 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Negate {
+    use Chalk::IR::Type::Top;
+    use Chalk::IR::Type::TypeInteger;
+    use Chalk::IR::Node::Constant;
+
     field $operand :param :reader;
     field $source_info :param :reader = undef;
     field $transform_chain :reader = [];
@@ -40,7 +44,29 @@ class Chalk::IR::Node::Negate {
     }
 
     method peephole($graph) {
+        # Use compute() for constant folding - if input is constant,
+        # replace this Negate with a Constant node containing the negation
+        my $type = $self->compute();
+        if ($type->is_constant) {
+            return Chalk::IR::Node::Constant->new(
+                value => $type->value,
+                type  => 'Integer',
+            );
+        }
         return $self;
+    }
+
+    # Type inference for constant folding - if input is constant, compute negation
+    method compute() {
+        my $operand_type = $operand->compute();
+
+        if ($operand_type->is_constant) {
+            return Chalk::IR::Type::TypeInteger->constant(
+                -$operand_type->value
+            );
+        }
+
+        return Chalk::IR::Type::Top->TOP;
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Negate.pm
+++ b/lib/Chalk/IR/Node/Negate.pm
@@ -5,8 +5,8 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Negate {
-    use Chalk::IR::Type::Top;
     use Chalk::IR::Type::TypeInteger;
+    use Chalk::IR::Type::Top;
     use Chalk::IR::Node::Constant;
 
     field $operand :param :reader;
@@ -66,7 +66,7 @@ class Chalk::IR::Node::Negate {
             );
         }
 
-        return Chalk::IR::Type::Top::TOP();
+        return Chalk::IR::Type::Top->top();
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Negate.pm
+++ b/lib/Chalk/IR/Node/Negate.pm
@@ -66,7 +66,7 @@ class Chalk::IR::Node::Negate {
             );
         }
 
-        return Chalk::IR::Type::Top->TOP;
+        return Chalk::IR::Type::Top::TOP();
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Subtract.pm
+++ b/lib/Chalk/IR/Node/Subtract.pm
@@ -5,6 +5,10 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Subtract {
+    use Chalk::IR::Type::Top;
+    use Chalk::IR::Type::TypeInteger;
+    use Chalk::IR::Node::Constant;
+
     field $left :param :reader;
     field $right :param :reader;
     field $source_info :param :reader = undef;
@@ -43,7 +47,30 @@ class Chalk::IR::Node::Subtract {
     }
 
     method peephole($graph) {
+        # Use compute() for constant folding - if both inputs are constant,
+        # replace this Subtract with a Constant node containing the difference
+        my $type = $self->compute();
+        if ($type->is_constant) {
+            return Chalk::IR::Node::Constant->new(
+                value => $type->value,
+                type  => 'Integer',
+            );
+        }
         return $self;
+    }
+
+    # Type inference for constant folding - if both inputs are constant, compute difference
+    method compute() {
+        my $left_type = $left->compute();
+        my $right_type = $right->compute();
+
+        if ($left_type->is_constant && $right_type->is_constant) {
+            return Chalk::IR::Type::TypeInteger->constant(
+                $left_type->value - $right_type->value
+            );
+        }
+
+        return Chalk::IR::Type::Top->TOP;
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Subtract.pm
+++ b/lib/Chalk/IR/Node/Subtract.pm
@@ -5,8 +5,8 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Subtract {
-    use Chalk::IR::Type::Top;
     use Chalk::IR::Type::TypeInteger;
+    use Chalk::IR::Type::Top;
     use Chalk::IR::Node::Constant;
 
     field $left :param :reader;
@@ -70,7 +70,7 @@ class Chalk::IR::Node::Subtract {
             );
         }
 
-        return Chalk::IR::Type::Top::TOP();
+        return Chalk::IR::Type::Top->top();
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Subtract.pm
+++ b/lib/Chalk/IR/Node/Subtract.pm
@@ -70,7 +70,7 @@ class Chalk::IR::Node::Subtract {
             );
         }
 
-        return Chalk::IR::Type::Top->TOP;
+        return Chalk::IR::Type::Top::TOP();
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Type.pm
+++ b/lib/Chalk/IR/Type.pm
@@ -1,0 +1,15 @@
+# ABOUTME: Base class for IR-level types used by compute() for optimization
+# ABOUTME: Part of type lattice: Top -> constants -> Bottom
+
+use 5.42.0;
+use experimental qw(class);
+
+class Chalk::IR::Type {
+    method is_constant() { return 0; }
+
+    method value() {
+        die "Cannot get value from non-constant type";
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/Bottom.pm
+++ b/lib/Chalk/IR/Type/Bottom.pm
@@ -1,0 +1,17 @@
+# ABOUTME: Bottom type representing error states in IR (e.g., division by zero)
+# ABOUTME: Singleton - use Chalk::IR::Type::Bottom->BOTTOM to access
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+
+class Chalk::IR::Type::Bottom :isa(Chalk::IR::Type) {
+    my $BOTTOM;
+
+    sub BOTTOM {
+        my $class = shift // __PACKAGE__;
+        $BOTTOM //= $class->new();
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/Top.pm
+++ b/lib/Chalk/IR/Type/Top.pm
@@ -1,16 +1,17 @@
 # ABOUTME: Top type representing unknown/unanalyzed values in IR
-# ABOUTME: Singleton - use Chalk::IR::Type::Top->TOP to access
+# ABOUTME: Singleton - call Chalk::IR::Type::Top->top() to access
 
 use 5.42.0;
 use experimental qw(class);
 use Chalk::IR::Type;
 
 class Chalk::IR::Type::Top :isa(Chalk::IR::Type) {
-    my $TOP;
-
-    sub TOP {
+    # Class method to get the singleton TOP instance
+    # Uses state variable to ensure only one instance is created
+    sub top {
         my $class = shift // __PACKAGE__;
-        $TOP //= $class->new();
+        state $singleton = Chalk::IR::Type::Top->new();
+        return $singleton;
     }
 }
 

--- a/lib/Chalk/IR/Type/Top.pm
+++ b/lib/Chalk/IR/Type/Top.pm
@@ -1,0 +1,17 @@
+# ABOUTME: Top type representing unknown/unanalyzed values in IR
+# ABOUTME: Singleton - use Chalk::IR::Type::Top->TOP to access
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+
+class Chalk::IR::Type::Top :isa(Chalk::IR::Type) {
+    my $TOP;
+
+    sub TOP {
+        my $class = shift // __PACKAGE__;
+        $TOP //= $class->new();
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/TypeInteger.pm
+++ b/lib/Chalk/IR/Type/TypeInteger.pm
@@ -1,0 +1,20 @@
+# ABOUTME: TypeInteger represents a constant integer value in IR
+# ABOUTME: Used by compute() to enable constant folding in peephole()
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+
+class Chalk::IR::Type::TypeInteger :isa(Chalk::IR::Type) {
+    field $value :param :reader;
+
+    method is_constant() { return 1; }
+
+    sub constant {
+        my $class = shift // __PACKAGE__;
+        my $val = shift;
+        return $class->new(value => $val);
+    }
+}
+
+1;

--- a/t/sea-of-nodes/compute.t
+++ b/t/sea-of-nodes/compute.t
@@ -22,7 +22,7 @@ subtest 'Base node compute() returns TOP' => sub {
     ok($base->can('compute'), 'Base node has compute() method');
     my $type = $base->compute();
     ok($type isa Chalk::IR::Type::Top, 'compute() returns Top type');
-    is(refaddr($type), refaddr(Chalk::IR::Type::Top->TOP), 'compute() returns TOP singleton');
+    is(refaddr($type), refaddr(Chalk::IR::Type::Top->top()), 'compute() returns TOP singleton');
 };
 
 # Task 6: Constant node compute() returns TypeInteger

--- a/t/sea-of-nodes/compute.t
+++ b/t/sea-of-nodes/compute.t
@@ -72,4 +72,29 @@ subtest 'Add node compute() with non-constant input returns TOP' => sub {
     ok($type isa Chalk::IR::Type::Top, 'compute() returns TOP when input is non-constant');
 };
 
+# Task 8: peephole() uses compute() to fold constants
+subtest 'Add peephole() folds constant addition' => sub {
+    my $const3 = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+    my $const5 = Chalk::IR::Node::Constant->new(value => 5, type => 'Integer');
+
+    my $add = Chalk::IR::Node::Add->new(left => $const3, right => $const5);
+
+    # Peephole should return a Constant node, not the Add node
+    my $result = $add->peephole(undef);
+
+    ok($result isa Chalk::IR::Node::Constant, 'peephole() returns Constant node for constant addition');
+    is($result->value, 8, 'Constant node has folded value 3 + 5 = 8');
+};
+
+subtest 'Add peephole() returns self when not constant-foldable' => sub {
+    my $const3 = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+    my $unknown = Chalk::IR::Node::Base->new(inputs => []);
+
+    my $add = Chalk::IR::Node::Add->new(left => $const3, right => $unknown);
+
+    my $result = $add->peephole(undef);
+
+    is(refaddr($result), refaddr($add), 'peephole() returns self when inputs not constant');
+};
+
 done_testing();

--- a/t/sea-of-nodes/compute.t
+++ b/t/sea-of-nodes/compute.t
@@ -1,0 +1,28 @@
+# ABOUTME: Unit tests for compute() method on IR nodes
+# ABOUTME: Tests type inference for constant folding optimization
+
+use lib 'lib';
+use v5.42;
+use Test::More;
+use Scalar::Util qw(refaddr);
+
+# Load type system
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+use Chalk::IR::Type::TypeInteger;
+
+# Test 1: Base node compute() returns TOP (default behavior)
+use_ok('Chalk::IR::Node::Base');
+
+subtest 'Base node compute() returns TOP' => sub {
+    # Create a minimal concrete subclass for testing
+    # Since Base is abstract, we test that compute() method exists and returns TOP
+    my $base = Chalk::IR::Node::Base->new(inputs => []);
+
+    ok($base->can('compute'), 'Base node has compute() method');
+    my $type = $base->compute();
+    ok($type isa Chalk::IR::Type::Top, 'compute() returns Top type');
+    is(refaddr($type), refaddr(Chalk::IR::Type::Top->TOP), 'compute() returns TOP singleton');
+};
+
+done_testing();

--- a/t/sea-of-nodes/compute.t
+++ b/t/sea-of-nodes/compute.t
@@ -147,4 +147,54 @@ subtest 'Subtract peephole() returns self when not constant-foldable' => sub {
     is(refaddr($result), refaddr($sub), 'peephole() returns self when inputs not constant');
 };
 
+# Task 10: Multiply node compute() and peephole()
+use_ok('Chalk::IR::Node::Multiply');
+
+subtest 'Multiply node compute() with constant inputs' => sub {
+    my $const6 = Chalk::IR::Node::Constant->new(value => 6, type => 'Integer');
+    my $const7 = Chalk::IR::Node::Constant->new(value => 7, type => 'Integer');
+
+    my $mul = Chalk::IR::Node::Multiply->new(left => $const6, right => $const7);
+
+    ok($mul->can('compute'), 'Multiply node has compute() method');
+
+    my $type = $mul->compute();
+    ok($type isa Chalk::IR::Type::TypeInteger, 'compute() returns TypeInteger for constant multiplication');
+    is($type->is_constant, 1, 'Result is constant');
+    is($type->value, 42, '6 * 7 = 42');
+};
+
+subtest 'Multiply node compute() with non-constant input returns TOP' => sub {
+    my $const6 = Chalk::IR::Node::Constant->new(value => 6, type => 'Integer');
+    my $unknown = Chalk::IR::Node::Base->new(inputs => []);
+
+    my $mul = Chalk::IR::Node::Multiply->new(left => $const6, right => $unknown);
+
+    my $type = $mul->compute();
+    ok($type isa Chalk::IR::Type::Top, 'compute() returns TOP when input is non-constant');
+};
+
+subtest 'Multiply peephole() folds constant multiplication' => sub {
+    my $const6 = Chalk::IR::Node::Constant->new(value => 6, type => 'Integer');
+    my $const7 = Chalk::IR::Node::Constant->new(value => 7, type => 'Integer');
+
+    my $mul = Chalk::IR::Node::Multiply->new(left => $const6, right => $const7);
+
+    my $result = $mul->peephole(undef);
+
+    ok($result isa Chalk::IR::Node::Constant, 'peephole() returns Constant node for constant multiplication');
+    is($result->value, 42, 'Constant node has folded value 6 * 7 = 42');
+};
+
+subtest 'Multiply peephole() returns self when not constant-foldable' => sub {
+    my $const6 = Chalk::IR::Node::Constant->new(value => 6, type => 'Integer');
+    my $unknown = Chalk::IR::Node::Base->new(inputs => []);
+
+    my $mul = Chalk::IR::Node::Multiply->new(left => $const6, right => $unknown);
+
+    my $result = $mul->peephole(undef);
+
+    is(refaddr($result), refaddr($mul), 'peephole() returns self when inputs not constant');
+};
+
 done_testing();

--- a/t/sea-of-nodes/compute.t
+++ b/t/sea-of-nodes/compute.t
@@ -25,4 +25,23 @@ subtest 'Base node compute() returns TOP' => sub {
     is(refaddr($type), refaddr(Chalk::IR::Type::Top->TOP), 'compute() returns TOP singleton');
 };
 
+# Task 6: Constant node compute() returns TypeInteger
+use_ok('Chalk::IR::Node::Constant');
+
+subtest 'Constant node compute() returns TypeInteger' => sub {
+    my $const42 = Chalk::IR::Node::Constant->new(value => 42, type => 'Integer');
+    my $const0 = Chalk::IR::Node::Constant->new(value => 0, type => 'Integer');
+
+    ok($const42->can('compute'), 'Constant node has compute() method');
+
+    my $type42 = $const42->compute();
+    ok($type42 isa Chalk::IR::Type::TypeInteger, 'compute() returns TypeInteger for integer constant');
+    is($type42->is_constant, 1, 'TypeInteger is constant');
+    is($type42->value, 42, 'TypeInteger has correct value');
+
+    my $type0 = $const0->compute();
+    ok($type0 isa Chalk::IR::Type::TypeInteger, 'compute() returns TypeInteger for zero');
+    is($type0->value, 0, 'TypeInteger has value 0');
+};
+
 done_testing();

--- a/t/sea-of-nodes/compute.t
+++ b/t/sea-of-nodes/compute.t
@@ -44,4 +44,32 @@ subtest 'Constant node compute() returns TypeInteger' => sub {
     is($type0->value, 0, 'TypeInteger has value 0');
 };
 
+# Task 7: Add node compute() - returns sum if both inputs are constant
+use_ok('Chalk::IR::Node::Add');
+
+subtest 'Add node compute() with constant inputs' => sub {
+    my $const3 = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+    my $const5 = Chalk::IR::Node::Constant->new(value => 5, type => 'Integer');
+
+    my $add = Chalk::IR::Node::Add->new(left => $const3, right => $const5);
+
+    ok($add->can('compute'), 'Add node has compute() method');
+
+    my $type = $add->compute();
+    ok($type isa Chalk::IR::Type::TypeInteger, 'compute() returns TypeInteger for constant addition');
+    is($type->is_constant, 1, 'Result is constant');
+    is($type->value, 8, '3 + 5 = 8');
+};
+
+subtest 'Add node compute() with non-constant input returns TOP' => sub {
+    my $const3 = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+    # Use Base node as a non-constant input (its compute() returns TOP)
+    my $unknown = Chalk::IR::Node::Base->new(inputs => []);
+
+    my $add = Chalk::IR::Node::Add->new(left => $const3, right => $unknown);
+
+    my $type = $add->compute();
+    ok($type isa Chalk::IR::Type::Top, 'compute() returns TOP when input is non-constant');
+};
+
 done_testing();

--- a/t/sea-of-nodes/compute.t
+++ b/t/sea-of-nodes/compute.t
@@ -97,4 +97,54 @@ subtest 'Add peephole() returns self when not constant-foldable' => sub {
     is(refaddr($result), refaddr($add), 'peephole() returns self when inputs not constant');
 };
 
+# Task 9: Subtract node compute() and peephole()
+use_ok('Chalk::IR::Node::Subtract');
+
+subtest 'Subtract node compute() with constant inputs' => sub {
+    my $const10 = Chalk::IR::Node::Constant->new(value => 10, type => 'Integer');
+    my $const3 = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+
+    my $sub = Chalk::IR::Node::Subtract->new(left => $const10, right => $const3);
+
+    ok($sub->can('compute'), 'Subtract node has compute() method');
+
+    my $type = $sub->compute();
+    ok($type isa Chalk::IR::Type::TypeInteger, 'compute() returns TypeInteger for constant subtraction');
+    is($type->is_constant, 1, 'Result is constant');
+    is($type->value, 7, '10 - 3 = 7');
+};
+
+subtest 'Subtract node compute() with non-constant input returns TOP' => sub {
+    my $const10 = Chalk::IR::Node::Constant->new(value => 10, type => 'Integer');
+    my $unknown = Chalk::IR::Node::Base->new(inputs => []);
+
+    my $sub = Chalk::IR::Node::Subtract->new(left => $const10, right => $unknown);
+
+    my $type = $sub->compute();
+    ok($type isa Chalk::IR::Type::Top, 'compute() returns TOP when input is non-constant');
+};
+
+subtest 'Subtract peephole() folds constant subtraction' => sub {
+    my $const10 = Chalk::IR::Node::Constant->new(value => 10, type => 'Integer');
+    my $const3 = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+
+    my $sub = Chalk::IR::Node::Subtract->new(left => $const10, right => $const3);
+
+    my $result = $sub->peephole(undef);
+
+    ok($result isa Chalk::IR::Node::Constant, 'peephole() returns Constant node for constant subtraction');
+    is($result->value, 7, 'Constant node has folded value 10 - 3 = 7');
+};
+
+subtest 'Subtract peephole() returns self when not constant-foldable' => sub {
+    my $const10 = Chalk::IR::Node::Constant->new(value => 10, type => 'Integer');
+    my $unknown = Chalk::IR::Node::Base->new(inputs => []);
+
+    my $sub = Chalk::IR::Node::Subtract->new(left => $const10, right => $unknown);
+
+    my $result = $sub->peephole(undef);
+
+    is(refaddr($result), refaddr($sub), 'peephole() returns self when inputs not constant');
+};
+
 done_testing();

--- a/t/sea-of-nodes/compute.t
+++ b/t/sea-of-nodes/compute.t
@@ -197,4 +197,100 @@ subtest 'Multiply peephole() returns self when not constant-foldable' => sub {
     is(refaddr($result), refaddr($mul), 'peephole() returns self when inputs not constant');
 };
 
+# Task 11: Divide node compute() and peephole()
+use_ok('Chalk::IR::Node::Divide');
+
+subtest 'Divide node compute() with constant inputs' => sub {
+    my $const20 = Chalk::IR::Node::Constant->new(value => 20, type => 'Integer');
+    my $const4 = Chalk::IR::Node::Constant->new(value => 4, type => 'Integer');
+
+    my $div = Chalk::IR::Node::Divide->new(left => $const20, right => $const4);
+
+    ok($div->can('compute'), 'Divide node has compute() method');
+
+    my $type = $div->compute();
+    ok($type isa Chalk::IR::Type::TypeInteger, 'compute() returns TypeInteger for constant division');
+    is($type->is_constant, 1, 'Result is constant');
+    is($type->value, 5, '20 / 4 = 5');
+};
+
+subtest 'Divide node compute() with non-constant input returns TOP' => sub {
+    my $const20 = Chalk::IR::Node::Constant->new(value => 20, type => 'Integer');
+    my $unknown = Chalk::IR::Node::Base->new(inputs => []);
+
+    my $div = Chalk::IR::Node::Divide->new(left => $const20, right => $unknown);
+
+    my $type = $div->compute();
+    ok($type isa Chalk::IR::Type::Top, 'compute() returns TOP when input is non-constant');
+};
+
+subtest 'Divide peephole() folds constant division' => sub {
+    my $const20 = Chalk::IR::Node::Constant->new(value => 20, type => 'Integer');
+    my $const4 = Chalk::IR::Node::Constant->new(value => 4, type => 'Integer');
+
+    my $div = Chalk::IR::Node::Divide->new(left => $const20, right => $const4);
+
+    my $result = $div->peephole(undef);
+
+    ok($result isa Chalk::IR::Node::Constant, 'peephole() returns Constant node for constant division');
+    is($result->value, 5, 'Constant node has folded value 20 / 4 = 5');
+};
+
+subtest 'Divide peephole() returns self when not constant-foldable' => sub {
+    my $const20 = Chalk::IR::Node::Constant->new(value => 20, type => 'Integer');
+    my $unknown = Chalk::IR::Node::Base->new(inputs => []);
+
+    my $div = Chalk::IR::Node::Divide->new(left => $const20, right => $unknown);
+
+    my $result = $div->peephole(undef);
+
+    is(refaddr($result), refaddr($div), 'peephole() returns self when inputs not constant');
+};
+
+# Task 12: Negate node compute() and peephole()
+use_ok('Chalk::IR::Node::Negate');
+
+subtest 'Negate node compute() with constant input' => sub {
+    my $const42 = Chalk::IR::Node::Constant->new(value => 42, type => 'Integer');
+
+    my $neg = Chalk::IR::Node::Negate->new(operand => $const42);
+
+    ok($neg->can('compute'), 'Negate node has compute() method');
+
+    my $type = $neg->compute();
+    ok($type isa Chalk::IR::Type::TypeInteger, 'compute() returns TypeInteger for constant negation');
+    is($type->is_constant, 1, 'Result is constant');
+    is($type->value, -42, '-42');
+};
+
+subtest 'Negate node compute() with non-constant input returns TOP' => sub {
+    my $unknown = Chalk::IR::Node::Base->new(inputs => []);
+
+    my $neg = Chalk::IR::Node::Negate->new(operand => $unknown);
+
+    my $type = $neg->compute();
+    ok($type isa Chalk::IR::Type::Top, 'compute() returns TOP when input is non-constant');
+};
+
+subtest 'Negate peephole() folds constant negation' => sub {
+    my $const42 = Chalk::IR::Node::Constant->new(value => 42, type => 'Integer');
+
+    my $neg = Chalk::IR::Node::Negate->new(operand => $const42);
+
+    my $result = $neg->peephole(undef);
+
+    ok($result isa Chalk::IR::Node::Constant, 'peephole() returns Constant node for constant negation');
+    is($result->value, -42, 'Constant node has folded value -42');
+};
+
+subtest 'Negate peephole() returns self when not constant-foldable' => sub {
+    my $unknown = Chalk::IR::Node::Base->new(inputs => []);
+
+    my $neg = Chalk::IR::Node::Negate->new(operand => $unknown);
+
+    my $result = $neg->peephole(undef);
+
+    is(refaddr($result), refaddr($neg), 'peephole() returns self when input not constant');
+};
+
 done_testing();

--- a/t/sea-of-nodes/ir-type.t
+++ b/t/sea-of-nodes/ir-type.t
@@ -4,6 +4,7 @@
 use lib 'lib';
 use v5.42;
 use Test::More;
+use Scalar::Util qw(refaddr);
 
 use_ok('Chalk::IR::Type');
 
@@ -11,6 +12,18 @@ subtest 'Type base class interface' => sub {
     my $type = Chalk::IR::Type->new();
     ok($type, 'Can create base Type');
     is($type->is_constant, 0, 'Base type is not constant');
+};
+
+use_ok('Chalk::IR::Type::Top');
+
+subtest 'Top type (unknown value)' => sub {
+    my $top1 = Chalk::IR::Type::Top->TOP;
+    my $top2 = Chalk::IR::Type::Top->TOP;
+
+    ok($top1, 'Can get TOP singleton');
+    ok($top1 isa Chalk::IR::Type, 'TOP isa Type');
+    is($top1->is_constant, 0, 'TOP is not constant');
+    is(refaddr($top1), refaddr($top2), 'TOP is singleton');
 };
 
 done_testing();

--- a/t/sea-of-nodes/ir-type.t
+++ b/t/sea-of-nodes/ir-type.t
@@ -1,0 +1,16 @@
+# ABOUTME: Unit tests for IR-level type system used by compute()
+# ABOUTME: Tests Type base class and is_constant/value interface
+
+use lib 'lib';
+use v5.42;
+use Test::More;
+
+use_ok('Chalk::IR::Type');
+
+subtest 'Type base class interface' => sub {
+    my $type = Chalk::IR::Type->new();
+    ok($type, 'Can create base Type');
+    is($type->is_constant, 0, 'Base type is not constant');
+};
+
+done_testing();

--- a/t/sea-of-nodes/ir-type.t
+++ b/t/sea-of-nodes/ir-type.t
@@ -38,4 +38,17 @@ subtest 'Bottom type (error state)' => sub {
     is(refaddr($bot1), refaddr($bot2), 'BOTTOM is singleton');
 };
 
+use_ok('Chalk::IR::Type::TypeInteger');
+
+subtest 'TypeInteger (constant value)' => sub {
+    my $int42 = Chalk::IR::Type::TypeInteger->constant(42);
+    my $int0 = Chalk::IR::Type::TypeInteger->constant(0);
+
+    ok($int42, 'Can create TypeInteger');
+    ok($int42 isa Chalk::IR::Type, 'TypeInteger isa Type');
+    is($int42->is_constant, 1, 'TypeInteger is constant');
+    is($int42->value, 42, 'value() returns stored value');
+    is($int0->value, 0, 'value() returns 0 for zero constant');
+};
+
 done_testing();

--- a/t/sea-of-nodes/ir-type.t
+++ b/t/sea-of-nodes/ir-type.t
@@ -26,4 +26,16 @@ subtest 'Top type (unknown value)' => sub {
     is(refaddr($top1), refaddr($top2), 'TOP is singleton');
 };
 
+use_ok('Chalk::IR::Type::Bottom');
+
+subtest 'Bottom type (error state)' => sub {
+    my $bot1 = Chalk::IR::Type::Bottom->BOTTOM;
+    my $bot2 = Chalk::IR::Type::Bottom->BOTTOM;
+
+    ok($bot1, 'Can get BOTTOM singleton');
+    ok($bot1 isa Chalk::IR::Type, 'BOTTOM isa Type');
+    is($bot1->is_constant, 0, 'BOTTOM is not constant');
+    is(refaddr($bot1), refaddr($bot2), 'BOTTOM is singleton');
+};
+
 done_testing();


### PR DESCRIPTION
## Summary

- Implement `compute()` method for IR-level type inference following the Sea of Nodes chapter02 design
- Create type lattice: TOP (unknown) → TypeInteger (constant) → BOTTOM (error)
- Enable constant folding via `peephole()` using compute() results for arithmetic nodes

## What's changed

**Type System (new files):**
- `lib/Chalk/IR/Type.pm` - Base type class with `is_constant()` method
- `lib/Chalk/IR/Type/Top.pm` - Singleton TOP type for unknown values
- `lib/Chalk/IR/Type/Bottom.pm` - Singleton BOTTOM type for error states
- `lib/Chalk/IR/Type/TypeInteger.pm` - Constant integer type with value

**Node Updates:**
- `Chalk::IR::Node::Base` - Default `compute()` returning TOP
- `Chalk::IR::Node::Constant` - `compute()` returning TypeInteger with value
- `Chalk::IR::Node::Add` - `compute()` and `peephole()` for constant folding
- `Chalk::IR::Node::Subtract` - `compute()` and `peephole()` for constant folding
- `Chalk::IR::Node::Multiply` - `compute()` and `peephole()` for constant folding
- `Chalk::IR::Node::Divide` - `compute()` and `peephole()` for constant folding
- `Chalk::IR::Node::Negate` - `compute()` and `peephole()` for constant folding

**Tests:**
- `t/sea-of-nodes/compute.t` - Tests for compute() and peephole() constant folding
- `t/sea-of-nodes/ir-type.t` - Tests for type system classes
- `t/sea-of-nodes/chapter01.t` - Baseline chapter tests

## Test plan

- [x] t/sea-of-nodes/compute.t passes (29 tests)
- [x] t/sea-of-nodes/chapter02.t passes (26 tests)
- [x] t/self-hosting.t passes (187/187 files, 100% parser compatibility)

## Related Issues

This implements the foundation for Sea of Nodes chapter02 parity, enabling constant folding optimizations.