### PR TITLE
feat(ir): Implement singleUniqueInput optimization for Phi nodes

### DIFF
--- a/lib/Chalk/IR/Node/Phi.pm
+++ b/lib/Chalk/IR/Node/Phi.pm
@@ -57,6 +57,33 @@ class Chalk::IR::Node::Phi :isa(Chalk::IR::Node::Base) {
     method peephole($graph = undef) {
         return $self unless $graph;
 
+        my @inputs = $self->inputs->@*;
+
+        # singleUniqueInput optimization: if all data inputs are the same node, return that node
+        # Data inputs start at index 1 (index 0 is region_id)
+        # BUT only for Region-based phis, not Loop-based phis
+        if (@inputs > 1) {
+            # Check if control is a Loop - if so, don't apply singleUniqueInput
+            my $control_node = $graph->get_node($region_id);
+            my $is_loop = $control_node && $control_node->op eq 'Loop';
+
+            if (!$is_loop) {
+                my @data_inputs = @inputs[1..$#inputs];
+                my $first = $data_inputs[0];
+                my $all_same = 1;
+                for my $input (@data_inputs[1..$#data_inputs]) {
+                    if ($input ne $first) {
+                        $all_same = 0;
+                        last;
+                    }
+                }
+                if ($all_same && defined $first) {
+                    my $node = $graph->get_node($first);
+                    return $node if $node;
+                }
+            }
+        }
+
         # Get the Region node
         my $region_node = $graph->get_node($region_id);
         return $self unless $region_node;

--- a/t/sea-of-nodes/chapter07.t
+++ b/t/sea-of-nodes/chapter07.t
@@ -13,6 +13,9 @@ use Chalk::IR::Node;
 use Chalk::IR::Graph;
 use Chalk::IR::Node::Scope;
 use Chalk::IR::Validator;
+use Chalk::IR::Node::Region;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Node::Phi;
 
 subtest 'Loop node creation' => sub {
     my $graph = Chalk::IR::Graph->new();
@@ -633,4 +636,71 @@ subtest 'Peephole does not optimize across loop boundaries' => sub {
     # Should not simplify to constant even though init is constant
     isnt $optimized->op, 'Constant', 'Loop phi not constant folded';
     is $optimized->id, $phi->id, 'Loop phi preserved';
+};
+
+subtest 'Phi singleUniqueInput optimization: all inputs same node' => sub {
+    # When all data inputs to a Phi are the same node, simplify to that node
+    # Phi(region, x, x, x) → x
+    my $graph = Chalk::IR::Graph->new();
+
+    # Region node with two control inputs
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [0, 0],  # Two control inputs
+    );
+    $graph->add_node($region);
+
+    # The single data value that all Phi inputs point to
+    my $const_42 = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_42);
+
+    # Phi with all inputs being the same node
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $const_42->id, $const_42->id],  # Both data inputs are const_42
+    );
+    $graph->add_node($phi);
+
+    my $optimized = $phi->peephole($graph);
+
+    # Should simplify to the single unique input
+    is $optimized->id, $const_42->id, 'Phi with same inputs simplifies to that input';
+    is $optimized->op, 'Constant', 'Simplified to Constant node';
+};
+
+subtest 'Phi singleUniqueInput: different inputs should NOT simplify' => sub {
+    # When data inputs are different, Phi should NOT simplify
+    my $graph = Chalk::IR::Graph->new();
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [0, 0],
+    );
+    $graph->add_node($region);
+
+    my $const_1 = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1);
+
+    my $const_2 = Chalk::IR::Node::Constant->new(
+        value => 2,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_2);
+
+    # Phi with different inputs
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $const_1->id, $const_2->id],
+    );
+    $graph->add_node($phi);
+
+    my $optimized = $phi->peephole($graph);
+
+    # Should NOT simplify
+    is $optimized->id, $phi->id, 'Phi with different inputs is preserved';
+    is $optimized->op, 'Phi', 'Still a Phi node';
 };


### PR DESCRIPTION
## Summary

- Adds `singleUniqueInput` optimization to Phi node peephole: when all data inputs point to the same node, the Phi simplifies to that node
- Only applies to Region-based phis, not Loop-based phis (to preserve loop semantics)
- Includes tests for both positive case (same inputs → simplify) and negative case (different inputs → preserve)

## Test plan

- [x] New subtests added to `t/sea-of-nodes/chapter07.t`
- [x] All 484 sea-of-nodes tests pass
- [x] Existing loop phi tests continue to pass (no regression)

## Changes

- `lib/Chalk/IR/Node/Phi.pm`: Added singleUniqueInput check before existing single-live-input optimization
- `t/sea-of-nodes/chapter07.t`: Added 2 new subtests with polymorphic node classes

Fixes #252

## Related Issues

- #252 - Phi singleUniqueInput Optimization