### PR TITLE
test(chapter07): Add nested loop and conditional-in-loop tests (#267)

### DIFF
--- a/t/sea-of-nodes/chapter07.t
+++ b/t/sea-of-nodes/chapter07.t
@@ -1892,3 +1892,244 @@ subtest 'While with if-else and increment (with peephole)' => sub {
     is $optimized->right->op, 'Constant', 'Right is Constant';
     is $optimized->right->attributes->{value}, 1, 'Right value is 1';
 };
+
+# ============================================================================
+# Regression test: conditional with while in else branch
+# Matches Simple chapter07 testRegression pattern
+# ============================================================================
+
+subtest 'Conditional with while in else (no peephole)' => sub {
+    # Simple: if(arg) return 1; int a = 1; while(a < arg) { a = a + 1; } return a;
+    # Expected: Phi(Region,1,Phi(Loop,1,(Phi_a+1)))
+    # True branch returns 1, false branch runs a while loop
+    my $graph = Chalk::IR::Graph->new();
+
+    my $start = Chalk::IR::Node->new(
+        id => 1,
+        op => 'Start',
+        inputs => [],
+        attributes => {},
+    );
+    $graph->add_node($start);
+
+    # arg (some input value)
+    my $arg = Chalk::IR::Node::Constant->new(
+        value => 10,  # Arbitrary non-zero value for testing structure
+        type  => 'Integer',
+    );
+    $graph->add_node($arg);
+
+    # if(arg) - conditional on arg
+    my $if_node = Chalk::IR::Node->new(
+        id => 3,
+        op => 'If',
+        inputs => [$start->id, $arg->id],
+        attributes => {},
+    );
+    $graph->add_node($if_node);
+
+    # True branch projection
+    my $proj_true = Chalk::IR::Node->new(
+        id => 4,
+        op => 'Proj',
+        inputs => [$if_node->id],
+        attributes => { index => 0 },
+    );
+    $graph->add_node($proj_true);
+
+    # False branch projection
+    my $proj_false = Chalk::IR::Node->new(
+        id => 5,
+        op => 'Proj',
+        inputs => [$if_node->id],
+        attributes => { index => 1 },
+    );
+    $graph->add_node($proj_false);
+
+    # True branch: return 1
+    my $const_1_true = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1_true);
+
+    # False branch: int a = 1; while(a < arg) { a = a + 1; } return a;
+    my $init_a = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_a);
+
+    # Loop in false branch
+    my $loop = Chalk::IR::Node->new(
+        id => 8,
+        op => 'Loop',
+        inputs => [$proj_false->id],
+        attributes => {},
+    );
+    $graph->add_node($loop);
+
+    # Loop phi for a
+    my $phi_a = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $init_a->id],
+    );
+    $graph->add_node($phi_a);
+
+    # a = a + 1
+    my $const_1_loop = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1_loop);
+
+    my $a_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_a,
+        right => $const_1_loop,
+    );
+    $graph->add_node($a_plus_1);
+
+    # Update loop backedges
+    push $phi_a->inputs->@*, $a_plus_1->id;
+    push $loop->inputs->@*, $loop->id;
+
+    # Region merges true branch (early return) and false branch (loop exit)
+    my $merge_region = Chalk::IR::Node::Region->new(
+        inputs => [$proj_true->id, $loop->id],
+    );
+    $graph->add_node($merge_region);
+
+    # Final Phi: Phi(Region, 1, Phi(Loop, 1, a+1))
+    # Selects between true branch's 1 and loop's final phi_a
+    my $result_phi = Chalk::IR::Node::Phi->new(
+        region_id => $merge_region->id,
+        inputs => [$merge_region->id, $const_1_true->id, $phi_a->id],
+    );
+    $graph->add_node($result_phi);
+
+    # Verify structure: Phi(Region,1,Phi(Loop,1,(Phi_a+1)))
+    is $result_phi->op, 'Phi', 'Result is Phi';
+    my @result_inputs = $result_phi->inputs->@*;
+    is scalar(@result_inputs), 3, 'Result Phi has 3 inputs';
+
+    # First data input: constant 1 (true branch)
+    my $true_input = $graph->get_node($result_inputs[1]);
+    is $true_input->op, 'Constant', 'True branch input is Constant';
+    is $true_input->attributes->{value}, 1, 'True branch returns 1';
+
+    # Second data input: loop Phi
+    my $loop_input = $graph->get_node($result_inputs[2]);
+    is $loop_input->op, 'Phi', 'False branch input is Phi (from loop)';
+
+    # Verify inner loop Phi structure
+    my @loop_phi_inputs = $loop_input->inputs->@*;
+    is scalar(@loop_phi_inputs), 3, 'Loop Phi has 3 inputs';
+
+    my $loop_init = $graph->get_node($loop_phi_inputs[1]);
+    is $loop_init->attributes->{value}, 1, 'Loop init is 1';
+
+    my $loop_update = $graph->get_node($loop_phi_inputs[2]);
+    is $loop_update->op, 'Add', 'Loop update is Add (a+1)';
+};
+
+subtest 'Conditional with while in else (with peephole)' => sub {
+    # Same structure - peephole should preserve it (no optimization opportunity)
+    my $graph = Chalk::IR::Graph->new();
+
+    my $start = Chalk::IR::Node->new(
+        id => 1,
+        op => 'Start',
+        inputs => [],
+        attributes => {},
+    );
+    $graph->add_node($start);
+
+    my $arg = Chalk::IR::Node::Constant->new(
+        value => 10,
+        type  => 'Integer',
+    );
+    $graph->add_node($arg);
+
+    my $if_node = Chalk::IR::Node->new(
+        id => 3,
+        op => 'If',
+        inputs => [$start->id, $arg->id],
+        attributes => {},
+    );
+    $graph->add_node($if_node);
+
+    my $proj_true = Chalk::IR::Node->new(
+        id => 4,
+        op => 'Proj',
+        inputs => [$if_node->id],
+        attributes => { index => 0 },
+    );
+    $graph->add_node($proj_true);
+
+    my $proj_false = Chalk::IR::Node->new(
+        id => 5,
+        op => 'Proj',
+        inputs => [$if_node->id],
+        attributes => { index => 1 },
+    );
+    $graph->add_node($proj_false);
+
+    my $const_1_true = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1_true);
+
+    my $init_a = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_a);
+
+    my $loop = Chalk::IR::Node->new(
+        id => 8,
+        op => 'Loop',
+        inputs => [$proj_false->id],
+        attributes => {},
+    );
+    $graph->add_node($loop);
+
+    my $phi_a = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $init_a->id],
+    );
+    $graph->add_node($phi_a);
+
+    my $const_1_loop = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1_loop);
+
+    my $a_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_a,
+        right => $const_1_loop,
+    );
+    $graph->add_node($a_plus_1);
+
+    push $phi_a->inputs->@*, $a_plus_1->id;
+    push $loop->inputs->@*, $loop->id;
+
+    my $merge_region = Chalk::IR::Node::Region->new(
+        inputs => [$proj_true->id, $loop->id],
+    );
+    $graph->add_node($merge_region);
+
+    my $result_phi = Chalk::IR::Node::Phi->new(
+        region_id => $merge_region->id,
+        inputs => [$merge_region->id, $const_1_true->id, $phi_a->id],
+    );
+    $graph->add_node($result_phi);
+
+    # Apply peephole to result phi
+    my $optimized = $result_phi->peephole($graph);
+
+    # Should preserve structure (both inputs are different)
+    is $optimized->op, 'Phi', 'Peephole preserves Phi';
+    is $optimized->id, $result_phi->id, 'Same Phi node (no simplification)';
+};

