### PR TITLE
refactor(ir): Simplify Graph.pm by removing pending_nodes pattern

### DIFF
--- a/app.pl
+++ b/app.pl
@@ -338,9 +338,6 @@ if ( !caller ) {
                             }
                         }
 
-                        # Materialize pending nodes
-                        $graph->materialize_pending_nodes();
-
                         # Run GVN optimizer
                         require Chalk::IR::Optimizer::GVN;
                         my $gvn_result = Chalk::IR::Optimizer::GVN->run_gvn($graph);

--- a/lib/Chalk/IR/Graph.pm
+++ b/lib/Chalk/IR/Graph.pm
@@ -10,73 +10,31 @@ class Chalk::IR::Graph {
     field $nodes :reader = {};
     field $entry :reader = undef;
     field $uses = {};  # Use-def map: node_id => [user_id1, user_id2, ...]
-    field $pending_nodes = {};  # Nodes created but not yet added to graph (deferred for materialization)
 
     method add_node($node) {
         my $node_id = $node->id;
 
-        # DEFERRED ADDITION: Store in pending instead of immediately adding to graph
-        # This prevents duplicate nodes from intermediate Earley parser completions
-        # Graph will be materialized later via materialize_pending_nodes()
-        $pending_nodes->{$node_id} = $node;
+        # Add directly to graph
+        $nodes->{$node_id} = $node;
 
-        return;
-    }
+        # Initialize use list for this node (empty initially)
+        $uses->{$node_id} //= [];
 
-    method clear_pending() {
-        # Clear all pending nodes AND materialized graph
-        # This is called at the start of each Program.evaluate() to ensure
-        # only the final Earley completion's nodes end up in the graph
-        $pending_nodes = {};
-        $nodes = {};
-        $uses = {};
-        return;
-    }
-
-    method materialize_pending_nodes() {
-        # Move all pending nodes into the actual graph
-        # This should be called once at the end of parsing (e.g., in Program.evaluate())
-        for my $node_id (keys %{$pending_nodes}) {
-            my $node = $pending_nodes->{$node_id};
-
-            # Actually add to graph
-            $nodes->{$node_id} = $node;
-
-            # Initialize use list for this node (empty initially)
-            $uses->{$node_id} //= [];
-
-            # Update use-def chains: for each input, add this node as a user
-            for my $input_id ( $node->inputs->@* ) {
-                next unless defined $input_id;  # Skip undefined inputs
-                next if $input_id eq '__CONTROL_PLACEHOLDER__';  # Skip placeholders
-                $uses->{$input_id} //= [];
-                push $uses->{$input_id}->@*, $node_id;
-            }
-
-            # First node added becomes entry point
-            $entry //= $node_id;
+        # Update use-def chains: for each input, add this node as a user
+        for my $input_id ( $node->inputs->@* ) {
+            next unless defined $input_id;  # Skip undefined inputs
+            next if $input_id eq '__CONTROL_PLACEHOLDER__';  # Skip placeholders
+            $uses->{$input_id} //= [];
+            push $uses->{$input_id}->@*, $node_id;
         }
 
-        # Clear pending nodes
-        $pending_nodes = {};
+        # First node added becomes entry point
+        $entry //= $node_id;
 
         return;
-    }
-
-    # Get a pending node by ID (for selective materialization)
-    method get_pending_node($id) {
-        return $pending_nodes->{$id};
-    }
-
-    # Get all pending nodes (returns hashref for direct manipulation)
-    method get_pending_all() {
-        return $pending_nodes;
     }
 
     method get_node($id) {
-        # Check pending nodes first (for nodes not yet materialized)
-        return $pending_nodes->{$id} if exists $pending_nodes->{$id};
-        # Then check materialized nodes
         return $nodes->{$id};
     }
 

--- a/lib/Chalk/IR/Optimizer/GVN.pm
+++ b/lib/Chalk/IR/Optimizer/GVN.pm
@@ -125,9 +125,6 @@ class Chalk::IR::Optimizer::GVN {
             $new_graph->set_entry($new_entry);
         }
 
-        # Materialize pending nodes into the graph
-        $new_graph->materialize_pending_nodes();
-
         # Compute metrics
         my $nodes_eliminated = scalar keys %{$redirections};
 

--- a/t/interpreter/cek-arithmetic.t
+++ b/t/interpreter/cek-arithmetic.t
@@ -26,7 +26,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($start);
     $graph->add_node($const);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -50,7 +49,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($c2);
     $graph->add_node($add);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -74,7 +72,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($c3);
     $graph->add_node($mul);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -102,7 +99,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($add);
     $graph->add_node($mul);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -128,7 +124,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($c3);
     $graph->add_node($sub);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -154,7 +149,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($c4);
     $graph->add_node($div);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -178,7 +172,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($c3);
     $graph->add_node($add);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -202,7 +195,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($c5);
     $graph->add_node($add);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -226,7 +218,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($c10);
     $graph->add_node($mul);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -250,7 +241,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($c3);
     $graph->add_node($mul);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -276,7 +266,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($c0);
     $graph->add_node($div);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
 
@@ -319,7 +308,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($mul);
     $graph->add_node($sub);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();

--- a/t/interpreter/cek-array-operations.t
+++ b/t/interpreter/cek-array-operations.t
@@ -21,7 +21,6 @@ my $return1 = Chalk::IR::Node::Return->new(
 );
 $graph1->add_node($new_array);
 $graph1->add_node($return1);
-$graph1->materialize_pending_nodes();
 
 my $interp1 = Chalk::Interpreter::CEKDataflow->new(graph => $graph1);
 my $result1 = $interp1->execute();
@@ -48,7 +47,6 @@ $graph2->add_node($index);
 $graph2->add_node($value);
 $graph2->add_node($store);
 $graph2->add_node($return2);
-$graph2->materialize_pending_nodes();
 
 my $interp2 = Chalk::Interpreter::CEKDataflow->new(graph => $graph2);
 my $result2 = $interp2->execute();
@@ -82,7 +80,6 @@ $graph3->add_node($value3);
 $graph3->add_node($store3);
 $graph3->add_node($load3);
 $graph3->add_node($return3);
-$graph3->materialize_pending_nodes();
 
 my $interp3 = Chalk::Interpreter::CEKDataflow->new(graph => $graph3);
 my $result3 = $interp3->execute();
@@ -130,7 +127,6 @@ $graph4->add_node($store4a);
 $graph4->add_node($store4b);
 $graph4->add_node($load4);
 $graph4->add_node($return4);
-$graph4->materialize_pending_nodes();
 
 my $interp4 = Chalk::Interpreter::CEKDataflow->new(graph => $graph4);
 my $result4 = $interp4->execute();
@@ -178,7 +174,6 @@ $graph5->add_node($store5a);
 $graph5->add_node($store5b);
 $graph5->add_node($load5);
 $graph5->add_node($return5);
-$graph5->materialize_pending_nodes();
 
 my $interp5 = Chalk::Interpreter::CEKDataflow->new(graph => $graph5);
 my $result5 = $interp5->execute();
@@ -226,7 +221,6 @@ $graph6->add_node($store6a);
 $graph6->add_node($store6b);
 $graph6->add_node($load6a);
 $graph6->add_node($return6);
-$graph6->materialize_pending_nodes();
 
 my $interp6 = Chalk::Interpreter::CEKDataflow->new(graph => $graph6);
 my $result6 = $interp6->execute();
@@ -274,7 +268,6 @@ $graph7->add_node($store7a);
 $graph7->add_node($store7b);
 $graph7->add_node($load7b);
 $graph7->add_node($return7);
-$graph7->materialize_pending_nodes();
 
 my $interp7 = Chalk::Interpreter::CEKDataflow->new(graph => $graph7);
 my $result7 = $interp7->execute();
@@ -330,7 +323,6 @@ $graph10->add_node($store10a);
 $graph10->add_node($store10b);
 $graph10->add_node($load10);
 $graph10->add_node($return10);
-$graph10->materialize_pending_nodes();
 
 my $interp10 = Chalk::Interpreter::CEKDataflow->new(graph => $graph10);
 my $result10 = $interp10->execute();

--- a/t/interpreter/cek-control-flow.t
+++ b/t/interpreter/cek-control-flow.t
@@ -40,7 +40,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($cond_true);
     $graph->add_node($if_node);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -75,7 +74,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($if_node);
     $graph->add_node($proj_true);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -113,7 +111,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($gt);
     $graph->add_node($if_node);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -162,7 +159,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($proj_true);
     $graph->add_node($region);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -212,7 +208,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($proj_true);
     $graph->add_node($region);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -270,7 +265,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($val_true);
     $graph->add_node($phi);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -328,7 +322,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($val_true);
     $graph->add_node($phi);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -393,7 +386,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($region);
     $graph->add_node($phi);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -458,7 +450,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($region);
     $graph->add_node($phi);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -529,7 +520,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($region);
     $graph->add_node($phi);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -555,7 +545,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($invalid);
     $graph->add_node($region);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     eval { $interp->execute(); };

--- a/t/interpreter/cek-error-cases.t
+++ b/t/interpreter/cek-error-cases.t
@@ -86,7 +86,6 @@ subtest 'ArrayLoad with non-existent heap_id' => sub {
     $graph->add_node($index);
     $graph->add_node($load);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     eval { $interp->execute(); };
@@ -124,7 +123,6 @@ subtest 'ArrayLoad with non-integer heap_id type' => sub {
     $graph->add_node($index);
     $graph->add_node($load);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     eval { $interp->execute(); };
@@ -164,7 +162,6 @@ subtest 'ArrayStore with invalid index type' => sub {
     $graph->add_node($value);
     $graph->add_node($store);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = eval { $interp->execute(); };
@@ -204,7 +201,6 @@ subtest 'HashLoad with undefined key' => sub {
     $graph->add_node($key);
     $graph->add_node($load);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = eval { $interp->execute(); };
@@ -253,7 +249,6 @@ subtest 'HashStore with non-existent heap_id' => sub {
     $graph->add_node($value);
     $graph->add_node($store);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     eval { $interp->execute(); };
@@ -329,7 +324,6 @@ subtest 'Phi node with active_path out of range' => sub {
     $graph->add_node($region);
     $graph->add_node($phi);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     eval { $interp->execute(); };
@@ -366,7 +360,6 @@ subtest 'Region with all paths inactive' => sub {
     $graph->add_node($false_val);
     $graph->add_node($region);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     eval { $interp->execute(); };
@@ -407,7 +400,6 @@ subtest 'If node with non-boolean condition' => sub {
     $graph->add_node($if_node);
     $graph->add_node($proj_true);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = eval { $interp->execute(); };
@@ -433,7 +425,6 @@ subtest 'Calling step() without initialize_stepping()' => sub {
     $graph->add_node($start);
     $graph->add_node($const);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     # Try to step without initialization
@@ -454,7 +445,6 @@ subtest 'Stepping past completion' => sub {
     $graph->add_node($start);
     $graph->add_node($const);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     $interp->initialize_stepping();
@@ -484,7 +474,6 @@ subtest 'Restoring snapshot from different graph' => sub {
     $graph1->add_node($start1);
     $graph1->add_node($const1);
     $graph1->add_node($return1);
-    $graph1->materialize_pending_nodes();
 
     my $interp1 = Chalk::Interpreter::CEKDataflow->new(graph => $graph1);
     $interp1->initialize_stepping();
@@ -506,7 +495,6 @@ subtest 'Restoring snapshot from different graph' => sub {
     $graph2->add_node($start2);
     $graph2->add_node($const2);
     $graph2->add_node($return2);
-    $graph2->materialize_pending_nodes();
 
     my $interp2 = Chalk::Interpreter::CEKDataflow->new(graph => $graph2);
 
@@ -534,7 +522,6 @@ subtest 'Snapshot with corrupted data' => sub {
     $graph->add_node($start);
     $graph->add_node($const);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
 
@@ -585,7 +572,6 @@ subtest 'Return node without value producer' => sub {
         control_id => 'non_existent'
     );
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     eval { $interp->execute(); };
@@ -614,7 +600,6 @@ subtest 'Multiple Return nodes' => sub {
     $graph->add_node($const2);
     $graph->add_node($return1);
     $graph->add_node($return2);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = eval { $interp->execute(); };
@@ -646,7 +631,6 @@ subtest 'Division by zero' => sub {
     $graph->add_node($denominator);
     $graph->add_node($div);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = eval { $interp->execute(); };
@@ -692,7 +676,6 @@ subtest 'Negative array index' => sub {
     $graph->add_node($value);
     $graph->add_node($store);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = eval { $interp->execute(); };
@@ -718,7 +701,6 @@ subtest 'Context lookup with malformed key' => sub {
     $graph->add_node($const);
     $graph->add_node($add);
     $graph->add_node($return);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = eval { $interp->execute(); };

--- a/t/interpreter/cek-error-missing-return.t
+++ b/t/interpreter/cek-error-missing-return.t
@@ -31,7 +31,6 @@ use Chalk::Interpreter::CEKDataflow;
 
     $graph->add_node($start);
     $graph->add_node($const);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     eval { $interp->execute(); };
@@ -51,7 +50,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($start);
     $graph->add_node($const);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result;

--- a/t/interpreter/cek-execution-log.t
+++ b/t/interpreter/cek-execution-log.t
@@ -31,7 +31,6 @@ $graph->add_node($const1);
 $graph->add_node($const2);
 $graph->add_node($add);
 $graph->add_node($ret);
-$graph->materialize_pending_nodes();
 
 # Test 1-2: Create execution log and capture steps
 my $log = Chalk::Interpreter::ExecutionLog->new(graph => $graph);

--- a/t/interpreter/cek-hash-operations.t
+++ b/t/interpreter/cek-hash-operations.t
@@ -25,7 +25,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($start);
     $graph->add_node($new_hash);
     $graph->add_node($return_node);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -56,7 +55,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($value);
     $graph->add_node($store);
     $graph->add_node($return_node);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -94,7 +92,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($store);
     $graph->add_node($load);
     $graph->add_node($return_node);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -146,7 +143,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($store_y);
     $graph->add_node($load_y);
     $graph->add_node($return_node);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -199,7 +195,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($store_y);
     $graph->add_node($load_x);
     $graph->add_node($return_node);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -252,7 +247,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($store_bob);
     $graph->add_node($load_alice);
     $graph->add_node($return_node);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -305,7 +299,6 @@ use Chalk::Interpreter::CEKDataflow;
     $graph->add_node($store_bob);
     $graph->add_node($load_bob);
     $graph->add_node($return_node);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -337,7 +330,6 @@ TODO: {
     $graph->add_node($key);
     $graph->add_node($load);
     $graph->add_node($return_node);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     eval {

--- a/t/interpreter/cek-integration.t
+++ b/t/interpreter/cek-integration.t
@@ -51,7 +51,6 @@ use Chalk::Interpreter::ExecutionLog;
     $graph->add_node($sub);
     $graph->add_node($mul);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -141,7 +140,6 @@ use Chalk::Interpreter::ExecutionLog;
     $graph->add_node($load1);
     $graph->add_node($result_sum);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();
@@ -245,7 +243,6 @@ use Chalk::Interpreter::ExecutionLog;
     $graph->add_node($load2);
     $graph->add_node($result_mul);
     $graph->add_node($ret);
-    $graph->materialize_pending_nodes();
 
     my $interp = Chalk::Interpreter::CEKDataflow->new(graph => $graph);
     my $result = $interp->execute();

--- a/t/interpreter/cek-object-operations.t
+++ b/t/interpreter/cek-object-operations.t
@@ -27,7 +27,6 @@ my $return1 = Chalk::IR::Node::Return->new(
 $graph1->add_node($start1);
 $graph1->add_node($new_obj);
 $graph1->add_node($return1);
-$graph1->materialize_pending_nodes();
 
 my $interp1 = Chalk::Interpreter::CEKDataflow->new(graph => $graph1);
 my $result1 = $interp1->execute();
@@ -59,7 +58,6 @@ $graph2->add_node($field);
 $graph2->add_node($value);
 $graph2->add_node($store);
 $graph2->add_node($return2);
-$graph2->materialize_pending_nodes();
 
 my $interp2 = Chalk::Interpreter::CEKDataflow->new(graph => $graph2);
 my $result2 = $interp2->execute();
@@ -98,7 +96,6 @@ $graph3->add_node($value3);
 $graph3->add_node($store3);
 $graph3->add_node($load3);
 $graph3->add_node($return3);
-$graph3->materialize_pending_nodes();
 
 my $interp3 = Chalk::Interpreter::CEKDataflow->new(graph => $graph3);
 my $result3 = $interp3->execute();
@@ -151,7 +148,6 @@ $graph4->add_node($store4a);
 $graph4->add_node($store4b);
 $graph4->add_node($load4);
 $graph4->add_node($return4);
-$graph4->materialize_pending_nodes();
 
 my $interp4 = Chalk::Interpreter::CEKDataflow->new(graph => $graph4);
 my $result4 = $interp4->execute();
@@ -204,7 +200,6 @@ $graph5->add_node($store5a);
 $graph5->add_node($store5b);
 $graph5->add_node($load5);
 $graph5->add_node($return5);
-$graph5->materialize_pending_nodes();
 
 my $interp5 = Chalk::Interpreter::CEKDataflow->new(graph => $graph5);
 my $result5 = $interp5->execute();
@@ -260,7 +255,6 @@ $graph6->add_node($store6a);
 $graph6->add_node($store6b);
 $graph6->add_node($load6a);
 $graph6->add_node($return6);
-$graph6->materialize_pending_nodes();
 
 my $interp6 = Chalk::Interpreter::CEKDataflow->new(graph => $graph6);
 my $result6 = $interp6->execute();
@@ -316,7 +310,6 @@ $graph7->add_node($store7a);
 $graph7->add_node($store7b);
 $graph7->add_node($load7b);
 $graph7->add_node($return7);
-$graph7->materialize_pending_nodes();
 
 my $interp7 = Chalk::Interpreter::CEKDataflow->new(graph => $graph7);
 my $result7 = $interp7->execute();
@@ -367,7 +360,6 @@ $graph8->add_node($test_obj);
 $graph8->add_node($test_field);
 $graph8->add_node($store_result);
 $graph8->add_node($return8);
-$graph8->materialize_pending_nodes();
 
 my $interp8 = Chalk::Interpreter::CEKDataflow->new(graph => $graph8);
 my $result8 = $interp8->execute();

--- a/t/interpreter/cek-stepping.t
+++ b/t/interpreter/cek-stepping.t
@@ -27,7 +27,6 @@ $graph1->add_node($const1);
 $graph1->add_node($const2);
 $graph1->add_node($add);
 $graph1->add_node($ret);
-$graph1->materialize_pending_nodes();
 
 my $interp1 = Chalk::Interpreter::CEKDataflow->new(graph => $graph1);
 $interp1->initialize_stepping();
@@ -93,7 +92,6 @@ $graph2->add_node($c1);
 $graph2->add_node($c2);
 $graph2->add_node($add2);
 $graph2->add_node($ret2);
-$graph2->materialize_pending_nodes();
 
 my $interp2 = Chalk::Interpreter::CEKDataflow->new(graph => $graph2);
 $interp2->initialize_stepping();
@@ -120,7 +118,6 @@ $graph3->add_node($c3);
 $graph3->add_node($c4);
 $graph3->add_node($add3);
 $graph3->add_node($ret3);
-$graph3->materialize_pending_nodes();
 
 # Execute with full execute() method
 my $interp3a = Chalk::Interpreter::CEKDataflow->new(graph => $graph3);

--- a/t/interpreter/issue-195-early-return.t
+++ b/t/interpreter/issue-195-early-return.t
@@ -105,7 +105,6 @@ sub execute_chalk {
         }
     }
 
-    $graph->materialize_pending_nodes();
 
     # Run GVN optimizer
     my $gvn_result = Chalk::IR::Optimizer::GVN->run_gvn($graph);

--- a/t/sea-of-nodes/chapter01.t
+++ b/t/sea-of-nodes/chapter01.t
@@ -131,9 +131,6 @@ subtest 'Build minimal graph: Start -> Return(Constant)' => sub {
     $graph->add_node($const);
     $graph->add_node($return);
 
-    # Graph uses deferred addition - must materialize pending nodes
-    $graph->materialize_pending_nodes();
-
     is($graph->node_count, 3, 'Graph has 3 nodes');
 
     # Verify nodes are retrievable
@@ -205,9 +202,6 @@ sub build_graph_from_result {
             }
         }
     }
-
-    # Materialize pending nodes into actual graph
-    $graph->materialize_pending_nodes();
 
     return $graph;
 }

--- a/t/sea-of-nodes/chapter02.t
+++ b/t/sea-of-nodes/chapter02.t
@@ -76,8 +76,6 @@ sub build_graph_from_result {
         }
     }
 
-    # Materialize pending nodes into actual graph
-    $graph->materialize_pending_nodes();
 
     return $graph;
 }

--- a/t/sea-of-nodes/chapter03.t
+++ b/t/sea-of-nodes/chapter03.t
@@ -165,8 +165,6 @@ sub build_graph_from_result {
         }
     }
 
-    # Materialize pending nodes into actual graph
-    $graph->materialize_pending_nodes();
 
     return $graph;
 }

--- a/t/sea-of-nodes/chapter05.t
+++ b/t/sea-of-nodes/chapter05.t
@@ -423,9 +423,6 @@ subtest 'Complete if-then-else: classify($x) with phi merge' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes
-    $graph->materialize_pending_nodes();
-
     # Verify graph structure
     is($graph->node_count, 12, 'Graph has 12 nodes');
 
@@ -540,8 +537,6 @@ subtest 'Validator confirms Chapter 5 IR correctness' => sub {
         attributes => {}
     ));
 
-    # Materialize pending nodes
-    $graph->materialize_pending_nodes();
 
     # Run validator
     my $validator = Chalk::IR::Validator->new();
@@ -598,8 +593,6 @@ subtest 'JSON serialization with If/Region/Phi' => sub {
         attributes => {}
     ));
 
-    # Materialize pending nodes
-    $graph->materialize_pending_nodes();
 
     # Serialize to JSON
     my $json = $graph->to_json();

--- a/t/sea-of-nodes/chapter06.t
+++ b/t/sea-of-nodes/chapter06.t
@@ -510,8 +510,6 @@ subtest 'Validator confirms optimized IR correctness' => sub {
         attributes => {}
     ));
 
-    # Materialize pending nodes
-    $graph->materialize_pending_nodes();
 
     # Run validator
     my $validator = Chalk::IR::Validator->new();

--- a/t/sea-of-nodes/chapter07.t
+++ b/t/sea-of-nodes/chapter07.t
@@ -141,7 +141,6 @@ subtest 'Simple while(true) infinite loop IR' => sub {
     $graph->add_node($return_node);
 
     is scalar($loop->inputs->@*), 2, 'Loop has entry and backedge';
-    $graph->materialize_pending_nodes();
     my $json = $graph->to_json();
     my $has_loop = scalar(grep { $_->{op} eq 'Loop' } $json->{nodes}->@*);
     ok $has_loop, 'IR contains Loop node';
@@ -261,8 +260,6 @@ subtest 'While loop with counter: while(i < 10) { i = i + 1; }' => sub {
     is scalar($loop->inputs->@*), 2, 'Loop has entry and backedge';
     is scalar($phi_i->inputs->@*), 3, 'Loop phi has control, init, and loop value';
 
-    # Materialize pending nodes before validation
-    $graph->materialize_pending_nodes();
 
     my $validator = Chalk::IR::Validator->new();
     my @cfg_errors = $validator->validate_cfg($graph);
@@ -542,7 +539,6 @@ subtest 'Loop exit with final value' => sub {
 
     is $return_node->inputs->[1], $phi->id, 'Return uses loop phi value';
 
-    $graph->materialize_pending_nodes();
     my $json = $graph->to_json();
     my $has_return = scalar(grep { $_->{op} eq 'Return' } $json->{nodes}->@*);
     my $has_loop = scalar(grep { $_->{op} eq 'Loop' } $json->{nodes}->@*);
@@ -590,7 +586,6 @@ subtest 'Loop validator integration' => sub {
     );
     $graph->add_node($return_node);
 
-    $graph->materialize_pending_nodes();
 
     my $validator = Chalk::IR::Validator->new();
 

--- a/t/sea-of-nodes/chapter08.t
+++ b/t/sea-of-nodes/chapter08.t
@@ -670,8 +670,6 @@ subtest 'Validation with break and continue' => sub {
     );
     $graph->add_node($return_node);
 
-    # Materialize pending nodes before validation
-    $graph->materialize_pending_nodes();
 
     my $validator = Chalk::IR::Validator->new();
     my @cfg_errors = $validator->validate_cfg($graph);

--- a/t/sea-of-nodes/chapter09.t
+++ b/t/sea-of-nodes/chapter09.t
@@ -50,8 +50,6 @@ subtest 'GVN basic concept: identical operations' => sub {
     );
     $graph->add_node($add2);
 
-    # Materialize pending nodes before counting
-    $graph->materialize_pending_nodes();
 
     # Without GVN: 2 separate Add nodes
     is $graph->node_count(), 4, 'Without GVN: 4 nodes (2 constants, 2 adds)';

--- a/t/sea-of-nodes/chapter11.t
+++ b/t/sea-of-nodes/chapter11.t
@@ -535,9 +535,6 @@ subtest 'JSON serialization with Call nodes' => sub {
     );
     $graph->add_node($call);
 
-    # Materialize pending nodes before JSON serialization
-    $graph->materialize_pending_nodes();
-
     my $json = $graph->to_json();
 
     my $has_call = scalar(grep { $_->{op} eq 'Call' } $json->{nodes}->@*);

--- a/t/sea-of-nodes/dce.t
+++ b/t/sea-of-nodes/dce.t
@@ -39,7 +39,6 @@ subtest 'Graph tracks use counts correctly' => sub {
     $graph->add_node($add_inner);
     $graph->add_node($c3);
     $graph->add_node($add_outer);
-    $graph->materialize_pending_nodes();
 
     # Check use counts
     my $c1_uses = $graph->get_uses($c1->id);
@@ -64,7 +63,6 @@ subtest 'remove_node removes node from graph' => sub {
 
     my $c1 = make_constant(1);
     $graph->add_node($c1);
-    $graph->materialize_pending_nodes();
 
     is($graph->node_count(), 1, 'Graph has 1 node before removal');
 
@@ -84,7 +82,6 @@ subtest 'remove_node updates use lists' => sub {
     $graph->add_node($c1);
     $graph->add_node($c2);
     $graph->add_node($add);
-    $graph->materialize_pending_nodes();
 
     # c1 and c2 should have add as a user
     is(scalar(@{$graph->get_uses($c1->id)}), 1, 'c1 has 1 use before removal');
@@ -106,7 +103,6 @@ subtest 'kill removes unused node' => sub {
 
     my $c1 = make_constant(1);
     $graph->add_node($c1);
-    $graph->materialize_pending_nodes();
 
     is($graph->node_count(), 1, 'Graph has 1 node before kill');
 
@@ -126,7 +122,6 @@ subtest 'kill recursively removes unused inputs' => sub {
     $graph->add_node($c1);
     $graph->add_node($c2);
     $graph->add_node($add);
-    $graph->materialize_pending_nodes();
 
     is($graph->node_count(), 3, 'Graph has 3 nodes before kill');
 
@@ -152,7 +147,6 @@ subtest 'kill does not remove inputs still in use' => sub {
     $graph->add_node($add1);
     $graph->add_node($add2);
     $graph->add_node($c3);
-    $graph->materialize_pending_nodes();
 
     my $initial_count = $graph->node_count();
 
@@ -178,7 +172,6 @@ subtest 'DCE after constant folding cleans up original nodes' => sub {
     $graph->add_node($c1);
     $graph->add_node($c2);
     $graph->add_node($add);
-    $graph->materialize_pending_nodes();
 
     is($graph->node_count(), 3, 'Graph has 3 nodes before optimization');
 
@@ -189,7 +182,6 @@ subtest 'DCE after constant folding cleans up original nodes' => sub {
 
     # Replace add with folded in graph (simulating what would happen during optimization)
     $graph->add_node($folded);
-    $graph->materialize_pending_nodes();
 
     # Kill the original add (which is now dead code)
     $graph->kill($add->id);

--- a/t/sea-of-nodes/gvn.t
+++ b/t/sea-of-nodes/gvn.t
@@ -89,8 +89,6 @@ subtest 'Eliminate redundant arithmetic' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before counting/GVN
-    $graph->materialize_pending_nodes();
 
     # Before GVN: 7 nodes
     is($graph->node_count, 7, 'Graph has 7 nodes before GVN');
@@ -184,8 +182,6 @@ subtest 'Common subexpression elimination' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before counting/GVN
-    $graph->materialize_pending_nodes();
 
     is($graph->node_count, 7, 'Graph has 7 nodes before GVN');
 
@@ -261,8 +257,6 @@ subtest 'Commutativity in Add operations' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before GVN
-    $graph->materialize_pending_nodes();
 
     # Run GVN
     my $result = Chalk::IR::Optimizer::GVN->run_gvn($graph);
@@ -336,8 +330,6 @@ subtest 'Commutativity in Multiply operations' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before GVN
-    $graph->materialize_pending_nodes();
 
     # Run GVN
     my $result = Chalk::IR::Optimizer::GVN->run_gvn($graph);
@@ -387,8 +379,6 @@ subtest 'Different constants are not merged' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before GVN
-    $graph->materialize_pending_nodes();
 
     # Run GVN
     my $result = Chalk::IR::Optimizer::GVN->run_gvn($graph);
@@ -452,8 +442,6 @@ subtest 'Identical constants are merged' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before GVN
-    $graph->materialize_pending_nodes();
 
     # Run GVN
     my $result = Chalk::IR::Optimizer::GVN->run_gvn($graph);
@@ -511,8 +499,6 @@ subtest 'GVN is idempotent' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before GVN
-    $graph->materialize_pending_nodes();
 
     # First GVN pass
     my $result1 = Chalk::IR::Optimizer::GVN->run_gvn($graph);
@@ -592,8 +578,6 @@ subtest 'Non-commutative operations respect order' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before GVN
-    $graph->materialize_pending_nodes();
 
     # Run GVN
     my $result = Chalk::IR::Optimizer::GVN->run_gvn($graph);
@@ -658,8 +642,6 @@ subtest 'Proj nodes respect index differences' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before GVN
-    $graph->materialize_pending_nodes();
 
     # Run GVN
     my $result = Chalk::IR::Optimizer::GVN->run_gvn($graph);
@@ -796,8 +778,6 @@ subtest 'Complex expression optimization' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before counting/GVN
-    $graph->materialize_pending_nodes();
 
     is($graph->node_count, 11, 'Graph has 11 nodes before GVN');
 
@@ -874,8 +854,6 @@ subtest 'GVN preserves polymorphic node types' => sub {
 
     $graph->set_entry($start->id);
 
-    # Materialize pending nodes before GVN
-    $graph->materialize_pending_nodes();
 
     # Verify nodes are polymorphic before GVN
     is(ref($graph->nodes->{$add1->id}), 'Chalk::IR::Node::Add', 'Add node is polymorphic before GVN');

--- a/t/sea-of-nodes/issue-229-graph-simplify.t
+++ b/t/sea-of-nodes/issue-229-graph-simplify.t
@@ -1,0 +1,208 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests for issue #229 - Graph.pm simplification
+# ABOUTME: Verifies that add_node directly adds to graph and builds use-def chains immediately
+use lib 'lib';
+use 5.42.0;
+use experimental qw(class builtin keyword_any keyword_all);
+use utf8;
+use Test::More;
+
+use Chalk::IR::Graph;
+use Chalk::IR::Node;
+
+# Test 1: Basic add_node immediately adds to graph
+subtest 'add_node immediately adds to graph' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $node = Chalk::IR::Node->new(
+        id => 'test-node-1',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 42 }
+    );
+
+    $graph->add_node($node);
+
+    # After add_node, node should be immediately available
+    is($graph->node_count, 1, 'Graph has 1 node immediately after add_node');
+    ok($graph->get_node('test-node-1'), 'Node is immediately retrievable by ID');
+    is($graph->get_node('test-node-1')->op, 'Constant', 'Retrieved node has correct op');
+};
+
+# Test 2: Use-def chains built immediately on add_node
+subtest 'use-def chains built immediately' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Create a constant node
+    my $const = Chalk::IR::Node->new(
+        id => 'const-1',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 10 }
+    );
+
+    # Create a node that uses the constant
+    my $add = Chalk::IR::Node->new(
+        id => 'add-1',
+        op => 'Add',
+        inputs => ['const-1', 'const-1'],
+        attributes => {}
+    );
+
+    $graph->add_node($const);
+    $graph->add_node($add);
+
+    # Verify use-def chains are immediately available
+    my $uses = $graph->get_uses('const-1');
+    is(ref($uses), 'ARRAY', 'get_uses returns array ref');
+    is(scalar(@$uses), 2, 'const-1 has 2 uses (used twice by add-1)');
+    is($uses->[0], 'add-1', 'First user is add-1');
+    is($uses->[1], 'add-1', 'Second user is also add-1');
+};
+
+# Test 3: Entry point set on first node
+subtest 'first node becomes entry point' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $node1 = Chalk::IR::Node->new(
+        id => 'first-node',
+        op => 'Start',
+        inputs => [],
+        attributes => {}
+    );
+
+    my $node2 = Chalk::IR::Node->new(
+        id => 'second-node',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 1 }
+    );
+
+    $graph->add_node($node1);
+    is($graph->entry, 'first-node', 'Entry set to first node');
+
+    $graph->add_node($node2);
+    is($graph->entry, 'first-node', 'Entry remains first node after adding more');
+};
+
+# Test 4: Use-def chains handle forward references (input nodes added later)
+subtest 'use-def handles forward references' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Add a node that references an input that doesn't exist yet
+    my $return = Chalk::IR::Node->new(
+        id => 'return-1',
+        op => 'Return',
+        inputs => ['control-1', 'value-1'],  # Forward refs
+        attributes => {}
+    );
+
+    $graph->add_node($return);
+
+    # The use-def entry should exist even if the input node doesn't
+    my $control_uses = $graph->get_uses('control-1');
+    is(ref($control_uses), 'ARRAY', 'Use list created for forward reference');
+    is(scalar(@$control_uses), 1, 'Forward ref has correct use count');
+    is($control_uses->[0], 'return-1', 'Forward ref user is correct');
+
+    # Now add the referenced node
+    my $start = Chalk::IR::Node->new(
+        id => 'control-1',
+        op => 'Start',
+        inputs => [],
+        attributes => {}
+    );
+
+    $graph->add_node($start);
+
+    # Verify the use chain is still correct
+    $control_uses = $graph->get_uses('control-1');
+    is(scalar(@$control_uses), 1, 'Use list preserved after adding referenced node');
+};
+
+# Test 5: Placeholder inputs are skipped
+subtest 'placeholder inputs are skipped' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $node = Chalk::IR::Node->new(
+        id => 'node-with-placeholder',
+        op => 'Return',
+        inputs => ['__CONTROL_PLACEHOLDER__', 'value-1'],
+        attributes => {}
+    );
+
+    $graph->add_node($node);
+
+    # Placeholder should not create use-def entry
+    my $placeholder_uses = $graph->get_uses('__CONTROL_PLACEHOLDER__');
+    is(scalar(@$placeholder_uses), 0, 'No uses registered for placeholder');
+
+    # But real input should have use
+    my $value_uses = $graph->get_uses('value-1');
+    is(scalar(@$value_uses), 1, 'Real input has use registered');
+};
+
+# Test 6: Undefined inputs are skipped
+subtest 'undefined inputs are skipped' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $node = Chalk::IR::Node->new(
+        id => 'node-with-undef',
+        op => 'Return',
+        inputs => [undef, 'value-1'],
+        attributes => {}
+    );
+
+    $graph->add_node($node);
+
+    # Only the defined input should have use
+    my $value_uses = $graph->get_uses('value-1');
+    is(scalar(@$value_uses), 1, 'Defined input has use registered');
+};
+
+# Test 7: verify dead code methods removed - get_pending_node should not exist
+subtest 'pending methods removed' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # These methods should no longer exist after the simplification
+    ok(!$graph->can('get_pending_node'), 'get_pending_node method removed');
+    ok(!$graph->can('get_pending_all'), 'get_pending_all method removed');
+    ok(!$graph->can('clear_pending'), 'clear_pending method removed');
+    ok(!$graph->can('materialize_pending_nodes'), 'materialize_pending_nodes method removed');
+};
+
+# Test 8: remove_node still works correctly
+subtest 'remove_node works correctly' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $const = Chalk::IR::Node->new(
+        id => 'const-to-remove',
+        op => 'Constant',
+        inputs => [],
+        attributes => { value => 42 }
+    );
+
+    my $add = Chalk::IR::Node->new(
+        id => 'add-node',
+        op => 'Add',
+        inputs => ['const-to-remove', 'const-to-remove'],
+        attributes => {}
+    );
+
+    $graph->add_node($const);
+    $graph->add_node($add);
+
+    is($graph->node_count, 2, 'Graph has 2 nodes');
+
+    # Remove the add node
+    $graph->remove_node('add-node');
+
+    is($graph->node_count, 1, 'Graph has 1 node after removal');
+    ok(!$graph->get_node('add-node'), 'Removed node is gone');
+
+    # Use-def chains should be updated
+    my $uses = $graph->get_uses('const-to-remove');
+    is(scalar(@$uses), 0, 'No uses remaining after removal');
+};
+
+done_testing();

--- a/t/sea-of-nodes/optimizer-pipeline.t
+++ b/t/sea-of-nodes/optimizer-pipeline.t
@@ -38,8 +38,6 @@ subtest 'Empty pipeline' => sub {
     # Create empty pipeline
     my $pipeline = Chalk::IR::OptimizerPipeline->new(optimizers => []);
 
-    # Materialize pending nodes before pipeline
-    $graph->materialize_pending_nodes();
 
     # Apply pipeline
     my $result = $pipeline->apply($graph);
@@ -104,8 +102,6 @@ subtest 'Single optimizer pipeline' => sub {
     );
     $graph->add_node($add3);
 
-    # Materialize pending nodes before counting/pipeline
-    $graph->materialize_pending_nodes();
 
     # Before optimization: 6 nodes
     is($graph->node_count, 6, 'Graph has 6 nodes before optimization');
@@ -142,8 +138,6 @@ subtest 'Multiple optimizer pipeline' => sub {
     );
     $graph->add_node($const);
 
-    # Materialize pending nodes before pipeline
-    $graph->materialize_pending_nodes();
 
     # Create pipeline with multiple optimizers (GVN twice for testing)
     my $gvn1 = Chalk::IR::Optimizer::GVN->new();
@@ -170,8 +164,6 @@ subtest 'Pipeline preserves entry point' => sub {
     $graph->add_node($start);
     $graph->set_entry('node_0');
 
-    # Materialize pending nodes before pipeline
-    $graph->materialize_pending_nodes();
 
     my $pipeline = Chalk::IR::OptimizerPipeline->new(optimizers => []);
     my $result = $pipeline->apply($graph);

--- a/t/sea-of-nodes/use-def-chains.t
+++ b/t/sea-of-nodes/use-def-chains.t
@@ -42,8 +42,6 @@ subtest 'Node tracks uses via Graph' => sub {
     );
     $graph->add_node($return);
 
-    # Materialize pending nodes before getting uses
-    $graph->materialize_pending_nodes();
 
     # Test: Get uses of Start node (should be used by Constant and Return)
     my $start_uses = $graph->get_uses('node_0');
@@ -80,8 +78,6 @@ subtest 'Use-def chains update when adding nodes' => sub {
     );
     $graph->add_node($start);
 
-    # Materialize pending nodes before getting uses
-    $graph->materialize_pending_nodes();
 
     # Initially, Start has no uses
     my $uses = $graph->get_uses('node_0');
@@ -97,7 +93,6 @@ subtest 'Use-def chains update when adding nodes' => sub {
     $graph->add_node($constant);
 
     # Materialize new pending nodes
-    $graph->materialize_pending_nodes();
 
     # Now Start should have one use
     $uses = $graph->get_uses('node_0');
@@ -114,7 +109,6 @@ subtest 'Use-def chains update when adding nodes' => sub {
     $graph->add_node($return);
 
     # Materialize new pending nodes
-    $graph->materialize_pending_nodes();
 
     # Now Start should have two uses, Constant should have one
     $uses = $graph->get_uses('node_0');
@@ -166,8 +160,6 @@ subtest 'Use-def chains with arithmetic operations' => sub {
     );
     $graph->add_node($add);
 
-    # Materialize pending nodes before getting uses
-    $graph->materialize_pending_nodes();
 
     # Verify use-def chains
     my $uses_a = $graph->get_uses('node_1');
@@ -224,8 +216,6 @@ subtest 'Use-def chains with Phi nodes' => sub {
     );
     $graph->add_node($phi);
 
-    # Materialize pending nodes before getting uses
-    $graph->materialize_pending_nodes();
 
     # Verify use-def chains
     my $region_uses = $graph->get_uses('region_1');


### PR DESCRIPTION
## Summary

Closes #229

The `pending_nodes` deferred materialization pattern was vestigial from the SPPF parser era. With SPPF removed, this complexity is no longer needed. This change simplifies the mental model - nodes are now added directly to the graph and use-def chains are built immediately.

## Changes

- Remove `$pending_nodes` field from Graph.pm
- Remove `clear_pending()`, `get_pending_node()`, `get_pending_all()`, and `materialize_pending_nodes()` methods
- Modify `add_node()` to directly add to `$nodes` and build use-def chains immediately
- Simplify `get_node()` to only check `$nodes`
- Update all callers in `app.pl`, `GVN.pm`, and test files to remove `materialize_pending_nodes()` calls
- Add new test file `t/sea-of-nodes/issue-229-graph-simplify.t` verifying the new behavior

## Benefits

- Simpler mental model (no deferred/immediate distinction)
- Less code to maintain (-214 lines added, +220 lines removed net simplification)
- Removes dead code (`clear_pending`)
- Use-def chains built incrementally rather than in batch

## Test plan

- [x] New tests in `t/sea-of-nodes/issue-229-graph-simplify.t` pass
- [x] All sea-of-nodes tests pass
- [x] Pre-existing test failures (unrelated to this change) verified on `pu` branch

## Related Issues

- Discovered during investigation of #225 and #226