### PR TITLE
Fix Issue #213: Support parentheses to override operator precedence

### DIFF
--- a/lib/Chalk/Grammar/Chalk/Rule/Expression.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Expression.pm
@@ -12,8 +12,18 @@ class Chalk::Grammar::Chalk::Rule::Expression :isa(Chalk::GrammarRule) {
         # Expression -> YaddaYadda
         # Expression -> FunctionCall
         # Expression -> Assignment (and many other operators)
+        # Expression -> '(' WS_OPT Expression WS_OPT ')' (parenthesized)
 
-        my $child = $context->child(0);
+        my $first_child = $context->child(0);
+
+        # Handle parenthesized expressions: '(' WS_OPT Expression WS_OPT ')'
+        # When first child is '(', the actual expression is at child(2)
+        # This allows (1 + 2) * 3 to work correctly
+        if (defined $first_child && $first_child eq '(') {
+            return $context->child(2);
+        }
+
+        my $child = $first_child;
 
         # Check if child is a variable metadata hashref (from ScalarVar via Variable)
         # Variables in expression context need to be converted to Load nodes

--- a/lib/Chalk/Semiring/Precedence.pm
+++ b/lib/Chalk/Semiring/Precedence.pm
@@ -406,6 +406,18 @@ class Chalk::Semiring::Precedence :isa(Chalk::Semiring) {
         # This prevents wiping out precedence validation results
         my $was_valid = $completed_element->can('valid') ? $completed_element->valid : 1;
 
+        # PARENTHESIZED EXPRESSIONS: Clear operator info when completing a rule
+        # that starts with '(' - parentheses "seal off" the inner precedence context.
+        # This makes (1 + 2) behave as a primary value with no operator, so
+        # (1 + 2) * 3 parses correctly (no precedence conflict between + and *).
+        my $rhs = $completed_item->rule->rhs;
+        if ($rhs && $rhs->@* > 0 && $rhs->[0] eq '(') {
+            return Chalk::Semiring::PrecedenceElement->new(
+                valid => $was_valid,
+                operator_index => $operator_index
+            );
+        }
+
         # Preserve operator info for Expression and operator-producing rules
         # Clear it elsewhere to prevent comparing unrelated operators
         my @expression_rules = qw(

--- a/t/precedence-arithmetic.t
+++ b/t/precedence-arithmetic.t
@@ -1,5 +1,5 @@
 # ABOUTME: Tests for arithmetic operator precedence handling
-# ABOUTME: Verifies correct evaluation order for +, *, and parentheses (Issue #199)
+# ABOUTME: Verifies correct evaluation order for +, *, and parentheses
 
 use lib 'lib';
 use v5.42;
@@ -48,7 +48,7 @@ sub extract_result {
 
 # Test cases for arithmetic precedence
 my @tests = (
-    # Basic Issue #199 tests - operator ordering
+    # Basic operator ordering tests
     { code => 'return 2 * 3 + 1;', expected => 7, desc => 'multiply first (2*3)+1' },
     { code => 'return 1 + 2 * 3;', expected => 7, desc => 'add first 1+(2*3)' },
 
@@ -73,8 +73,8 @@ my @tests = (
     { code => 'return 1 + 12 / 3;', expected => 5, desc => 'add after divide: 1+(12/3)' },
 );
 
-# TODO tests - parentheses override precedence (not yet implemented)
-my @todo_tests = (
+# Parentheses override precedence (Issue #213)
+my @paren_tests = (
     { code => 'return (1 + 2) * 3;', expected => 9, desc => 'parentheses: (1+2)*3' },
     { code => 'return 3 * (1 + 2);', expected => 9, desc => 'parentheses after: 3*(1+2)' },
     { code => 'return (2 + 3) * (4 + 1);', expected => 25, desc => 'double parens: (2+3)*(4+1)' },
@@ -99,25 +99,21 @@ for my $test (@tests) {
     };
 }
 
-# Run TODO tests for parentheses (not yet implemented)
-for my $test (@todo_tests) {
+# Run parentheses tests (Issue #213)
+for my $test (@paren_tests) {
     subtest $test->{desc} => sub {
         my $parser = make_parser();
 
         diag "Parsing: $test->{code}";
         my $result = $parser->parse_string($test->{code});
 
-        TODO: {
-            local $TODO = "Parentheses precedence override not yet implemented (Issue #213)";
+        ok($result, 'Parse succeeded');
 
-            ok($result, 'Parse succeeded');
-
-            my $actual = extract_result($result);
-            if (defined $actual) {
-                is($actual, $test->{expected}, "Correct value: $test->{expected}");
-            } else {
-                fail("Could not extract result from parse");
-            }
+        my $actual = extract_result($result);
+        if (defined $actual) {
+            is($actual, $test->{expected}, "Correct value: $test->{expected}");
+        } else {
+            fail("Could not extract result from parse");
         }
     };
 }

--- a/t/sea-of-nodes/chapter02.t
+++ b/t/sea-of-nodes/chapter02.t
@@ -111,86 +111,62 @@ subtest 'Parse: Simple addition - return 1+2 (constant folded)' => sub {
     is($constants[0]->value, 3, 'Constant value is 3 (1+2 folded)');
 };
 
-subtest 'Parse: Operator precedence - return 1 + 2 * 3' => sub {
+subtest 'Parse: Operator precedence - return 1 + 2 * 3 (constant folded)' => sub {
     my $parser = make_parser();
 
     # Chapter 2 key example: tests precedence (multiply before add)
+    # With constant folding: 1 + 2 * 3 = 1 + 6 = 7 -> Constant(7)
     my $code = 'return 1 + 2 * 3;';
     my $result = $parser->parse_string($code);
     ok($result, 'Parse succeeded');
 
     my $graph = build_graph_from_result($result);
+    ok($graph, 'Graph built from result');
 
-    TODO: {
-        local $TODO = 'Issue #199: Nested expressions not evaluated to IR nodes';
+    my @nodes = values %{$graph->nodes};
 
-        ok($graph, 'Graph built from result');
+    # With constant folding, entire expression folds to Constant(7)
+    # This proves correct precedence: 2*3=6, then 1+6=7
+    my @adds = grep { $_->op eq 'Add' } @nodes;
+    is(scalar(@adds), 0, 'Add node folded away');
 
-        SKIP: {
-            skip 'No graph to inspect', 5 unless $graph;
+    my @muls = grep { $_->op eq 'Multiply' } @nodes;
+    is(scalar(@muls), 0, 'Multiply node folded away');
 
-            my @nodes = values %{$graph->nodes};
-
-            # Should have both Add and Multiply nodes
-            my @adds = grep { $_->op eq 'Add' } @nodes;
-            is(scalar(@adds), 1, 'Has Add node');
-
-            my @muls = grep { $_->op eq 'Multiply' } @nodes;
-            is(scalar(@muls), 1, 'Has Multiply node');
-
-            # Multiply should be input to Add (precedence)
-            my $add = $adds[0];
-            my $mul = $muls[0];
-
-            ok($add && $mul, 'Both Add and Multiply nodes exist');
-
-            # Verify Multiply comes before Add in the graph
-            # The Add node should reference Multiply via its left or right operand
-            my $add_uses_mul = 0;
-            if ($add && $add->can('left') && $add->left) {
-                $add_uses_mul = 1 if blessed($add->left) && $add->left->id eq $mul->id;
-            }
-            if ($add && $add->can('right') && $add->right) {
-                $add_uses_mul = 1 if blessed($add->right) && $add->right->id eq $mul->id;
-            }
-            ok($add_uses_mul, 'Add node uses Multiply node result (correct precedence)');
-        }
-    }
+    # Should have single constant with value 7 (proves precedence: 1 + (2*3) = 7)
+    my @constants = grep { $_->op eq 'Constant' } @nodes;
+    is(scalar(@constants), 1, 'Has single Constant node (folded result)');
+    is($constants[0]->value, 7, 'Constant value is 7 (1 + 2*3 folded with correct precedence)');
 };
 
-subtest 'Parse: Complex expression - return 1 + 2 * 3 + -5' => sub {
+subtest 'Parse: Complex expression - return 1 + 2 * 3 + -5 (constant folded)' => sub {
     my $parser = make_parser();
 
     # Chapter 2 complex example from README
+    # With constant folding: 1 + 2 * 3 + -5 = 1 + 6 + -5 = 2 -> Constant(2)
     my $code = 'return 1 + 2 * 3 + -5;';
     my $result = $parser->parse_string($code);
     ok($result, 'Parse succeeded');
 
     my $graph = build_graph_from_result($result);
+    ok($graph, 'Graph built from result');
 
-    TODO: {
-        local $TODO = 'Issue #199: Nested expressions not evaluated to IR nodes';
+    my @nodes = values %{$graph->nodes};
 
-        ok($graph, 'Graph built from result');
+    # With constant folding, all arithmetic is folded away
+    my @adds = grep { $_->op eq 'Add' } @nodes;
+    is(scalar(@adds), 0, 'Add nodes folded away');
 
-        SKIP: {
-            skip 'No graph to inspect', 3 unless $graph;
+    my @muls = grep { $_->op eq 'Multiply' } @nodes;
+    is(scalar(@muls), 0, 'Multiply node folded away');
 
-            my @nodes = values %{$graph->nodes};
+    my @negs = grep { $_->op eq 'Negate' } @nodes;
+    is(scalar(@negs), 0, 'Negate node folded away');
 
-            # Should have two Add nodes (1 + (2*3), result + (-5))
-            my @adds = grep { $_->op eq 'Add' } @nodes;
-            ok(scalar(@adds) >= 1, 'Has Add nodes');
-
-            # Should have Multiply node for 2*3
-            my @muls = grep { $_->op eq 'Multiply' } @nodes;
-            is(scalar(@muls), 1, 'Has Multiply node for 2*3');
-
-            # Should have Negate node for -5
-            my @negs = grep { $_->op eq 'Negate' } @nodes;
-            is(scalar(@negs), 1, 'Has Negate node for -5');
-        }
-    }
+    # Should have single constant with value 2 (proves correct evaluation order)
+    my @constants = grep { $_->op eq 'Constant' } @nodes;
+    is(scalar(@constants), 1, 'Has single Constant node (folded result)');
+    is($constants[0]->value, 2, 'Constant value is 2 (1 + 2*3 + -5 = 1 + 6 - 5 = 2)');
 };
 
 subtest 'Parse: Subtraction - return 10 - 3 (constant folded)' => sub {
@@ -235,33 +211,27 @@ subtest 'Parse: Division - return 6 / 2 (constant folded)' => sub {
     is($constants[0]->value, 3, 'Constant value is 3 (6/2 folded)');
 };
 
-# Nested expression constant folding - blocked by Issue #199
-subtest 'Constant folding: 1 + 2 * 3 + -5 should fold to 2' => sub {
+# Additional constant folding verification
+subtest 'Constant folding: verify 1 + 2 * 3 + -5 = 2 (explicit check)' => sub {
     my $parser = make_parser();
 
     # Chapter 2 README example: 1 + 6 + -5 = 2
     my $code = 'return 1 + 2 * 3 + -5;';
     my $result = $parser->parse_string($code);
+    ok($result, 'Parse succeeded');
 
     my $graph = build_graph_from_result($result);
+    ok($graph, 'Graph built from result');
 
-    TODO: {
-        local $TODO = 'Issue #199: Nested expressions not evaluated to IR nodes';
+    my @nodes = values %{$graph->nodes};
 
-        SKIP: {
-            skip 'No graph to inspect', 2 unless $graph;
+    # With full constant folding, entire expression folds to 2
+    my @twos = grep { $_->op eq 'Constant' && $_->value == 2 } @nodes;
+    is(scalar(@twos), 1, 'Has Constant(2) from folded expression');
 
-            my @nodes = values %{$graph->nodes};
-
-            # With full constant folding, entire expression folds to 2
-            my @constants = grep { $_->op eq 'Constant' && $_->value == 2 } @nodes;
-            is(scalar(@constants), 1, 'Should fold to Constant(2)');
-
-            # No arithmetic nodes should remain
-            my @arith = grep { $_->op =~ /^(Add|Multiply|Negate)$/ } @nodes;
-            is(scalar(@arith), 0, 'All arithmetic nodes folded away');
-        }
-    }
+    # No arithmetic nodes should remain
+    my @arith = grep { $_->op =~ /^(Add|Multiply|Negate)$/ } @nodes;
+    is(scalar(@arith), 0, 'All arithmetic nodes folded away');
 };
 
 done_testing();


### PR DESCRIPTION
## Summary

Parenthesized expressions like `(1 + 2) * 3` now correctly override operator precedence, returning `9` instead of failing to parse or returning `undef`.

- Clear operator precedence context when completing parenthesized expressions
- Extract inner expression value from parenthesized grammar forms  
- Remove TODO markers from tests since feature is now implemented

Fixes #213

## Changes

**lib/Chalk/Semiring/Precedence.pm**
- Add detection for parenthesized expression rules in `on_complete()`
- Clear operator info when rule starts with `(` to "seal off" inner precedence context

**lib/Chalk/Grammar/Chalk/Rule/Expression.pm**  
- Handle parenthesized expressions by returning `child(2)` when first child is `(`

**t/precedence-arithmetic.t**
- Remove TODO wrappers from parentheses tests
- Update comments to reflect implementation status

**t/sea-of-nodes/chapter02.t**
- Remove TODO blocks for Issue #199 (now fixed)
- Update tests to expect constant folding behavior

## Test Results

- `(1 + 2) * 3` → 9 ✓
- `3 * (1 + 2)` → 9 ✓  
- `(2 + 3) * (4 + 1)` → 25 ✓

**Stats:** 4 files changed, 75 insertions(+), 87 deletions(-)

## Related Issues

- #213 - Support parentheses to override operator precedence (this PR)
- #199 - ArithmeticOp receives unevaluated EvalContext children (fixed)