--- a/t/sea-of-nodes/chapter07.t
+++ b/t/sea-of-nodes/chapter07.t
@@ -1258,3 +1258,637 @@ subtest 'While with variable shadowing (with peephole)' => sub {
     is $optimized->right->op, 'Constant', 'Right is Constant';
     is $optimized->right->attributes->{value}, 3, 'Constants combined: 1+2=3';
 };
+
+# ============================================================================
+# Nested loops and conditional-in-loop tests
+# These tests match Simple chapter07 testWhileNested, testWhileScope patterns
+# ============================================================================
+
+subtest 'Nested while loops (no peephole)' => sub {
+    # Simple: int i=0; int sum=0; while(i < 100) { int j=0; while(j < 10) { sum = sum + j; j = j + 1; } i = i + 1; } return sum;
+    # Expected structure: Phi(OuterLoop,0,Phi(InnerLoop,Phi_sum,(Phi_j+Phi_sum)))
+    my $graph = Chalk::IR::Graph->new();
+
+    my $start = Chalk::IR::Node->new(
+        id => 1,
+        op => 'Start',
+        inputs => [],
+        attributes => {},
+    );
+    $graph->add_node($start);
+
+    # Initial: i = 0, sum = 0
+    my $init_i = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_i);
+
+    my $init_sum = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_sum);
+
+    # Outer loop
+    my $outer_loop = Chalk::IR::Node->new(
+        id => 4,
+        op => 'Loop',
+        inputs => [$start->id],
+        attributes => {},
+    );
+    $graph->add_node($outer_loop);
+
+    # Outer loop phi for i
+    my $phi_i = Chalk::IR::Node::Phi->new(
+        region_id => $outer_loop->id,
+        inputs => [$outer_loop->id, $init_i->id],
+    );
+    $graph->add_node($phi_i);
+
+    # Outer loop phi for sum (this will be updated by inner loop)
+    my $phi_sum_outer = Chalk::IR::Node::Phi->new(
+        region_id => $outer_loop->id,
+        inputs => [$outer_loop->id, $init_sum->id],
+    );
+    $graph->add_node($phi_sum_outer);
+
+    # Inner loop: j = 0
+    my $init_j = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_j);
+
+    my $inner_loop = Chalk::IR::Node->new(
+        id => 8,
+        op => 'Loop',
+        inputs => [$outer_loop->id],  # Inner loop's entry is from outer loop
+        attributes => {},
+    );
+    $graph->add_node($inner_loop);
+
+    # Inner loop phi for j
+    my $phi_j = Chalk::IR::Node::Phi->new(
+        region_id => $inner_loop->id,
+        inputs => [$inner_loop->id, $init_j->id],
+    );
+    $graph->add_node($phi_j);
+
+    # Inner loop phi for sum (carries sum from outer to inner)
+    my $phi_sum_inner = Chalk::IR::Node::Phi->new(
+        region_id => $inner_loop->id,
+        inputs => [$inner_loop->id, $phi_sum_outer->id],
+    );
+    $graph->add_node($phi_sum_inner);
+
+    # sum = sum + j
+    my $sum_plus_j = Chalk::IR::Node::Add->new(
+        left  => $phi_sum_inner,
+        right => $phi_j,
+    );
+    $graph->add_node($sum_plus_j);
+
+    # j = j + 1
+    my $const_1 = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1);
+
+    my $j_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_j,
+        right => $const_1,
+    );
+    $graph->add_node($j_plus_1);
+
+    # Update inner loop backedges
+    push $phi_j->inputs->@*, $j_plus_1->id;
+    push $phi_sum_inner->inputs->@*, $sum_plus_j->id;
+    push $inner_loop->inputs->@*, $inner_loop->id;
+
+    # i = i + 1 (after inner loop)
+    my $i_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_i,
+        right => $const_1,
+    );
+    $graph->add_node($i_plus_1);
+
+    # Update outer loop backedges
+    push $phi_i->inputs->@*, $i_plus_1->id;
+    push $phi_sum_outer->inputs->@*, $phi_sum_inner->id;  # sum from inner loop
+    push $outer_loop->inputs->@*, $outer_loop->id;
+
+    # Verify nested loop structure
+    is $outer_loop->op, 'Loop', 'Outer loop exists';
+    is $inner_loop->op, 'Loop', 'Inner loop exists';
+    is $phi_sum_outer->op, 'Phi', 'Outer sum phi exists';
+    is $phi_sum_inner->op, 'Phi', 'Inner sum phi exists';
+    is $sum_plus_j->op, 'Add', 'sum + j operation exists';
+    is $sum_plus_j->left->op, 'Phi', 'Add left is Phi (inner sum)';
+    is $sum_plus_j->right->op, 'Phi', 'Add right is Phi (j)';
+};
+
+subtest 'Nested while loops (with peephole)' => sub {
+    # Same structure, but peephole should not change nested loop structure
+    # (no constant folding opportunity in this pattern)
+    my $graph = Chalk::IR::Graph->new();
+
+    my $start = Chalk::IR::Node->new(
+        id => 1,
+        op => 'Start',
+        inputs => [],
+        attributes => {},
+    );
+    $graph->add_node($start);
+
+    my $init_i = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_i);
+
+    my $init_sum = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_sum);
+
+    my $outer_loop = Chalk::IR::Node->new(
+        id => 4,
+        op => 'Loop',
+        inputs => [$start->id],
+        attributes => {},
+    );
+    $graph->add_node($outer_loop);
+
+    my $phi_i = Chalk::IR::Node::Phi->new(
+        region_id => $outer_loop->id,
+        inputs => [$outer_loop->id, $init_i->id],
+    );
+    $graph->add_node($phi_i);
+
+    my $phi_sum_outer = Chalk::IR::Node::Phi->new(
+        region_id => $outer_loop->id,
+        inputs => [$outer_loop->id, $init_sum->id],
+    );
+    $graph->add_node($phi_sum_outer);
+
+    my $init_j = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_j);
+
+    my $inner_loop = Chalk::IR::Node->new(
+        id => 8,
+        op => 'Loop',
+        inputs => [$outer_loop->id],
+        attributes => {},
+    );
+    $graph->add_node($inner_loop);
+
+    my $phi_j = Chalk::IR::Node::Phi->new(
+        region_id => $inner_loop->id,
+        inputs => [$inner_loop->id, $init_j->id],
+    );
+    $graph->add_node($phi_j);
+
+    my $phi_sum_inner = Chalk::IR::Node::Phi->new(
+        region_id => $inner_loop->id,
+        inputs => [$inner_loop->id, $phi_sum_outer->id],
+    );
+    $graph->add_node($phi_sum_inner);
+
+    my $sum_plus_j = Chalk::IR::Node::Add->new(
+        left  => $phi_sum_inner,
+        right => $phi_j,
+    );
+    $graph->add_node($sum_plus_j);
+
+    my $const_1 = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1);
+
+    my $j_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_j,
+        right => $const_1,
+    );
+    $graph->add_node($j_plus_1);
+
+    push $phi_j->inputs->@*, $j_plus_1->id;
+    push $phi_sum_inner->inputs->@*, $sum_plus_j->id;
+    push $inner_loop->inputs->@*, $inner_loop->id;
+
+    my $i_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_i,
+        right => $const_1,
+    );
+    $graph->add_node($i_plus_1);
+
+    push $phi_i->inputs->@*, $i_plus_1->id;
+    push $phi_sum_outer->inputs->@*, $phi_sum_inner->id;
+    push $outer_loop->inputs->@*, $outer_loop->id;
+
+    # Apply peephole - should preserve structure (no optimization opportunity)
+    my $optimized = $sum_plus_j->peephole($graph);
+
+    # sum + j has no constant folding opportunity
+    is $optimized->op, 'Add', 'Result is still Add';
+    is $optimized->left->op, 'Phi', 'Left is still Phi';
+    is $optimized->right->op, 'Phi', 'Right is still Phi';
+};
+
+subtest 'While with conditional inside (no peephole)' => sub {
+    # Simple: int b = 2; while(a < 10) { if(a == 2) b = 4; a = a + 1; } return b;
+    # Expected: Phi(Loop,2,Phi(Region,Phi_b,4))
+    my $graph = Chalk::IR::Graph->new();
+
+    my $start = Chalk::IR::Node->new(
+        id => 1,
+        op => 'Start',
+        inputs => [],
+        attributes => {},
+    );
+    $graph->add_node($start);
+
+    # Initial: a = arg (assume 0), b = 2
+    my $init_a = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_a);
+
+    my $init_b = Chalk::IR::Node::Constant->new(
+        value => 2,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_b);
+
+    my $loop = Chalk::IR::Node->new(
+        id => 4,
+        op => 'Loop',
+        inputs => [$start->id],
+        attributes => {},
+    );
+    $graph->add_node($loop);
+
+    # Loop phi for a
+    my $phi_a = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $init_a->id],
+    );
+    $graph->add_node($phi_a);
+
+    # Loop phi for b
+    my $phi_b = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $init_b->id],
+    );
+    $graph->add_node($phi_b);
+
+    # Inside loop: if(a == 2) b = 4
+    # This creates a Region with two control paths merging
+    # True path: b = 4
+    # False path: b = Phi_b (unchanged)
+
+    my $const_4 = Chalk::IR::Node::Constant->new(
+        value => 4,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_4);
+
+    # Region merges the if-else control flow
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [$loop->id, $loop->id],  # Both paths from loop
+    );
+    $graph->add_node($region);
+
+    # Phi for b after the if: Phi(Region, Phi_b, 4)
+    # input[1] = false path (b unchanged = Phi_b)
+    # input[2] = true path (b = 4)
+    my $phi_b_after_if = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $phi_b->id, $const_4->id],
+    );
+    $graph->add_node($phi_b_after_if);
+
+    # a = a + 1
+    my $const_1 = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1);
+
+    my $a_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_a,
+        right => $const_1,
+    );
+    $graph->add_node($a_plus_1);
+
+    # Update loop backedges
+    push $phi_a->inputs->@*, $a_plus_1->id;
+    push $phi_b->inputs->@*, $phi_b_after_if->id;  # b gets the Region Phi result
+    push $loop->inputs->@*, $loop->id;
+
+    # Verify structure: Phi(Loop,2,Phi(Region,Phi_b,4))
+    is $phi_b->op, 'Phi', 'Outer b is Phi';
+    my @phi_b_inputs = $phi_b->inputs->@*;
+    is scalar(@phi_b_inputs), 3, 'Loop Phi has 3 inputs';
+
+    my $init_input = $graph->get_node($phi_b_inputs[1]);
+    is $init_input->op, 'Constant', 'Init input is Constant';
+    is $init_input->attributes->{value}, 2, 'Init value is 2';
+
+    my $loop_input = $graph->get_node($phi_b_inputs[2]);
+    is $loop_input->op, 'Phi', 'Loop input is Phi (from Region)';
+
+    # Check the inner Phi structure
+    my @inner_phi_inputs = $loop_input->inputs->@*;
+    is scalar(@inner_phi_inputs), 3, 'Inner Phi has 3 inputs';
+};
+
+subtest 'While with conditional inside (with peephole)' => sub {
+    # Same structure - peephole should preserve loop phi
+    my $graph = Chalk::IR::Graph->new();
+
+    my $start = Chalk::IR::Node->new(
+        id => 1,
+        op => 'Start',
+        inputs => [],
+        attributes => {},
+    );
+    $graph->add_node($start);
+
+    my $init_a = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_a);
+
+    my $init_b = Chalk::IR::Node::Constant->new(
+        value => 2,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_b);
+
+    my $loop = Chalk::IR::Node->new(
+        id => 4,
+        op => 'Loop',
+        inputs => [$start->id],
+        attributes => {},
+    );
+    $graph->add_node($loop);
+
+    my $phi_a = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $init_a->id],
+    );
+    $graph->add_node($phi_a);
+
+    my $phi_b = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $init_b->id],
+    );
+    $graph->add_node($phi_b);
+
+    my $const_4 = Chalk::IR::Node::Constant->new(
+        value => 4,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_4);
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [$loop->id, $loop->id],
+    );
+    $graph->add_node($region);
+
+    my $phi_b_after_if = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $phi_b->id, $const_4->id],
+    );
+    $graph->add_node($phi_b_after_if);
+
+    my $const_1 = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1);
+
+    my $a_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_a,
+        right => $const_1,
+    );
+    $graph->add_node($a_plus_1);
+
+    push $phi_a->inputs->@*, $a_plus_1->id;
+    push $phi_b->inputs->@*, $phi_b_after_if->id;
+    push $loop->inputs->@*, $loop->id;
+
+    # Apply peephole to the loop phi for b
+    my $optimized = $phi_b->peephole($graph);
+
+    # Should preserve loop phi (no optimization opportunity)
+    is $optimized->op, 'Phi', 'Peephole preserves loop Phi';
+    is $optimized->id, $phi_b->id, 'Same Phi node';
+};
+
+subtest 'While with if-else and increment (no peephole)' => sub {
+    # Simple: int b = 2; while(a < 10) { if(a == 2) b = 4; a = a + 1; b = b + 1; } return b;
+    # Expected: Phi(Loop,2,(Phi(Region,Phi_b,4)+1))
+    my $graph = Chalk::IR::Graph->new();
+
+    my $start = Chalk::IR::Node->new(
+        id => 1,
+        op => 'Start',
+        inputs => [],
+        attributes => {},
+    );
+    $graph->add_node($start);
+
+    my $init_a = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_a);
+
+    my $init_b = Chalk::IR::Node::Constant->new(
+        value => 2,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_b);
+
+    my $loop = Chalk::IR::Node->new(
+        id => 4,
+        op => 'Loop',
+        inputs => [$start->id],
+        attributes => {},
+    );
+    $graph->add_node($loop);
+
+    my $phi_a = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $init_a->id],
+    );
+    $graph->add_node($phi_a);
+
+    my $phi_b = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $init_b->id],
+    );
+    $graph->add_node($phi_b);
+
+    # if(a == 2) b = 4; else b = Phi_b
+    my $const_4 = Chalk::IR::Node::Constant->new(
+        value => 4,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_4);
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [$loop->id, $loop->id],
+    );
+    $graph->add_node($region);
+
+    # Phi(Region, Phi_b, 4)
+    my $phi_b_after_if = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $phi_b->id, $const_4->id],
+    );
+    $graph->add_node($phi_b_after_if);
+
+    # a = a + 1
+    my $const_1 = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1);
+
+    my $a_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_a,
+        right => $const_1,
+    );
+    $graph->add_node($a_plus_1);
+
+    # b = b + 1 (after the if-else, using phi_b_after_if)
+    my $b_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_b_after_if,
+        right => $const_1,
+    );
+    $graph->add_node($b_plus_1);
+
+    # Update loop backedges
+    push $phi_a->inputs->@*, $a_plus_1->id;
+    push $phi_b->inputs->@*, $b_plus_1->id;  # b gets (Phi(Region,...)+1)
+    push $loop->inputs->@*, $loop->id;
+
+    # Verify structure: Phi(Loop,2,(Phi(Region,Phi_b,4)+1))
+    is $phi_b->op, 'Phi', 'Outer b is Phi';
+    my @phi_b_inputs = $phi_b->inputs->@*;
+
+    my $init_input = $graph->get_node($phi_b_inputs[1]);
+    is $init_input->attributes->{value}, 2, 'Init value is 2';
+
+    my $loop_input = $graph->get_node($phi_b_inputs[2]);
+    is $loop_input->op, 'Add', 'Loop input is Add (b+1)';
+
+    # Check the Add structure: (Phi(Region,...)+1)
+    is $b_plus_1->left->op, 'Phi', 'Add left is Phi (from Region)';
+    is $b_plus_1->right->attributes->{value}, 1, 'Add right is 1';
+};
+
+subtest 'While with if-else and increment (with peephole)' => sub {
+    # Same structure - peephole should preserve the structure
+    # (no constant combining opportunity here)
+    my $graph = Chalk::IR::Graph->new();
+
+    my $start = Chalk::IR::Node->new(
+        id => 1,
+        op => 'Start',
+        inputs => [],
+        attributes => {},
+    );
+    $graph->add_node($start);
+
+    my $init_a = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_a);
+
+    my $init_b = Chalk::IR::Node::Constant->new(
+        value => 2,
+        type  => 'Integer',
+    );
+    $graph->add_node($init_b);
+
+    my $loop = Chalk::IR::Node->new(
+        id => 4,
+        op => 'Loop',
+        inputs => [$start->id],
+        attributes => {},
+    );
+    $graph->add_node($loop);
+
+    my $phi_a = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $init_a->id],
+    );
+    $graph->add_node($phi_a);
+
+    my $phi_b = Chalk::IR::Node::Phi->new(
+        region_id => $loop->id,
+        inputs => [$loop->id, $init_b->id],
+    );
+    $graph->add_node($phi_b);
+
+    my $const_4 = Chalk::IR::Node::Constant->new(
+        value => 4,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_4);
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [$loop->id, $loop->id],
+    );
+    $graph->add_node($region);
+
+    my $phi_b_after_if = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $phi_b->id, $const_4->id],
+    );
+    $graph->add_node($phi_b_after_if);
+
+    my $const_1 = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Integer',
+    );
+    $graph->add_node($const_1);
+
+    my $a_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_a,
+        right => $const_1,
+    );
+    $graph->add_node($a_plus_1);
+
+    my $b_plus_1 = Chalk::IR::Node::Add->new(
+        left  => $phi_b_after_if,
+        right => $const_1,
+    );
+    $graph->add_node($b_plus_1);
+
+    push $phi_a->inputs->@*, $a_plus_1->id;
+    push $phi_b->inputs->@*, $b_plus_1->id;
+    push $loop->inputs->@*, $loop->id;
+
+    # Apply peephole to b+1
+    my $optimized = $b_plus_1->peephole($graph);
+
+    # Should preserve structure (Phi + constant, no combining opportunity)
+    is $optimized->op, 'Add', 'Result is still Add';
+    is $optimized->left->op, 'Phi', 'Left is Phi';
+    is $optimized->right->op, 'Constant', 'Right is Constant';
+    is $optimized->right->attributes->{value}, 1, 'Right value is 1';
+};


### PR DESCRIPTION
## Summary
- Adds 6 new subtests matching Simple compiler chapter07 test patterns
- Tests cover nested loops, conditional-in-loop, and if-else + increment patterns
- Total chapter07.t subtests: 26 (was 20)

## Test plan
- [x] All 26 chapter07.t subtests pass
- [x] Tests verify nested Loop node structures
- [x] Tests verify Region+Phi for conditional assignments inside loops

## Changes
- 1 file changed, 634 insertions

Fixes #267

## Related Issues
- #254 (basic paired peephole tests - completed)
- #267 (nested loop and conditional-in-loop tests)