### PR TITLE
feat(ir): Implement Phi operation pulling optimization

### DIFF
--- a/lib/Chalk/IR/Node/Phi.pm
+++ b/lib/Chalk/IR/Node/Phi.pm
@@ -5,6 +5,10 @@ use experimental qw(class);
 use utf8;
 
 class Chalk::IR::Node::Phi :isa(Chalk::IR::Node::Base) {
+    use Chalk::IR::Node::Add;
+    use Chalk::IR::Node::Multiply;
+    use Chalk::IR::Node::Subtract;
+    use Chalk::IR::Node::Divide;
     field $region_id :param :reader;
 
     method op() { 'Phi' }
@@ -109,7 +113,100 @@ class Chalk::IR::Node::Phi :isa(Chalk::IR::Node::Base) {
             }
         }
 
+        # Operation pulling: Phi(region, Op(a,b), Op(c,d)) -> Op(Phi(region,a,c), Phi(region,b,d))
+        if (my $idealized = $self->idealize($graph)) {
+            return $idealized->peephole($graph);
+        }
+
         return $self;
+    }
+
+    # Idealize: algebraic simplification for Phi nodes
+    # Implements operation pulling optimization from Simple compiler
+    method idealize($graph = undef) {
+        return unless $graph;
+
+        my @inputs = $self->inputs->@*;
+        return unless @inputs > 2;  # Need region + at least 2 data inputs
+
+        # Check if control is a Loop - if so, don't apply operation pulling
+        my $control_node = $graph->get_node($region_id);
+        return if $control_node && $control_node->op eq 'Loop';
+
+        # Get all data input nodes
+        my @data_inputs = @inputs[1..$#inputs];
+        my @data_nodes = map { $graph->get_node($_) } @data_inputs;
+
+        # Verify all data input nodes exist
+        return if grep { !defined $_ } @data_nodes;
+
+        # Check if all data inputs have the same operation type
+        my $first_op = $data_nodes[0]->op;
+
+        # Skip CFG nodes - only pull data operations
+        my %cfg_ops = (
+            Region => 1, Loop => 1, If => 1, Proj => 1,
+            Start => 1, Return => 1, Stop => 1,
+        );
+        return if $cfg_ops{$first_op};
+
+        # Skip Phi and Constant - no benefit from pulling these
+        return if $first_op eq 'Phi';
+        return if $first_op eq 'Constant';
+
+        # Check all inputs have the same op
+        for my $node (@data_nodes[1..$#data_nodes]) {
+            return unless $node->op eq $first_op;
+        }
+
+        # Check all operations have left/right accessors (binary ops)
+        for my $node (@data_nodes) {
+            return unless $node->can('left') && $node->can('right');
+        }
+
+        # All data inputs have the same binary operation
+        # Create new Phi nodes for left and right operands
+
+        # Collect left operands from each input
+        my @left_nodes = map { $_->left } @data_nodes;
+        my @left_ids = map { $_->id } @left_nodes;
+
+        # Collect right operands from each input
+        my @right_nodes = map { $_->right } @data_nodes;
+        my @right_ids = map { $_->id } @right_nodes;
+
+        # Create Phi for left operands
+        my $left_phi = Chalk::IR::Node::Phi->new(
+            region_id => $region_id,
+            inputs => [$region_id, @left_ids],
+        );
+        $graph->add_node($left_phi);
+
+        # Create Phi for right operands
+        my $right_phi = Chalk::IR::Node::Phi->new(
+            region_id => $region_id,
+            inputs => [$region_id, @right_ids],
+        );
+        $graph->add_node($right_phi);
+
+        # Create the pulled-out operation with the new Phi nodes
+        my %op_class = (
+            Add      => 'Chalk::IR::Node::Add',
+            Subtract => 'Chalk::IR::Node::Subtract',
+            Multiply => 'Chalk::IR::Node::Multiply',
+            Divide   => 'Chalk::IR::Node::Divide',
+        );
+
+        my $op_class = $op_class{$first_op};
+        return unless $op_class;
+
+        my $new_op = $op_class->new(
+            left  => $left_phi,
+            right => $right_phi,
+        );
+        $graph->add_node($new_op);
+
+        return $new_op;
     }
 }
 

--- a/t/sea-of-nodes/phi-operation-pulling.t
+++ b/t/sea-of-nodes/phi-operation-pulling.t
@@ -1,0 +1,286 @@
+#!/usr/bin/env perl
+# ABOUTME: Test Phi operation pulling optimization (Issue #253)
+# ABOUTME: Validates that Phi(region, Op(a,b), Op(c,d)) -> Op(Phi(region,a,c), Phi(region,b,d))
+
+use lib 'lib';
+use 5.42.0;
+use Test2::V0;
+use FindBin qw($RealBin);
+use experimental qw(defer);
+defer { done_testing() }
+
+use Chalk::IR::Node;
+use Chalk::IR::Graph;
+use Chalk::IR::Node::Region;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Node::Phi;
+use Chalk::IR::Node::Add;
+use Chalk::IR::Node::Multiply;
+
+# Test 1: Basic operation pulling with Add
+subtest 'Phi operation pulling: Phi(region, Add(a,b), Add(c,d)) -> Add(Phi(a,c), Phi(b,d))' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Region node with two control inputs
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [0, 0],  # Two control inputs
+    );
+    $graph->add_node($region);
+
+    # Create constants for Add inputs
+    my $a = Chalk::IR::Node::Constant->new(value => 1, type => 'Integer');
+    my $b = Chalk::IR::Node::Constant->new(value => 2, type => 'Integer');
+    my $c = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+    my $d = Chalk::IR::Node::Constant->new(value => 4, type => 'Integer');
+    $graph->add_node($a);
+    $graph->add_node($b);
+    $graph->add_node($c);
+    $graph->add_node($d);
+
+    # Create Add nodes: Add(a, b) and Add(c, d)
+    my $add1 = Chalk::IR::Node::Add->new(left => $a, right => $b);
+    my $add2 = Chalk::IR::Node::Add->new(left => $c, right => $d);
+    $graph->add_node($add1);
+    $graph->add_node($add2);
+
+    # Create Phi with both Add nodes as data inputs
+    # Phi inputs: [region_id, value1, value2]
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $add1->id, $add2->id],
+    );
+    $graph->add_node($phi);
+
+    # Apply peephole optimization
+    my $optimized = $phi->peephole($graph);
+
+    # Should be transformed to Add(Phi(a,c), Phi(b,d))
+    is($optimized->op, 'Add', 'Result is Add node (operation pulled out)');
+    isnt($optimized->id, $phi->id, 'A new node was created');
+
+    # The Add's inputs should be Phi nodes
+    # Note: Add node stores left/right as node references, not IDs
+    ok($optimized->left, 'Add has left operand');
+    ok($optimized->right, 'Add has right operand');
+    is($optimized->left->op, 'Phi', 'Left operand is Phi');
+    is($optimized->right->op, 'Phi', 'Right operand is Phi');
+};
+
+# Test 2: No pulling when operations differ
+subtest 'Phi does NOT pull when operations differ' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [0, 0],
+    );
+    $graph->add_node($region);
+
+    my $a = Chalk::IR::Node::Constant->new(value => 1, type => 'Integer');
+    my $b = Chalk::IR::Node::Constant->new(value => 2, type => 'Integer');
+    my $c = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+    my $d = Chalk::IR::Node::Constant->new(value => 4, type => 'Integer');
+    $graph->add_node($a);
+    $graph->add_node($b);
+    $graph->add_node($c);
+    $graph->add_node($d);
+
+    # Create Add and Multiply nodes (different operations)
+    my $add = Chalk::IR::Node::Add->new(left => $a, right => $b);
+    my $mul = Chalk::IR::Node::Multiply->new(left => $c, right => $d);
+    $graph->add_node($add);
+    $graph->add_node($mul);
+
+    # Create Phi with different operation types
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $add->id, $mul->id],
+    );
+    $graph->add_node($phi);
+
+    my $optimized = $phi->peephole($graph);
+
+    # Should NOT transform - operations differ
+    is($optimized->op, 'Phi', 'Phi preserved when ops differ');
+    is($optimized->id, $phi->id, 'Same Phi node returned');
+};
+
+# Test 3: No pulling when one input is a constant (different op)
+subtest 'Phi does NOT pull when input types differ' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [0, 0],
+    );
+    $graph->add_node($region);
+
+    my $a = Chalk::IR::Node::Constant->new(value => 1, type => 'Integer');
+    my $b = Chalk::IR::Node::Constant->new(value => 2, type => 'Integer');
+    my $c = Chalk::IR::Node::Constant->new(value => 5, type => 'Integer');
+    $graph->add_node($a);
+    $graph->add_node($b);
+    $graph->add_node($c);
+
+    my $add = Chalk::IR::Node::Add->new(left => $a, right => $b);
+    $graph->add_node($add);
+
+    # Phi with Add and Constant (different op types)
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $add->id, $c->id],
+    );
+    $graph->add_node($phi);
+
+    my $optimized = $phi->peephole($graph);
+
+    # Should NOT transform
+    is($optimized->op, 'Phi', 'Phi preserved when input types differ');
+};
+
+# Test 4: Pulling with Multiply operations
+subtest 'Phi operation pulling works with Multiply' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [0, 0],
+    );
+    $graph->add_node($region);
+
+    my $a = Chalk::IR::Node::Constant->new(value => 2, type => 'Integer');
+    my $b = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+    my $c = Chalk::IR::Node::Constant->new(value => 4, type => 'Integer');
+    my $d = Chalk::IR::Node::Constant->new(value => 5, type => 'Integer');
+    $graph->add_node($a);
+    $graph->add_node($b);
+    $graph->add_node($c);
+    $graph->add_node($d);
+
+    my $mul1 = Chalk::IR::Node::Multiply->new(left => $a, right => $b);
+    my $mul2 = Chalk::IR::Node::Multiply->new(left => $c, right => $d);
+    $graph->add_node($mul1);
+    $graph->add_node($mul2);
+
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $mul1->id, $mul2->id],
+    );
+    $graph->add_node($phi);
+
+    my $optimized = $phi->peephole($graph);
+
+    is($optimized->op, 'Multiply', 'Result is Multiply node');
+    is($optimized->left->op, 'Phi', 'Left operand is Phi');
+    is($optimized->right->op, 'Phi', 'Right operand is Phi');
+};
+
+# Test 5: No pulling from Loop-based Phis (loop phis have different semantics)
+subtest 'Phi does NOT pull from Loop-based Phi' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Loop node instead of Region
+    my $loop = Chalk::IR::Node->new(
+        id => 'loop_1',
+        op => 'Loop',
+        inputs => [0],
+        attributes => {},
+    );
+    $graph->add_node($loop);
+
+    my $a = Chalk::IR::Node::Constant->new(value => 1, type => 'Integer');
+    my $b = Chalk::IR::Node::Constant->new(value => 2, type => 'Integer');
+    my $c = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+    my $d = Chalk::IR::Node::Constant->new(value => 4, type => 'Integer');
+    $graph->add_node($a);
+    $graph->add_node($b);
+    $graph->add_node($c);
+    $graph->add_node($d);
+
+    my $add1 = Chalk::IR::Node::Add->new(left => $a, right => $b);
+    my $add2 = Chalk::IR::Node::Add->new(left => $c, right => $d);
+    $graph->add_node($add1);
+    $graph->add_node($add2);
+
+    # Phi with Loop as control
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $add1->id, $add2->id],
+    );
+    $graph->add_node($phi);
+
+    my $optimized = $phi->peephole($graph);
+
+    # Should NOT transform Loop-based phis
+    is($optimized->op, 'Phi', 'Loop Phi preserved');
+    is($optimized->id, $phi->id, 'Same Phi node returned for Loop');
+};
+
+# Test 6: Three-way Region with same operations
+subtest 'Phi operation pulling with three inputs' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [0, 0, 0],  # Three control inputs
+    );
+    $graph->add_node($region);
+
+    my $a = Chalk::IR::Node::Constant->new(value => 1, type => 'Integer');
+    my $b = Chalk::IR::Node::Constant->new(value => 2, type => 'Integer');
+    my $c = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+    my $d = Chalk::IR::Node::Constant->new(value => 4, type => 'Integer');
+    my $e = Chalk::IR::Node::Constant->new(value => 5, type => 'Integer');
+    my $f = Chalk::IR::Node::Constant->new(value => 6, type => 'Integer');
+    $graph->add_node($a);
+    $graph->add_node($b);
+    $graph->add_node($c);
+    $graph->add_node($d);
+    $graph->add_node($e);
+    $graph->add_node($f);
+
+    my $add1 = Chalk::IR::Node::Add->new(left => $a, right => $b);
+    my $add2 = Chalk::IR::Node::Add->new(left => $c, right => $d);
+    my $add3 = Chalk::IR::Node::Add->new(left => $e, right => $f);
+    $graph->add_node($add1);
+    $graph->add_node($add2);
+    $graph->add_node($add3);
+
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $add1->id, $add2->id, $add3->id],
+    );
+    $graph->add_node($phi);
+
+    my $optimized = $phi->peephole($graph);
+
+    is($optimized->op, 'Add', 'Result is Add node with 3 inputs');
+    is($optimized->left->op, 'Phi', 'Left operand is Phi');
+    is($optimized->right->op, 'Phi', 'Right operand is Phi');
+};
+
+# Test 7: Single data input - no pulling needed (singleUniqueInput handles this)
+subtest 'Phi with single data input uses singleUniqueInput optimization instead' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [0],  # Single control input
+    );
+    $graph->add_node($region);
+
+    my $a = Chalk::IR::Node::Constant->new(value => 1, type => 'Integer');
+    my $b = Chalk::IR::Node::Constant->new(value => 2, type => 'Integer');
+    $graph->add_node($a);
+    $graph->add_node($b);
+
+    my $add = Chalk::IR::Node::Add->new(left => $a, right => $b);
+    $graph->add_node($add);
+
+    # Phi with single data input
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $add->id],
+    );
+    $graph->add_node($phi);
+
+    my $optimized = $phi->peephole($graph);
+
+    # singleUniqueInput should simplify to the single Add input
+    is($optimized->id, $add->id, 'Single input Phi simplifies to the input');
+};


### PR DESCRIPTION
## Summary
- Implements operation pulling optimization for Phi nodes as described in the Simple compiler chapter 7
- When all data inputs to a Phi have the same binary operation: `Phi(region, Add(a,b), Add(c,d))` becomes `Add(Phi(region,a,c), Phi(region,b,d))`
- Adds `idealize()` method to Phi.pm following the established pattern
- Comprehensive test suite with 7 subtests covering success cases and edge cases

## Test plan
- [x] Unit tests pass for basic operation pulling (Add, Multiply)
- [x] Unit tests verify no pulling when operations differ
- [x] Unit tests verify no pulling for Loop-based Phis
- [x] Unit tests verify three-way Region support
- [x] Full sea-of-nodes test suite passes (30 files, 484 tests)

Closes #253

## Related Issues
- Builds on #252 (singleUniqueInput optimization)
- Builds on #246 (lazy phi creation)