### PR TITLE
feat: Expression canonicalization (#225) and Dead Code Elimination (#226)

### DIFF
--- a/lib/Chalk/IR/Graph.pm
+++ b/lib/Chalk/IR/Graph.pm
@@ -84,6 +84,57 @@ class Chalk::IR::Graph {
         return $uses->{$id} // [];
     }
 
+    # Remove a node from the graph and update use-def chains
+    method remove_node($node_id) {
+        my $node = $nodes->{$node_id};
+        return unless $node;
+
+        # Remove this node as a user of its inputs
+        if ($node->can('inputs')) {
+            for my $input_id ($node->inputs->@*) {
+                next unless defined $input_id;
+                next if $input_id eq '__CONTROL_PLACEHOLDER__';
+                if (exists $uses->{$input_id}) {
+                    @{$uses->{$input_id}} = grep { $_ ne $node_id } @{$uses->{$input_id}};
+                }
+            }
+        }
+
+        # Remove this node's entry in uses (other nodes won't reference it)
+        delete $uses->{$node_id};
+
+        # Remove from graph
+        delete $nodes->{$node_id};
+
+        return;
+    }
+
+    # Kill a node with no uses, recursively killing inputs that become unused
+    # This is the core of Dead Code Elimination (DCE)
+    method kill($node_id) {
+        my $node = $nodes->{$node_id};
+        return unless $node;
+
+        # Get inputs before removing the node
+        my @input_ids;
+        if ($node->can('inputs')) {
+            @input_ids = grep { defined $_ && $_ ne '__CONTROL_PLACEHOLDER__' } $node->inputs->@*;
+        }
+
+        # Remove this node from the graph
+        $self->remove_node($node_id);
+
+        # Recursively kill inputs that are now unused
+        for my $input_id (@input_ids) {
+            my $input_uses = $self->get_uses($input_id);
+            if (scalar($input_uses->@*) == 0) {
+                $self->kill($input_id);
+            }
+        }
+
+        return;
+    }
+
     method node_count() {
         return scalar keys %{$nodes};
     }

--- a/lib/Chalk/IR/Graph.pm
+++ b/lib/Chalk/IR/Graph.pm
@@ -95,7 +95,7 @@ class Chalk::IR::Graph {
                 next unless defined $input_id;
                 next if $input_id eq '__CONTROL_PLACEHOLDER__';
                 if (exists $uses->{$input_id}) {
-                    @{$uses->{$input_id}} = grep { $_ ne $node_id } @{$uses->{$input_id}};
+                    $uses->{$input_id}->@* = grep { $_ ne $node_id } $uses->{$input_id}->@*;
                 }
             }
         }

