### PR TITLE
feat(optimizer): Implement dominator-based nested If optimization

### DIFF
--- a/lib/Chalk/IR/Node/If.pm
+++ b/lib/Chalk/IR/Node/If.pm
@@ -5,6 +5,11 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::If :isa(Chalk::IR::Node::Base) {
+    use Chalk::IR::Type::TypeTuple;
+    use Chalk::IR::Type::TypeCtrl;
+    use Chalk::IR::Type::Top;
+    use Chalk::IR::Type::Bottom;
+
     field $condition_id :param :reader;
     # Object reference to condition node for graph traversal
     field $condition :param :reader = undef;
@@ -29,6 +34,77 @@ class Chalk::IR::Node::If :isa(Chalk::IR::Node::Base) {
         # If node returns the condition value (1 or 0)
         # This tells Proj nodes which path is active
         return $context->("node:$condition_id");
+    }
+
+    # Type inference for If node
+    # Returns TypeTuple with (true_branch_ctrl, false_branch_ctrl)
+    # Uses dominator-based optimization to detect nested Ifs with identical predicates
+    method compute() {
+        # IF_BOTH: both branches reachable
+        my $IF_BOTH = Chalk::IR::Type::TypeTuple->of(
+            Chalk::IR::Type::TypeCtrl->CTRL(),
+            Chalk::IR::Type::TypeCtrl->CTRL()
+        );
+
+        # IF_TRUE: only true branch reachable
+        my $IF_TRUE = Chalk::IR::Type::TypeTuple->of(
+            Chalk::IR::Type::TypeCtrl->CTRL(),
+            Chalk::IR::Type::Bottom->BOTTOM()
+        );
+
+        # IF_FALSE: only false branch reachable
+        my $IF_FALSE = Chalk::IR::Type::TypeTuple->of(
+            Chalk::IR::Type::Bottom->BOTTOM(),
+            Chalk::IR::Type::TypeCtrl->CTRL()
+        );
+
+        # Check if condition is constant
+        if ($condition && $condition->can('compute')) {
+            my $cond_type = $condition->compute();
+            if ($cond_type->is_constant) {
+                return $cond_type->value ? $IF_TRUE : $IF_FALSE;
+            }
+        }
+
+        # Dominator-based optimization: walk up the dominator tree
+        # looking for an If with identical predicate
+        if ($control && $condition) {
+            my $dom = $control;
+
+            # Walk up the dominator tree
+            while ($dom) {
+                # Check if dom is a Proj from an If
+                if ($dom->can('source') && $dom->source && $dom->source->op eq 'If') {
+                    my $outer_if = $dom->source;
+
+                    # Check if outer If has same predicate (same node object)
+                    if ($outer_if->can('condition') && $outer_if->condition) {
+                        if (refaddr($outer_if->condition) == refaddr($condition)) {
+                            # Same predicate! Check which branch we're on
+                            # index 0 = true branch, index 1 = false branch
+                            my $proj_index = $dom->index;
+
+                            if ($proj_index == 0) {
+                                # We're on the TRUE branch of outer If
+                                # So this inner If with same predicate is always true
+                                return $IF_TRUE;
+                            } else {
+                                # We're on the FALSE branch of outer If
+                                # So this inner If with same predicate is always false
+                                return $IF_FALSE;
+                            }
+                        }
+                    }
+                }
+
+                # Move up to parent dominator
+                last unless $dom->can('idom');
+                $dom = $dom->idom();
+            }
+        }
+
+        # Default: both branches reachable
+        return $IF_BOTH;
     }
 
     # Peephole optimization for If nodes

--- a/lib/Chalk/IR/Node/Proj.pm
+++ b/lib/Chalk/IR/Node/Proj.pm
@@ -108,6 +108,54 @@ class Chalk::IR::Node::Proj :isa(Chalk::IR::Node::Base) {
 
         return $self;
     }
+
+    # Dominator tree: Proj's immediate dominator depends on source type
+    # For Proj from If: idom is the If's control input (not the If itself)
+    # For Proj from Start: idom is Start itself
+    # Caches result for efficiency
+    field $_idom :reader = undef;
+    field $_idepth :reader = undef;
+
+    method idom() {
+        return $_idom if defined $_idom;
+
+        return undef unless $source;
+
+        # If source is Start, this Proj's idom IS the Start node
+        if ($source->op eq 'Start') {
+            $_idom = $source;
+            return $_idom;
+        }
+
+        # If source is an If node, the Proj's idom is the If's control input
+        if ($source->op eq 'If' && $source->can('control')) {
+            $_idom = $source->control;
+            return $_idom;
+        }
+
+        # Default: try source's idom if it has one
+        if ($source->can('idom')) {
+            $_idom = $source->idom;
+            return $_idom;
+        }
+
+        return undef;
+    }
+
+    method idepth() {
+        return $_idepth if defined $_idepth;
+
+        my $dom = $self->idom();
+        return 0 unless $dom;
+
+        if ($dom->can('idepth')) {
+            $_idepth = $dom->idepth() + 1;
+        } else {
+            $_idepth = 1;  # Default if idom doesn't support idepth
+        }
+
+        return $_idepth;
+    }
 }
 
 1;

