### PR TITLE
feat(optimizer): Add self-referential idealize() optimizations

### DIFF
--- a/lib/Chalk/IR/Node/EQ.pm
+++ b/lib/Chalk/IR/Node/EQ.pm
@@ -57,6 +57,7 @@ class Chalk::IR::Node::EQ {
     }
 
     method peephole($graph = undef) {
+        # Step 1: Constant folding via compute()
         my $type = $self->compute();
         if ($type->is_constant) {
             return Chalk::IR::Node::Constant->new(
@@ -64,7 +65,22 @@ class Chalk::IR::Node::EQ {
                 type  => 'Bool',
             );
         }
+
+        # Step 2: Algebraic simplification via idealize()
+        if (my $idealized = $self->idealize()) {
+            return $idealized->peephole();
+        }
+
         return $self;
+    }
+
+    # Algebraic simplification for equality comparison
+    method idealize() {
+        # x == x -> true (self-equality)
+        if ($left->id eq $right->id) {
+            return Chalk::IR::Node::Constant->new(value => true, type => 'Bool');
+        }
+        return;
     }
 
     method record_transform(@args) {

--- a/lib/Chalk/IR/Node/NE.pm
+++ b/lib/Chalk/IR/Node/NE.pm
@@ -57,6 +57,7 @@ class Chalk::IR::Node::NE {
     }
 
     method peephole($graph = undef) {
+        # Step 1: Constant folding via compute()
         my $type = $self->compute();
         if ($type->is_constant) {
             return Chalk::IR::Node::Constant->new(
@@ -64,7 +65,22 @@ class Chalk::IR::Node::NE {
                 type  => 'Bool',
             );
         }
+
+        # Step 2: Algebraic simplification via idealize()
+        if (my $idealized = $self->idealize()) {
+            return $idealized->peephole();
+        }
+
         return $self;
+    }
+
+    # Algebraic simplification for inequality comparison
+    method idealize() {
+        # x != x -> false (self-inequality)
+        if ($left->id eq $right->id) {
+            return Chalk::IR::Node::Constant->new(value => false, type => 'Bool');
+        }
+        return;
     }
 
     method record_transform(@args) {

--- a/lib/Chalk/IR/Node/Subtract.pm
+++ b/lib/Chalk/IR/Node/Subtract.pm
@@ -91,8 +91,12 @@ class Chalk::IR::Node::Subtract {
         return Chalk::IR::Type::Top->top();
     }
 
-    # Algebraic simplification for subtraction - no optimizations in chapter04
+    # Algebraic simplification for subtraction
     method idealize() {
+        # x - x -> 0 (self-subtraction elimination)
+        if ($left->id eq $right->id) {
+            return Chalk::IR::Node::Constant->new(value => 0, type => 'Integer');
+        }
         return;
     }
 

--- a/t/sea-of-nodes/idealize.t
+++ b/t/sea-of-nodes/idealize.t
@@ -11,6 +11,8 @@ use_ok('Chalk::IR::Node::Divide');
 use_ok('Chalk::IR::Node::Subtract');
 use_ok('Chalk::IR::Node::Negate');
 use_ok('Chalk::IR::Node::Constant');
+use_ok('Chalk::IR::Node::EQ');
+use_ok('Chalk::IR::Node::NE');
 
 # Helper to create constant nodes
 sub const {
@@ -142,16 +144,26 @@ subtest 'Divide: no optimization for non-identity divisor' => sub {
 };
 
 # =============================================================================
-# Subtract::idealize() tests (no optimizations expected)
+# Subtract::idealize() tests
 # =============================================================================
 
-subtest 'Subtract: no optimizations' => sub {
+subtest 'Subtract: x - x -> 0 (self-subtraction elimination)' => sub {
+    my $x = const(42);
+    my $sub = Chalk::IR::Node::Subtract->new(left => $x, right => $x);
+
+    my $result = $sub->idealize();
+    ok($result, 'idealize() returns a replacement');
+    is($result->op, 'Constant', 'x - x returns Constant');
+    is($result->value, 0, 'x - x returns 0');
+};
+
+subtest 'Subtract: no optimization for different operands' => sub {
     my $a = const(10);
     my $b = const(3);
     my $sub = Chalk::IR::Node::Subtract->new(left => $a, right => $b);
 
     my $result = $sub->idealize();
-    ok(!$result, 'Subtract::idealize() returns nothing');
+    ok(!$result, 'Subtract::idealize() returns nothing for different operands');
 };
 
 # =============================================================================
@@ -164,6 +176,52 @@ subtest 'Negate: no optimizations' => sub {
 
     my $result = $neg->idealize();
     ok(!$result, 'Negate::idealize() returns nothing');
+};
+
+# =============================================================================
+# EQ::idealize() tests
+# =============================================================================
+
+subtest 'EQ: x == x -> true (self-equality)' => sub {
+    my $x = const(42);
+    my $eq = Chalk::IR::Node::EQ->new(left => $x, right => $x);
+
+    my $result = $eq->idealize();
+    ok($result, 'idealize() returns a replacement');
+    is($result->op, 'Constant', 'x == x returns Constant');
+    is($result->value, true, 'x == x returns true');
+};
+
+subtest 'EQ: no optimization for different operands' => sub {
+    my $a = const(5);
+    my $b = const(3);
+    my $eq = Chalk::IR::Node::EQ->new(left => $a, right => $b);
+
+    my $result = $eq->idealize();
+    ok(!$result, 'EQ::idealize() returns nothing for different operands');
+};
+
+# =============================================================================
+# NE::idealize() tests
+# =============================================================================
+
+subtest 'NE: x != x -> false (self-inequality)' => sub {
+    my $x = const(42);
+    my $ne = Chalk::IR::Node::NE->new(left => $x, right => $x);
+
+    my $result = $ne->idealize();
+    ok($result, 'idealize() returns a replacement');
+    is($result->op, 'Constant', 'x != x returns Constant');
+    is($result->value, false, 'x != x returns false');
+};
+
+subtest 'NE: no optimization for different operands' => sub {
+    my $a = const(5);
+    my $b = const(3);
+    my $ne = Chalk::IR::Node::NE->new(left => $a, right => $b);
+
+    my $result = $ne->idealize();
+    ok(!$result, 'NE::idealize() returns nothing for different operands');
 };
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Implement `x - x → 0` self-subtraction elimination in Subtract.pm
- Implement `x == x → true` self-equality optimization in EQ.pm
- Implement `x != x → false` self-inequality optimization in NE.pm
- Add comprehensive tests for all three optimizations

These optimizations achieve Sea of Nodes Chapter 04 parity by detecting when both operands of a binary operation refer to the same node and returning the mathematically-guaranteed result.

## Changes
- **4 files changed**, 98 insertions(+), 4 deletions(-)
- `lib/Chalk/IR/Node/Subtract.pm`: Added `idealize()` method
- `lib/Chalk/IR/Node/EQ.pm`: Added `idealize()` method and updated `peephole()` 
- `lib/Chalk/IR/Node/NE.pm`: Added `idealize()` method and updated `peephole()`
- `t/sea-of-nodes/idealize.t`: Added 6 new subtests for the optimizations

## Test plan
- [x] All 36 tests in `idealize.t` pass
- [x] All 484 tests in `t/sea-of-nodes/` pass
- [ ] CI pipeline passes

Closes #238

## Related Issues
- #238 - Missing peephole optimizations from Sea of Nodes Chapter 04