--- a/lib/Chalk/IR/Graph.pm
+++ b/lib/Chalk/IR/Graph.pm
@@ -111,6 +111,9 @@ class Chalk::IR::Graph {
 
     # Kill a node with no uses, recursively killing inputs that become unused
     # This is the core of Dead Code Elimination (DCE)
+    # Note: Safe against self-referential nodes - we capture input_ids before
+    # calling remove_node, so if a node references itself, the recursive kill
+    # call will find it already removed and return early.
     method kill($node_id) {
         my $node = $nodes->{$node_id};
         return unless $node;

--- a/lib/Chalk/IR/Node/Add.pm
+++ b/lib/Chalk/IR/Node/Add.pm
@@ -108,7 +108,105 @@ class Chalk::IR::Node::Add {
             );
         }
 
+        # Canonicalization: swap operands to put constants on right
+        # Goal: non-constants on left, constants on right for left-spine structure
+        # const + expr -> expr + const
+        if ($left_type->is_constant && !$right_type->is_constant) {
+            return $self->swap12();
+        }
+
+        # Canonicalization: right association to left - flatten right-nested Adds
+        # x + (y + z) -> (x + y) + z
+        # This creates a left-spine structure for easier optimization
+        if ($right->op eq 'Add') {
+            # right is (y + z), we are x + (y + z)
+            # Transform to (x + y) + z
+            my $new_left = Chalk::IR::Node::Add->new(
+                left  => $left,
+                right => $right->left,
+            );
+            return Chalk::IR::Node::Add->new(
+                left  => $new_left,
+                right => $right->right,
+            );
+        }
+
+        # Canonicalization for left-spine Add structures
+        if ($left->op eq 'Add') {
+            my $lhs_inner_left_type = $left->left->compute();
+            my $lhs_inner_right_type = $left->right->compute();
+
+            # Constant combining: (x + c1) + c2 -> x + (c1 + c2)
+            # Only when outer right is also constant
+            if ($right_type->is_constant) {
+                # Case 1: (x + c1) + c2 -> x + (c1 + c2) - inner already normalized
+                if ($lhs_inner_right_type->is_constant) {
+                    my $combined = Chalk::IR::Node::Constant->new(
+                        value => $lhs_inner_right_type->value + $right_type->value,
+                        type  => 'Integer',
+                    );
+                    return Chalk::IR::Node::Add->new(
+                        left  => $left->left,
+                        right => $combined,
+                    );
+                }
+
+                # Case 2: (c1 + x) + c2 -> x + (c1 + c2) - inner not yet normalized
+                if ($lhs_inner_left_type->is_constant) {
+                    my $combined = Chalk::IR::Node::Constant->new(
+                        value => $lhs_inner_left_type->value + $right_type->value,
+                        type  => 'Integer',
+                    );
+                    return Chalk::IR::Node::Add->new(
+                        left  => $left->right,
+                        right => $combined,
+                    );
+                }
+            }
+
+            # Spline sorting: push constants to the right to group non-constants together
+            # (x + c) + z where z is non-constant -> (x + z) + c
+            # This enables x + x -> x * 2 optimization when x and z are the same
+            if ($lhs_inner_right_type->is_constant && !$right_type->is_constant) {
+                my $new_left = Chalk::IR::Node::Add->new(
+                    left  => $left->left,
+                    right => $right,
+                );
+                # Peephole the new inner Add to trigger optimizations like x+x->x*2
+                $new_left = $new_left->peephole();
+                return Chalk::IR::Node::Add->new(
+                    left  => $new_left,
+                    right => $left->right,
+                );
+            }
+
+            # Spline sorting: (x + y) + z where both y and z are non-constants
+            # Sort by node id for deterministic ordering
+            if (!$lhs_inner_right_type->is_constant && !$right_type->is_constant) {
+                my $y = $left->right;
+                my $z = $right;
+                if ($z->id lt $y->id) {
+                    my $new_left = Chalk::IR::Node::Add->new(
+                        left  => $left->left,
+                        right => $z,
+                    );
+                    return Chalk::IR::Node::Add->new(
+                        left  => $new_left,
+                        right => $y,
+                    );
+                }
+            }
+        }
+
         return;
+    }
+
+    # Helper method to swap operands (returns new Add with swapped left/right)
+    method swap12() {
+        return Chalk::IR::Node::Add->new(
+            left  => $right,
+            right => $left,
+        );
     }
 
     # Stub for transform tracking

