### PR TITLE
fix(grammar): Use dynamic child search for conditional Expression (#195)

### DIFF
--- a/lib/Chalk/Grammar/Chalk/Rule/ConditionalStatement.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/ConditionalStatement.pm
@@ -13,19 +13,9 @@ class Chalk::Grammar::Chalk::Rule::ConditionalStatement :isa(Chalk::GrammarRule)
         return "'$val'";
     }
 
-    # Child index constants for ConditionalStatement grammar structure
+    # NOTE: Child indices are NOT fixed because WS_OPT nodes may or may not be present
+    # in the children array. We must search for children dynamically.
     # Grammar: ConditionalKeyword WS_OPT ( WS_OPT Expression WS_OPT ) WS_OPT Block [WS_OPT 'else' WS_OPT Block]
-    # NOTE: WS_OPT nodes may not be present in children array when empty
-    # Actual observed structure: [if, undef, '(', Expression, ')', undef, Block] for simple if
-    use constant {
-        CHILD_KEYWORD       => 0,   # 'if' keyword
-        CHILD_LPAREN        => 2,   # '(' terminal
-        CHILD_CONDITION     => 3,   # Expression node
-        CHILD_RPAREN        => 4,   # ')' terminal
-        CHILD_TRUE_BLOCK    => 6,   # Block for true branch
-        CHILD_ELSE_KEYWORD  => 8,   # 'else' keyword (if present)
-        CHILD_FALSE_BLOCK   => 10,  # Block for false/else branch (if present)
-    };
 
     method evaluate($context) {
         warn "[DEBUG] ConditionalStatement.evaluate() called\n" if $ENV{CHALK_DEBUG_TRACKING};
@@ -61,21 +51,43 @@ class Chalk::Grammar::Chalk::Rule::ConditionalStatement :isa(Chalk::GrammarRule)
         # Save current control
         my $entry_control = $pre_scope->current_control;
 
-        # Find 'if' keyword position (should be at start)
-        my $keyword_index = 0;
+        # CRITICAL FIX (Issue #195): WS_OPT nodes ARE present in children array (with undef focus).
+        # We must search for the Expression child dynamically between '(' and ')'.
+        # Grammar: ConditionalKeyword WS_OPT ( WS_OPT Expression WS_OPT ) WS_OPT Block
+        my $condition;
+        my $found_lparen = 0;
+        for my $i (0..$#children) {
+            my $child_ctx = $children[$i];
+            my $child_val = $context->child($i);
 
-        # Parse: ConditionalKeyword WS_OPT ( WS_OPT Expression WS_OPT ) WS_OPT Block
-        # Actual observed structure:
-        # child[0]: ConditionalKeyword ('if')
-        # child[1]: undef (WS_OPT)
-        # child[2]: '(' terminal
-        # child[3]: Expression IR node
-        # child[4]: undef (WS_OPT)
-        # child[5]: ')' terminal
-        # child[6]: undef (WS_OPT)
-        # child[7]: Block (HASH with statements)
+            # Check for '(' terminal
+            if (!$found_lparen) {
+                if (blessed($child_val) && $child_val->can('value') && "$child_val" eq '(') {
+                    $found_lparen = 1;
+                    next;
+                }
+                # Also check raw string terminals
+                if (defined($child_val) && !ref($child_val) && "$child_val" eq '(') {
+                    $found_lparen = 1;
+                    next;
+                }
+                next;
+            }
 
-        my $condition = $context->child(CHILD_CONDITION);
+            # After '(', check for ')' to stop searching
+            if (blessed($child_val) && $child_val->can('value') && "$child_val" eq ')') {
+                last;
+            }
+            if (defined($child_val) && !ref($child_val) && "$child_val" eq ')') {
+                last;
+            }
+
+            # Between '(' and ')', look for Expression (IR node with id())
+            if (blessed($child_val) && $child_val->can('id')) {
+                $condition = $child_val;
+                last;
+            }
+        }
         # Use duck typing (check for id capability) rather than inheritance
         # since IR node classes may not share a common base class
         unless (blessed($condition) && $condition->can('id')) {

--- a/t/interpreter/issue-195-early-return.t
+++ b/t/interpreter/issue-195-early-return.t
@@ -118,10 +118,7 @@ sub execute_chalk {
 
 # Test Case 1: if (1) { return 42; } else { return -42; }
 # Expected: 42 (true branch taken)
-# TODO: Issue #195 - conditional statements with returns in both branches
-#       return undef instead of the correct branch value
 subtest 'Case 1: if-else returns 42 when condition is true' => sub {
-    local $TODO = 'Issue #195: if/else with returns in both branches not working';
     my $code = 'if (1) { return 42; } else { return -42; }';
 
     my ($result, $error) = execute_chalk($code);
@@ -136,9 +133,7 @@ subtest 'Case 1: if-else returns 42 when condition is true' => sub {
 
 # Test Case 2: if (0) { return 42; } else { return -42; }
 # Expected: -42 (false branch taken)
-# TODO: Issue #195 - same as Case 1
 subtest 'Case 2: if-else returns -42 when condition is false' => sub {
-    local $TODO = 'Issue #195: if/else with returns in both branches not working';
     my $code = 'if (0) { return 42; } else { return -42; }';
 
     my ($result, $error) = execute_chalk($code);
@@ -153,9 +148,7 @@ subtest 'Case 2: if-else returns -42 when condition is false' => sub {
 
 # Test Case 3: my $x = 5; if ($x > 0) { return 42; } return -42;
 # Expected: 42 (early return taken because 5 > 0)
-# TODO: Issue #195 - early return from if-true branch returns fallthrough value
 subtest 'Case 3: early return when condition true' => sub {
-    local $TODO = 'Issue #195: early return not overriding fallthrough return';
     my $code = 'my $x = 5; if ($x > 0) { return 42; } return -42;';
 
     my ($result, $error) = execute_chalk($code);


### PR DESCRIPTION
## Summary

- Fix root cause of issue #195 where if/else statements returned incorrect values
- ConditionalStatement used fixed child index (CHILD_CONDITION => 3) but WS_OPT nodes are present in children array with undef focus, placing actual Expression at index 4
- Changed to dynamic search: find `(` terminal, then locate first IR node (with `id()` method) before `)` terminal

## Changes

- **lib/Chalk/Grammar/Chalk/Rule/ConditionalStatement.pm**: Replace fixed CHILD_CONDITION constant with dynamic child search between parentheses (+39/-34 lines)
- **t/interpreter/issue-195-early-return.t**: Remove TODO markers from tests that now pass (-7 lines)

## Test plan

- [x] All 5 issue-195 test cases pass (if-else true/false, early return, fallthrough, baseline)
- [x] Full test suite passes (224 tests)
- [x] Self-hosting at 100% (191/191 files)

Closes #195