--- a/lib/Chalk/IR/Node/Region.pm
+++ b/lib/Chalk/IR/Node/Region.pm
@@ -119,6 +119,61 @@ class Chalk::IR::Node::Region :isa(Chalk::IR::Node::Base) {
 
         return @live_indices;
     }
+
+    # Control inputs for dominator calculation (object references)
+    field $_control_inputs :reader = undef;
+
+    method set_control_inputs($inputs) {
+        $_control_inputs = $inputs;
+    }
+
+    # Cached dominator info
+    field $_idom :reader = undef;
+    field $_idepth :reader = undef;
+
+    # Region's idom is the lowest common ancestor (LCA) of all control inputs
+    # Uses parallel tree traversal algorithm from Simple Chapter 6
+    method idom() {
+        return $_idom if defined $_idom;
+
+        # Need control inputs for LCA calculation
+        return undef unless $_control_inputs && $_control_inputs->@* >= 2;
+
+        my ($lhs, $rhs) = ($_control_inputs->[0], $_control_inputs->[1]);
+
+        # Walk up both idom trees until they meet
+        while (defined $lhs && defined $rhs && refaddr($lhs) != refaddr($rhs)) {
+            return undef unless $lhs->can('idepth') && $rhs->can('idepth');
+
+            my $lhs_depth = $lhs->idepth() // 0;
+            my $rhs_depth = $rhs->idepth() // 0;
+
+            if ($lhs_depth >= $rhs_depth && $lhs->can('idom')) {
+                $lhs = $lhs->idom();
+            }
+            if ($rhs_depth >= $lhs_depth && $rhs->can('idom')) {
+                $rhs = $rhs->idom();
+            }
+        }
+
+        $_idom = $lhs;
+        return $_idom;
+    }
+
+    method idepth() {
+        return $_idepth if defined $_idepth;
+
+        my $dom = $self->idom();
+        return 0 unless $dom;
+
+        if ($dom->can('idepth')) {
+            $_idepth = $dom->idepth() + 1;
+        } else {
+            $_idepth = 1;
+        }
+
+        return $_idepth;
+    }
 }
 
 1;

--- a/lib/Chalk/IR/Node/Start.pm
+++ b/lib/Chalk/IR/Node/Start.pm
@@ -73,6 +73,12 @@ class Chalk::IR::Node::Start {
         return $self;
     }
 