--- a/lib/Chalk/IR/Node/Add.pm
+++ b/lib/Chalk/IR/Node/Add.pm
@@ -185,7 +185,7 @@ class Chalk::IR::Node::Add {
             if (!$lhs_inner_right_type->is_constant && !$right_type->is_constant) {
                 my $y = $left->right;
                 my $z = $right;
-                if ($z->id lt $y->id) {
+                if ($z->id < $y->id) {
                     my $new_left = Chalk::IR::Node::Add->new(
                         left  => $left->left,
                         right => $z,

--- a/t/sea-of-nodes/dce.t
+++ b/t/sea-of-nodes/dce.t
@@ -142,13 +142,16 @@ subtest 'kill does not remove inputs still in use' => sub {
     my $c1 = make_constant(1);
     my $c2 = make_constant(2);
     my $add1 = Chalk::IR::Node::Add->new(left => $c1, right => $c2);
-    my $add2 = Chalk::IR::Node::Add->new(left => $c1, right => make_constant(3));
+    # Note: Once GVN (Global Value Numbering) is implemented, duplicate
+    # constant values would be interned to the same node automatically.
+    my $c3 = make_constant(3);
+    my $add2 = Chalk::IR::Node::Add->new(left => $c1, right => $c3);
 
     $graph->add_node($c1);
     $graph->add_node($c2);
     $graph->add_node($add1);
     $graph->add_node($add2);
-    $graph->add_node(make_constant(3));  # The third constant used by add2
+    $graph->add_node($c3);
     $graph->materialize_pending_nodes();
 
     my $initial_count = $graph->node_count();

--- a/t/sea-of-nodes/dce.t
+++ b/t/sea-of-nodes/dce.t
@@ -1,0 +1,199 @@
+# ABOUTME: Tests for Dead Code Elimination (DCE) in the IR Graph
+# ABOUTME: Validates that unused nodes are properly cleaned up from the graph
+
+use lib 'lib';
+use v5.42;
+use Test::More;
+
+use_ok('Chalk::IR::Graph');
+use_ok('Chalk::IR::Node');
+use_ok('Chalk::IR::Node::Constant');
+use_ok('Chalk::IR::Node::Add');
+
+# =============================================================================
+# Helper functions
+# =============================================================================
+
+sub make_constant {
+    my ($value) = @_;
+    return Chalk::IR::Node::Constant->new(value => $value, type => 'Integer');
+}
+
+# =============================================================================
+# Basic Graph use counting tests
+# =============================================================================
+
+subtest 'Graph tracks use counts correctly' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Create nodes: outer Add uses inner Add, inner Add uses two Constants
+    my $c1 = make_constant(1);
+    my $c2 = make_constant(2);
+    my $add_inner = Chalk::IR::Node::Add->new(left => $c1, right => $c2);
+    my $c3 = make_constant(3);
+    my $add_outer = Chalk::IR::Node::Add->new(left => $add_inner, right => $c3);
+
+    # Add nodes to graph
+    $graph->add_node($c1);
+    $graph->add_node($c2);
+    $graph->add_node($add_inner);
+    $graph->add_node($c3);
+    $graph->add_node($add_outer);
+    $graph->materialize_pending_nodes();
+
+    # Check use counts
+    my $c1_uses = $graph->get_uses($c1->id);
+    my $c2_uses = $graph->get_uses($c2->id);
+    my $add_inner_uses = $graph->get_uses($add_inner->id);
+    my $c3_uses = $graph->get_uses($c3->id);
+    my $add_outer_uses = $graph->get_uses($add_outer->id);
+
+    is(scalar(@$c1_uses), 1, 'c1 has 1 use (from inner Add)');
+    is(scalar(@$c2_uses), 1, 'c2 has 1 use (from inner Add)');
+    is(scalar(@$add_inner_uses), 1, 'inner add has 1 use (from outer Add)');
+    is(scalar(@$c3_uses), 1, 'c3 has 1 use (from outer Add)');
+    is(scalar(@$add_outer_uses), 0, 'outer add has 0 uses (root node)');
+};
+
+# =============================================================================
+# DCE: remove_node method tests
+# =============================================================================
+
+subtest 'remove_node removes node from graph' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $c1 = make_constant(1);
+    $graph->add_node($c1);
+    $graph->materialize_pending_nodes();
+
+    is($graph->node_count(), 1, 'Graph has 1 node before removal');
+
+    $graph->remove_node($c1->id);
+
+    is($graph->node_count(), 0, 'Graph has 0 nodes after removal');
+    ok(!$graph->get_node($c1->id), 'Node is no longer accessible');
+};
+
+subtest 'remove_node updates use lists' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $c1 = make_constant(1);
+    my $c2 = make_constant(2);
+    my $add = Chalk::IR::Node::Add->new(left => $c1, right => $c2);
+
+    $graph->add_node($c1);
+    $graph->add_node($c2);
+    $graph->add_node($add);
+    $graph->materialize_pending_nodes();
+
+    # c1 and c2 should have add as a user
+    is(scalar(@{$graph->get_uses($c1->id)}), 1, 'c1 has 1 use before removal');
+    is(scalar(@{$graph->get_uses($c2->id)}), 1, 'c2 has 1 use before removal');
+
+    # Remove add node - should update c1 and c2 use lists
+    $graph->remove_node($add->id);
+
+    is(scalar(@{$graph->get_uses($c1->id)}), 0, 'c1 has 0 uses after add removed');
+    is(scalar(@{$graph->get_uses($c2->id)}), 0, 'c2 has 0 uses after add removed');
+};
+
+# =============================================================================
+# DCE: kill method tests
+# =============================================================================
+
+subtest 'kill removes unused node' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $c1 = make_constant(1);
+    $graph->add_node($c1);
+    $graph->materialize_pending_nodes();
+
+    is($graph->node_count(), 1, 'Graph has 1 node before kill');
+
+    # Kill the constant (it has no users)
+    $graph->kill($c1->id);
+
+    is($graph->node_count(), 0, 'Graph has 0 nodes after kill');
+};
+
+subtest 'kill recursively removes unused inputs' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $c1 = make_constant(1);
+    my $c2 = make_constant(2);
+    my $add = Chalk::IR::Node::Add->new(left => $c1, right => $c2);
+
+    $graph->add_node($c1);
+    $graph->add_node($c2);
+    $graph->add_node($add);
+    $graph->materialize_pending_nodes();
+
+    is($graph->node_count(), 3, 'Graph has 3 nodes before kill');
+
+    # Kill add - should recursively kill c1 and c2 since they become unused
+    $graph->kill($add->id);
+
+    is($graph->node_count(), 0, 'Graph has 0 nodes after recursive kill');
+};
+
+subtest 'kill does not remove inputs still in use' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $c1 = make_constant(1);
+    my $c2 = make_constant(2);
+    my $add1 = Chalk::IR::Node::Add->new(left => $c1, right => $c2);
+    my $add2 = Chalk::IR::Node::Add->new(left => $c1, right => make_constant(3));
+
+    $graph->add_node($c1);
+    $graph->add_node($c2);
+    $graph->add_node($add1);
+    $graph->add_node($add2);
+    $graph->add_node(make_constant(3));  # The third constant used by add2
+    $graph->materialize_pending_nodes();
+
+    my $initial_count = $graph->node_count();
+
+    # Kill add1 - c2 should be killed (only user), but c1 should remain (used by add2)
+    $graph->kill($add1->id);
+
+    ok(!$graph->get_node($add1->id), 'add1 is removed');
+    ok(!$graph->get_node($c2->id), 'c2 is removed (no more users)');
+    ok($graph->get_node($c1->id), 'c1 remains (still used by add2)');
+};
+
+# =============================================================================
+# DCE integration with peephole optimization
+# =============================================================================
+
+subtest 'DCE after constant folding cleans up original nodes' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $c1 = make_constant(1);
+    my $c2 = make_constant(2);
+    my $add = Chalk::IR::Node::Add->new(left => $c1, right => $c2);
+
+    $graph->add_node($c1);
+    $graph->add_node($c2);
+    $graph->add_node($add);
+    $graph->materialize_pending_nodes();
+
+    is($graph->node_count(), 3, 'Graph has 3 nodes before optimization');
+
+    # Peephole folds add to constant(3)
+    my $folded = $add->peephole();
+    is($folded->op, 'Constant', 'Add folded to Constant');
+    is($folded->value, 3, 'Folded value is 3');
+
+    # Replace add with folded in graph (simulating what would happen during optimization)
+    $graph->add_node($folded);
+    $graph->materialize_pending_nodes();
+
+    # Kill the original add (which is now dead code)
+    $graph->kill($add->id);
+
+    # Only the folded constant should remain
+    is($graph->node_count(), 1, 'Graph has 1 node after DCE');
+    ok($graph->get_node($folded->id), 'Folded constant remains in graph');
+};
+
+done_testing();

