### PR TITLE
feat(optimizer): Add idealize() for ordering comparison nodes

### DIFF
--- a/lib/Chalk/IR/Node/GE.pm
+++ b/lib/Chalk/IR/Node/GE.pm
@@ -57,6 +57,7 @@ class Chalk::IR::Node::GE {
     }
 
     method peephole($graph = undef) {
+        # Step 1: Constant folding via compute()
         my $type = $self->compute();
         if ($type->is_constant) {
             return Chalk::IR::Node::Constant->new(
@@ -64,7 +65,22 @@ class Chalk::IR::Node::GE {
                 type  => 'Bool',
             );
         }
+
+        # Step 2: Algebraic simplification via idealize()
+        if (my $idealized = $self->idealize()) {
+            return $idealized->peephole();
+        }
+
         return $self;
+    }
+
+    # Algebraic simplification for greater-than-or-equal comparison
+    method idealize() {
+        # x >= x -> true (self-comparison)
+        if ($left->id eq $right->id) {
+            return Chalk::IR::Node::Constant->new(value => true, type => 'Bool');
+        }
+        return;
     }
 
     method record_transform(@args) {

--- a/lib/Chalk/IR/Node/GT.pm
+++ b/lib/Chalk/IR/Node/GT.pm
@@ -57,6 +57,7 @@ class Chalk::IR::Node::GT {
     }
 
     method peephole($graph = undef) {
+        # Step 1: Constant folding via compute()
         my $type = $self->compute();
         if ($type->is_constant) {
             return Chalk::IR::Node::Constant->new(
@@ -64,7 +65,22 @@ class Chalk::IR::Node::GT {
                 type  => 'Bool',
             );
         }
+
+        # Step 2: Algebraic simplification via idealize()
+        if (my $idealized = $self->idealize()) {
+            return $idealized->peephole();
+        }
+
         return $self;
+    }
+
+    # Algebraic simplification for greater-than comparison
+    method idealize() {
+        # x > x -> false (self-comparison)
+        if ($left->id eq $right->id) {
+            return Chalk::IR::Node::Constant->new(value => false, type => 'Bool');
+        }
+        return;
     }
 
     method record_transform(@args) {

--- a/lib/Chalk/IR/Node/LE.pm
+++ b/lib/Chalk/IR/Node/LE.pm
@@ -57,6 +57,7 @@ class Chalk::IR::Node::LE {
     }
 
     method peephole($graph = undef) {
+        # Step 1: Constant folding via compute()
         my $type = $self->compute();
         if ($type->is_constant) {
             return Chalk::IR::Node::Constant->new(
@@ -64,7 +65,22 @@ class Chalk::IR::Node::LE {
                 type  => 'Bool',
             );
         }
+
+        # Step 2: Algebraic simplification via idealize()
+        if (my $idealized = $self->idealize()) {
+            return $idealized->peephole();
+        }
+
         return $self;
+    }
+
+    # Algebraic simplification for less-than-or-equal comparison
+    method idealize() {
+        # x <= x -> true (self-comparison)
+        if ($left->id eq $right->id) {
+            return Chalk::IR::Node::Constant->new(value => true, type => 'Bool');
+        }
+        return;
     }
 
     method record_transform(@args) {

--- a/lib/Chalk/IR/Node/LT.pm
+++ b/lib/Chalk/IR/Node/LT.pm
@@ -57,6 +57,7 @@ class Chalk::IR::Node::LT {
     }
 
     method peephole($graph = undef) {
+        # Step 1: Constant folding via compute()
         my $type = $self->compute();
         if ($type->is_constant) {
             return Chalk::IR::Node::Constant->new(
@@ -64,7 +65,22 @@ class Chalk::IR::Node::LT {
                 type  => 'Bool',
             );
         }
+
+        # Step 2: Algebraic simplification via idealize()
+        if (my $idealized = $self->idealize()) {
+            return $idealized->peephole();
+        }
+
         return $self;
+    }
+
+    # Algebraic simplification for less-than comparison
+    method idealize() {
+        # x < x -> false (self-comparison)
+        if ($left->id eq $right->id) {
+            return Chalk::IR::Node::Constant->new(value => false, type => 'Bool');
+        }
+        return;
     }
 
     method record_transform(@args) {

--- a/t/sea-of-nodes/idealize.t
+++ b/t/sea-of-nodes/idealize.t
@@ -13,6 +13,10 @@ use_ok('Chalk::IR::Node::Negate');
 use_ok('Chalk::IR::Node::Constant');
 use_ok('Chalk::IR::Node::EQ');
 use_ok('Chalk::IR::Node::NE');
+use_ok('Chalk::IR::Node::LT');
+use_ok('Chalk::IR::Node::GT');
+use_ok('Chalk::IR::Node::LE');
+use_ok('Chalk::IR::Node::GE');
 
 # Helper to create constant nodes
 sub const {
@@ -222,6 +226,98 @@ subtest 'NE: no optimization for different operands' => sub {
 
     my $result = $ne->idealize();
     ok(!$result, 'NE::idealize() returns nothing for different operands');
+};
+
+# =============================================================================
+# LT::idealize() tests
+# =============================================================================
+
+subtest 'LT: x < x -> false (self-comparison)' => sub {
+    my $x = const(42);
+    my $lt = Chalk::IR::Node::LT->new(left => $x, right => $x);
+
+    my $result = $lt->idealize();
+    ok($result, 'idealize() returns a replacement');
+    is($result->op, 'Constant', 'x < x returns Constant');
+    is($result->value, false, 'x < x returns false');
+};
+
+subtest 'LT: no optimization for different operands' => sub {
+    my $a = const(5);
+    my $b = const(3);
+    my $lt = Chalk::IR::Node::LT->new(left => $a, right => $b);
+
+    my $result = $lt->idealize();
+    ok(!$result, 'LT::idealize() returns nothing for different operands');
+};
+
+# =============================================================================
+# GT::idealize() tests
+# =============================================================================
+
+subtest 'GT: x > x -> false (self-comparison)' => sub {
+    my $x = const(42);
+    my $gt = Chalk::IR::Node::GT->new(left => $x, right => $x);
+
+    my $result = $gt->idealize();
+    ok($result, 'idealize() returns a replacement');
+    is($result->op, 'Constant', 'x > x returns Constant');
+    is($result->value, false, 'x > x returns false');
+};
+
+subtest 'GT: no optimization for different operands' => sub {
+    my $a = const(5);
+    my $b = const(3);
+    my $gt = Chalk::IR::Node::GT->new(left => $a, right => $b);
+
+    my $result = $gt->idealize();
+    ok(!$result, 'GT::idealize() returns nothing for different operands');
+};
+
+# =============================================================================
+# LE::idealize() tests
+# =============================================================================
+
+subtest 'LE: x <= x -> true (self-comparison)' => sub {
+    my $x = const(42);
+    my $le = Chalk::IR::Node::LE->new(left => $x, right => $x);
+
+    my $result = $le->idealize();
+    ok($result, 'idealize() returns a replacement');
+    is($result->op, 'Constant', 'x <= x returns Constant');
+    is($result->value, true, 'x <= x returns true');
+};
+
+subtest 'LE: no optimization for different operands' => sub {
+    my $a = const(5);
+    my $b = const(3);
+    my $le = Chalk::IR::Node::LE->new(left => $a, right => $b);
+
+    my $result = $le->idealize();
+    ok(!$result, 'LE::idealize() returns nothing for different operands');
+};
+
+# =============================================================================
+# GE::idealize() tests
+# =============================================================================
+
+subtest 'GE: x >= x -> true (self-comparison)' => sub {
+    my $x = const(42);
+    my $ge = Chalk::IR::Node::GE->new(left => $x, right => $x);
+
+    my $result = $ge->idealize();
+    ok($result, 'idealize() returns a replacement');
+    is($result->op, 'Constant', 'x >= x returns Constant');
+    is($result->value, true, 'x >= x returns true');
+};
+
+subtest 'GE: no optimization for different operands' => sub {
+    my $a = const(5);
+    my $b = const(3);
+    my $ge = Chalk::IR::Node::GE->new(left => $a, right => $b);
+
+    my $result = $ge->idealize();
+    ok(!$result, 'GE::idealize() returns nothing for different operands');
 };
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Implement `x < x → false` self-comparison optimization in LT.pm
- Implement `x > x → false` self-comparison optimization in GT.pm
- Implement `x <= x → true` self-comparison optimization in LE.pm
- Implement `x >= x → true` self-comparison optimization in GE.pm
- Add comprehensive tests for all four optimizations (8 subtests)

This completes Chapter 04 parity by implementing the missing `idealize()` methods for the ordering comparison operators, complementing the EQ/NE optimizations from #238.

## Changes
- **5 files changed**, 160 insertions(+)
- `lib/Chalk/IR/Node/LT.pm`: Added `idealize()` method and updated `peephole()`
- `lib/Chalk/IR/Node/GT.pm`: Added `idealize()` method and updated `peephole()`
- `lib/Chalk/IR/Node/LE.pm`: Added `idealize()` method and updated `peephole()`
- `lib/Chalk/IR/Node/GE.pm`: Added `idealize()` method and updated `peephole()`
- `t/sea-of-nodes/idealize.t`: Added 8 new subtests (48 total tests now pass)

## Test plan
- [x] All 48 tests in `idealize.t` pass
- [ ] All tests in `t/sea-of-nodes/` pass (running)
- [ ] CI pipeline passes

## Related Issues
- Completes Chapter 04 parity for Sea of Nodes
- Follows pattern from #238