+    # Dominator tree: Start is the root, so idom returns undef
+    method idom() { return undef; }
+
+    # Dominator depth: Start is at depth 0
+    method idepth() { return 0; }
+
     # Stub for transform tracking (not used in v2 but called by Builder)
     method record_transform(@args) {
         # No-op for compatibility

--- a/t/sea-of-nodes/dominator.t
+++ b/t/sea-of-nodes/dominator.t
@@ -1,0 +1,398 @@
+# ABOUTME: Tests for dominator-based optimization in the IR graph
+# ABOUTME: Validates idom()/idepth() calculation and nested If optimization with identical predicates
+
+use lib 'lib';
+use v5.42;
+use Test::More;
+use Scalar::Util qw(refaddr);
+
+# Load type system
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+use Chalk::IR::Type::TypeCtrl;
+use Chalk::IR::Type::TypeTuple;
+use Chalk::IR::Type::TypeBool;
+
+# Load node classes
+use_ok('Chalk::IR::Node::Base');
+use_ok('Chalk::IR::Node::Start');
+use_ok('Chalk::IR::Node::Constant');
+use_ok('Chalk::IR::Node::If');
+use_ok('Chalk::IR::Node::Proj');
+use_ok('Chalk::IR::Node::Region');
+use_ok('Chalk::IR::Node::Phi');
+use_ok('Chalk::IR::Node::GT');
+use_ok('Chalk::IR::Graph');
+
+# Test 1: CFG nodes have idom() method
+subtest 'CFG nodes have idom() and idepth() methods' => sub {
+    my $start = Chalk::IR::Node::Start->new(
+        function => 'test',
+        params => [],
+    );
+
+    ok($start->can('idom'), 'Start node has idom() method');
+    ok($start->can('idepth'), 'Start node has idepth() method');
+
+    my $ctrl = Chalk::IR::Node::Proj->new(
+        inputs => [],
+        index => 0,
+        label => '$ctrl',
+        source => $start,
+    );
+
+    ok($ctrl->can('idom'), 'Proj node has idom() method');
+    ok($ctrl->can('idepth'), 'Proj node has idepth() method');
+};
+
+# Test 2: Start node is the dominator root (idom returns undef, idepth returns 0)
+subtest 'Start node is dominator root' => sub {
+    my $start = Chalk::IR::Node::Start->new(
+        function => 'test',
+        params => [],
+    );
+
+    is($start->idom(), undef, 'Start idom() returns undef (it is the root)');
+    is($start->idepth(), 0, 'Start idepth() returns 0');
+};
+
+# Test 3: Proj from Start has Start as its idom
+subtest 'Proj from Start has depth 1' => sub {
+    my $start = Chalk::IR::Node::Start->new(
+        function => 'test',
+        params => [],
+    );
+
+    my $ctrl = Chalk::IR::Node::Proj->new(
+        inputs => [$start->id],
+        index => 0,
+        label => '$ctrl',
+        source => $start,
+    );
+
+    is(refaddr($ctrl->idom()), refaddr($start), 'Proj from Start has Start as idom');
+    is($ctrl->idepth(), 1, 'Proj from Start has depth 1');
+};
+
+# Test 4: If projections have correct dominator depth
+subtest 'If projections have If control as idom' => sub {
+    my $start = Chalk::IR::Node::Start->new(
+        function => 'test',
+        params => [],
+    );
+
+    my $ctrl = Chalk::IR::Node::Proj->new(
+        inputs => [$start->id],
+        index => 0,
+        label => '$ctrl',
+        source => $start,
+    );
+
+    my $cond = Chalk::IR::Node::Constant->new(
+        value => true,
+        type => 'Bool',
+    );
+
+    my $if_node = Chalk::IR::Node::If->new(
+        inputs => [$ctrl->id, $cond->id],
+        condition_id => $cond->id,
+        control => $ctrl,
+        condition => $cond,
+    );
+
+    my $true_proj = Chalk::IR::Node::Proj->new(
+        inputs => [$if_node->id],
+        index => 0,
+        label => 'true',
+        source => $if_node,
+    );
+
+    my $false_proj = Chalk::IR::Node::Proj->new(
+        inputs => [$if_node->id],
+        index => 1,
+        label => 'false',
+        source => $if_node,
+    );
+
+    # True/False projections should have depth = if's control depth + 1
+    is($true_proj->idepth(), $ctrl->idepth() + 1, 'True proj depth is ctrl depth + 1');
+    is($false_proj->idepth(), $ctrl->idepth() + 1, 'False proj depth is ctrl depth + 1');
+
+    # Their idom should be the If's control input (the ctrl Proj)
+    is(refaddr($true_proj->idom()), refaddr($ctrl), 'True proj idom is ctrl');
+    is(refaddr($false_proj->idom()), refaddr($ctrl), 'False proj idom is ctrl');
+};
+
+# Test 5: Region finds lowest common ancestor as idom
+subtest 'Region idom is lowest common ancestor of inputs' => sub {
+    my $start = Chalk::IR::Node::Start->new(
+        function => 'test',
+        params => [],
+    );
+
+    my $ctrl = Chalk::IR::Node::Proj->new(
+        inputs => [$start->id],
+        index => 0,
+        label => '$ctrl',
+        source => $start,
+    );
+
+    my $cond = Chalk::IR::Node::Constant->new(
+        value => true,
+        type => 'Bool',
+    );
+
+    my $if_node = Chalk::IR::Node::If->new(
+        inputs => [$ctrl->id, $cond->id],
+        condition_id => $cond->id,
+        control => $ctrl,
+        condition => $cond,
+    );
+
+    my $true_proj = Chalk::IR::Node::Proj->new(
+        inputs => [$if_node->id],
+        index => 0,
+        label => 'true',
+        source => $if_node,
+    );
+
+    my $false_proj = Chalk::IR::Node::Proj->new(
+        inputs => [$if_node->id],
+        index => 1,
+        label => 'false',
+        source => $if_node,
+    );
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [$true_proj->id, $false_proj->id],
+    );
+    # Manually set control inputs for idom calculation
+    $region->set_control_inputs([$true_proj, $false_proj]);
+
+    # Region's idom should be the common ancestor of both branches
+    # Both branches come from the same If, so their common ancestor is ctrl
+    is(refaddr($region->idom()), refaddr($ctrl), 'Region idom is LCA of branches (ctrl)');
+    is($region->idepth(), $ctrl->idepth() + 1, 'Region depth is LCA depth + 1');
+};
+
+# Load VariableRead for non-constant test values
+use_ok('Chalk::IR::Node::VariableRead');
+
+# Test 6: Nested If with identical predicate - inner If compute() detects dominating If
+subtest 'Nested If with identical predicate detected in compute()' => sub {
+    # Build: if ($x > 0) { if ($x > 0) { ... } }
+    # The inner if should detect that its condition is already determined
+
+    my $start = Chalk::IR::Node::Start->new(
+        function => 'test',
+        params => [],
+    );
+
+    my $ctrl = Chalk::IR::Node::Proj->new(
+        inputs => [$start->id],
+        index => 0,
+        label => '$ctrl',
+        source => $start,
+    );
+
+    # Variable $x - use VariableRead which returns TOP (non-constant)
+    my $x = Chalk::IR::Node::VariableRead->new(
+        inputs => [],
+        var_label => 'lexical:$x',
+    );
+
+    my $zero = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type => 'Integer',
+    );
+
+    # Predicate: $x > 0 (non-constant because $x is unknown)
+    my $cond = Chalk::IR::Node::GT->new(
+        left => $x,
+        right => $zero,
+    );
+
+    # Outer If
+    my $outer_if = Chalk::IR::Node::If->new(
+        inputs => [$ctrl->id, $cond->id],
+        condition_id => $cond->id,
+        control => $ctrl,
+        condition => $cond,
+    );
+
+    # True branch of outer If
+    my $outer_true = Chalk::IR::Node::Proj->new(
+        inputs => [$outer_if->id],
+        index => 0,
+        label => 'true',
+        source => $outer_if,
+    );
+
+    # Inner If with SAME predicate (inside true branch)
+    my $inner_if = Chalk::IR::Node::If->new(
+        inputs => [$outer_true->id, $cond->id],  # Same condition!
+        condition_id => $cond->id,
+        control => $outer_true,
+        condition => $cond,
+    );
+
+    # The inner If's compute() should detect that we're inside the true branch
+    # of an outer If with the same predicate, so the condition is always true
+    my $inner_type = $inner_if->compute();
+
+    # Type should indicate that only the true branch is reachable
+    # (IF_TRUE tuple: true branch live, false branch dead)
+    ok($inner_type isa Chalk::IR::Type::TypeTuple, 'Inner If compute() returns TypeTuple');
+
+    my $true_ctrl = $inner_type->at(0);
+    my $false_ctrl = $inner_type->at(1);
+
+    ok($true_ctrl isa Chalk::IR::Type::TypeCtrl, 'True branch is Ctrl (live)');
+    ok($false_ctrl isa Chalk::IR::Type::Bottom, 'False branch is Bottom (dead)');
+};
+
+# Test 7: Nested If on false branch - condition is always false
+subtest 'Nested If on false branch is always false' => sub {
+    my $start = Chalk::IR::Node::Start->new(
+        function => 'test',
+        params => [],
+    );
+
+    my $ctrl = Chalk::IR::Node::Proj->new(
+        inputs => [$start->id],
+        index => 0,
+        label => '$ctrl',
+        source => $start,
+    );
+
+    # Variable $x - use VariableRead which returns TOP (non-constant)
+    my $x = Chalk::IR::Node::VariableRead->new(
+        inputs => [],
+        var_label => 'lexical:$x',
+    );
+
+    my $zero = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type => 'Integer',
+    );
+
+    # Non-constant predicate
+    my $cond = Chalk::IR::Node::GT->new(
+        left => $x,
+        right => $zero,
+    );
+
+    my $outer_if = Chalk::IR::Node::If->new(
+        inputs => [$ctrl->id, $cond->id],
+        condition_id => $cond->id,
+        control => $ctrl,
+        condition => $cond,
+    );
+
+    # False branch of outer If
+    my $outer_false = Chalk::IR::Node::Proj->new(
+        inputs => [$outer_if->id],
+        index => 1,
+        label => 'false',
+        source => $outer_if,
+    );
+
+    # Inner If with SAME predicate (inside false branch)
+    my $inner_if = Chalk::IR::Node::If->new(
+        inputs => [$outer_false->id, $cond->id],  # Same condition!
+        condition_id => $cond->id,
+        control => $outer_false,
+        condition => $cond,
+    );
+
+    # The inner If should detect we're on the false branch of outer If
+    # with same predicate, so condition is always false
+    my $inner_type = $inner_if->compute();
+
+    ok($inner_type isa Chalk::IR::Type::TypeTuple, 'Inner If compute() returns TypeTuple');
+
+    my $true_ctrl = $inner_type->at(0);
+    my $false_ctrl = $inner_type->at(1);
+
+    ok($true_ctrl isa Chalk::IR::Type::Bottom, 'True branch is Bottom (dead)');
+    ok($false_ctrl isa Chalk::IR::Type::TypeCtrl, 'False branch is Ctrl (live)');
+};
+
+# Test 8: Different predicates - no optimization
+subtest 'Different predicates are not optimized' => sub {
+    my $start = Chalk::IR::Node::Start->new(
+        function => 'test',
+        params => [],
+    );
+
+    my $ctrl = Chalk::IR::Node::Proj->new(
+        inputs => [$start->id],
+        index => 0,
+        label => '$ctrl',
+        source => $start,
+    );
+
+    # Variables $x and $y - use VariableRead for non-constant values
+    my $x = Chalk::IR::Node::VariableRead->new(
+        inputs => [],
+        var_label => 'lexical:$x',
+    );
+
+    my $y = Chalk::IR::Node::VariableRead->new(
+        inputs => [],
+        var_label => 'lexical:$y',
+    );
+
+    my $zero = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type => 'Integer',
+    );
+
+    # Outer: $x > 0 (non-constant)
+    my $cond1 = Chalk::IR::Node::GT->new(
+        left => $x,
+        right => $zero,
+    );
+
+    # Inner: $y > 0 (different predicate, also non-constant)
+    my $cond2 = Chalk::IR::Node::GT->new(
+        left => $y,
+        right => $zero,
+    );
+
+    my $outer_if = Chalk::IR::Node::If->new(
+        inputs => [$ctrl->id, $cond1->id],
+        condition_id => $cond1->id,
+        control => $ctrl,
+        condition => $cond1,
+    );
+
+    my $outer_true = Chalk::IR::Node::Proj->new(
+        inputs => [$outer_if->id],
+        index => 0,
+        label => 'true',
+        source => $outer_if,
+    );
+
+    # Inner If with DIFFERENT predicate
+    my $inner_if = Chalk::IR::Node::If->new(
+        inputs => [$outer_true->id, $cond2->id],  # Different condition!
+        condition_id => $cond2->id,
+        control => $outer_true,
+        condition => $cond2,
+    );
+
+    my $inner_type = $inner_if->compute();
+
+    # Both branches should be reachable (IF_BOTH)
+    ok($inner_type isa Chalk::IR::Type::TypeTuple, 'Inner If compute() returns TypeTuple');
+
+    my $true_ctrl = $inner_type->at(0);
+    my $false_ctrl = $inner_type->at(1);
+
+    # Both should be live (TypeCtrl or at least not Bottom)
+    ok(!($true_ctrl isa Chalk::IR::Type::Bottom), 'True branch is live');
+    ok(!($false_ctrl isa Chalk::IR::Type::Bottom), 'False branch is live');
+};
+
+done_testing();