--- a/t/sea-of-nodes/idealize.t
+++ b/t/sea-of-nodes/idealize.t
@@ -167,6 +167,123 @@ subtest 'Negate: no optimizations' => sub {
 };
 
 # =============================================================================
+# Expression Canonicalization Tests (Issue #225)
+# Chapter 4: Transform expressions like 1 + arg + 2 into arg + 3
+# =============================================================================
+
+use_ok('Chalk::IR::Node::Start');
+use_ok('Chalk::IR::Node::Proj');
+
+# Helper to create an "arg" variable node (unknown integer value at compile time)
+sub make_arg {
+    my $start = Chalk::IR::Node::Start->new(label => 'main');
+    return Chalk::IR::Node::Proj->new(
+        source => $start,
+        index => 1,
+        label => 'arg',
+        inputs => [$start->id],
+    );
+}
+
+subtest 'Canonicalization: swap operands - move non-Add to right side' => sub {
+    # When left is constant and right is not, swap to normalize
+    # const + arg -> arg + const
+    my $arg = make_arg();
+    my $c1 = const(5);
+    my $add = Chalk::IR::Node::Add->new(left => $c1, right => $arg);
+
+    my $result = $add->idealize();
+    if (ok($result, 'idealize() returns a replacement for constant on left')) {
+        is($result->op, 'Add', 'Result is still Add');
+        is($result->left->id, $arg->id, 'arg moved to left (non-constant on LHS)');
+        is($result->right->id, $c1->id, 'constant moved to right');
+    }
+};
+
+subtest 'Canonicalization: no swap when already normalized' => sub {
+    # arg + const is already normalized
+    my $arg = make_arg();
+    my $c1 = const(5);
+    my $add = Chalk::IR::Node::Add->new(left => $arg, right => $c1);
+
+    my $result = $add->idealize();
+    ok(!$result, 'idealize() returns nothing when already normalized');
+};
+
+subtest 'Canonicalization: right association to left - x + (y + z) -> (x + y) + z' => sub {
+    # This ensures we have a left-spine structure for easier optimization
+    my $x = make_arg();
+    my $c1 = const(1);
+    my $c2 = const(2);
+
+    # x + (1 + 2) - though constants will fold, test the structure
+    my $inner = Chalk::IR::Node::Add->new(left => $c1, right => $c2);
+    my $outer = Chalk::IR::Node::Add->new(left => $x, right => $inner);
+
+    my $result = $outer->idealize();
+    # The inner Add is constant-foldable, so peephole should handle it
+    # But idealize should rotate: x + (y + z) -> (x + y) + z
+    if (ok($result, 'idealize() returns a rotation')) {
+        is($result->op, 'Add', 'Result is Add');
+        # After rotation: (x + 1) + 2
+        is($result->left->op, 'Add', 'Left is now Add node (rotated)');
+    }
+};
+
+subtest 'Canonicalization: constant combining - (x + c1) + c2 -> x + (c1 + c2)' => sub {
+    # 1 + arg + 2 should become arg + 3
+    my $arg = make_arg();
+    my $c1 = const(1);
+    my $c2 = const(2);
+
+    # Build: (1 + arg) + 2
+    my $inner = Chalk::IR::Node::Add->new(left => $c1, right => $arg);
+    my $outer = Chalk::IR::Node::Add->new(left => $inner, right => $c2);
+
+    # After peephole optimization chain:
+    # Step 1: inner idealizes to (arg + 1) - swap constants to right
+    # Step 2: outer becomes (arg + 1) + 2
+    # Step 3: constant combining: arg + (1 + 2) = arg + 3
+    my $result = $outer->peephole();
+    if (ok($result, 'peephole returns a result')) {
+        if (is($result->op, 'Add', 'Result is Add')) {
+            is($result->left->id, $arg->id, 'Left is arg');
+            if (ok($result->right, 'Right operand exists')) {
+                is($result->right->op, 'Constant', 'Right is Constant');
+                is($result->right->value, 3, 'Constants combined: 1 + 2 = 3');
+            }
+        }
+    }
+};
+
+subtest 'Canonicalization: arg + 1 + arg -> (arg + arg) + 1 -> (arg * 2) + 1' => sub {
+    my $arg = make_arg();
+    my $c1 = const(1);
+
+    # Build: (arg + 1) + arg
+    my $inner = Chalk::IR::Node::Add->new(left => $arg, right => $c1);
+    my $outer = Chalk::IR::Node::Add->new(left => $inner, right => $arg);
+
+    # After canonicalization and optimization:
+    # Should become (arg * 2) + 1
+    my $result = $outer->peephole();
+    if (ok($result, 'peephole returns a result')) {
+        if (is($result->op, 'Add', 'Result is Add')) {
+            if (ok($result->left, 'Left operand exists')) {
+                if (is($result->left->op, 'Multiply', 'Left is Multiply (arg * 2)')) {
+                    is($result->left->left->id, $arg->id, 'Multiply left is arg');
+                    is($result->left->right->value, 2, 'Multiply right is 2');
+                }
+            }
+            if (ok($result->right, 'Right operand exists')) {
+                is($result->right->op, 'Constant', 'Right is Constant');
+                is($result->right->value, 1, 'Right value is 1');
+            }
+        }
+    }
+};
+
+# =============================================================================
 # Peephole recursion termination tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Implement Chapter 4 expression canonicalization rules for Add nodes following the Sea of Nodes tutorial