### PR DESCRIPTION
## Summary

Implements dominator-based optimization for nested `if` statements with identical predicates, as described in Simple's Chapter 6.

- Add `idom()` and `idepth()` methods to CFG nodes for dominator tree calculation
- Add `compute()` to If node that walks the dominator tree to detect nested If statements with identical predicates
- When found, returns IF_TRUE or IF_FALSE tuple indicating which branch is predetermined

## Changes

**Files changed: 5, Lines added: +583**

### Implementation

- **Start.pm**: Root of dominator tree (`idom()` returns `undef`, `idepth()` returns 0)
- **Proj.pm**: Uses source node to determine `idom` (If's control input for If projections)
- **Region.pm**: Computes LCA (lowest common ancestor) of control inputs using parallel tree traversal
- **If.pm**: Added `compute()` that detects nested Ifs with identical predicates by walking the dominator tree

### Tests

- **t/sea-of-nodes/dominator.t**: Comprehensive tests for dominator calculation and nested If optimization

## Test plan

- [x] Run dominator tests: `prove t/sea-of-nodes/dominator.t`
- [x] Run chapter06 tests: `prove t/sea-of-nodes/chapter06.t`
- [x] Run optimizer tests: `prove t/sea-of-nodes/compute.t t/sea-of-nodes/idealize.t t/sea-of-nodes/dce.t`
- [x] Verify no regressions in other node tests

## Related Issues

Closes #241