- Implement Dead Code Elimination (DCE) with recursive `kill()` method in Graph.pm
- Add comprehensive test suites for both features

## Changes

### Issue #225: Expression Canonicalization for Add
- Swap operands to normalize constants on right (`1 + arg` → `arg + 1`)
- Right-to-left association (`x + (y + z)` → `(x + y) + z`)
- Constant combining (`(x + 1) + 2` → `x + 3`)
- Spline sorting to group variables together (`(arg + 1) + arg` → `(arg * 2) + 1`)

### Issue #226: Dead Code Elimination
- `remove_node()`: Remove a node and update use-def chains
- `kill()`: Recursively remove unused nodes and their orphaned inputs
- Enables cleanup after peephole optimizations like constant folding

## Files Changed
- `lib/Chalk/IR/Node/Add.pm`: Extended `idealize()` with canonicalization rules
- `lib/Chalk/IR/Graph.pm`: Added `remove_node()` and `kill()` methods
- `t/sea-of-nodes/idealize.t`: Added canonicalization test cases
- `t/sea-of-nodes/dce.t`: New test file for DCE

## Test Plan
- [x] All sea-of-nodes tests pass (412 tests across 27 files)
- [x] Canonicalization tests verify swap, rotation, constant combining, spline sorting
- [x] DCE tests verify remove_node, kill, recursive kill, integration with peephole

## Related Issues
- Closes #225
- Closes #226