### PR TITLE
feat(optimizer): Add automatic add_dep() calls to peepholes (#282)

### DIFF
--- a/lib/Chalk/IR/Node/Add.pm
+++ b/lib/Chalk/IR/Node/Add.pm
@@ -136,6 +136,8 @@ class Chalk::IR::Node::Add {
         # Canonicalization: right association to left - flatten right-nested Adds
         # x + (y + z) -> (x + y) + z
         # This creates a left-spine structure for easier optimization
+        # Register dependency on right child since we check its op (Issue #282)
+        $right->add_dep($self->id);
         if ($right->op eq 'Add') {
             # right is (y + z), we are x + (y + z)
             # Transform to (x + y) + z
@@ -150,7 +152,13 @@ class Chalk::IR::Node::Add {
         }
 
         # Canonicalization for left-spine Add structures
+        # Register dependency on left child since we check its op (Issue #282)
+        $left->add_dep($self->id);
         if ($left->op eq 'Add') {
+            # Register dependencies on grandchildren since we access them (Issue #282)
+            $left->left->add_dep($self->id);
+            $left->right->add_dep($self->id);
+
             my $lhs_inner_left_type = $left->left->compute();
             my $lhs_inner_right_type = $left->right->compute();
 

--- a/lib/Chalk/IR/Node/Phi.pm
+++ b/lib/Chalk/IR/Node/Phi.pm
@@ -152,6 +152,12 @@ class Chalk::IR::Node::Phi :isa(Chalk::IR::Node::Base) {
         # Verify all data input nodes exist
         return if grep { !defined $_ } @data_nodes;
 
+        # Register dependencies on all data input nodes since we check their ops (Issue #282)
+        # If any data input's op changes, we should re-run idealize
+        for my $node (@data_nodes) {
+            $node->add_dep($self->id);
+        }
+
         # Check if all data inputs have the same operation type
         my $first_op = $data_nodes[0]->op;
 

--- a/t/sea-of-nodes/iterpeeps-deps.t
+++ b/t/sea-of-nodes/iterpeeps-deps.t
@@ -72,3 +72,118 @@ subtest 'multiple dependencies handled' => sub {
 
     ok scalar(@value_10) >= 1, 'Both adds folded to Constant(10)';
 };
+
+# =============================================================================
+# Tests for automatic add_dep() calls by peepholes (Issue #282)
+# These tests verify that peepholes register dependencies WITHOUT manual setup
+# =============================================================================
+
+subtest 'Add.idealize registers dependency on right child when checking op' => sub {
+    # When Add checks if right child is also an Add (for restructuring),
+    # it should register a dependency so if right changes, we re-optimize
+    my $graph = Chalk::IR::Graph->new();
+
+    my $a = Chalk::IR::Node::Constant->new(value => 1, type => 'Integer');
+    my $b = Chalk::IR::Node::Constant->new(value => 2, type => 'Integer');
+    my $c = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+
+    # Build: a + (b + c) - this triggers right-association check
+    my $inner_add = Chalk::IR::Node::Add->new(left => $b, right => $c);
+    my $outer_add = Chalk::IR::Node::Add->new(left => $a, right => $inner_add);
+
+    $graph->add_node($a);
+    $graph->add_node($b);
+    $graph->add_node($c);
+    $graph->add_node($inner_add);
+    $graph->add_node($outer_add);
+
+    # Call idealize on outer_add - it checks $right->op eq 'Add'
+    # and should register a dependency on inner_add
+    $outer_add->idealize();
+
+    # Verify dependency was registered
+    my @deps = $inner_add->get_deps();
+    ok scalar(@deps) >= 1, 'inner_add has at least one dependent after idealize check';
+    ok((grep { $_ eq $outer_add->id } @deps), 'outer_add registered as dependent on inner_add');
+};
+
+subtest 'Add.idealize registers dependency on left child grandchildren' => sub {
+    # When Add checks left->left and left->right for constant combining,
+    # it should register dependencies on those grandchildren
+    my $graph = Chalk::IR::Graph->new();
+
+    my $x = Chalk::IR::Node::Constant->new(value => 5, type => 'Integer');
+    my $c1 = Chalk::IR::Node::Constant->new(value => 10, type => 'Integer');
+    my $c2 = Chalk::IR::Node::Constant->new(value => 20, type => 'Integer');
+
+    # Build: (x + c1) + c2 - this triggers constant combining check
+    my $inner_add = Chalk::IR::Node::Add->new(left => $x, right => $c1);
+    my $outer_add = Chalk::IR::Node::Add->new(left => $inner_add, right => $c2);
+
+    $graph->add_node($x);
+    $graph->add_node($c1);
+    $graph->add_node($c2);
+    $graph->add_node($inner_add);
+    $graph->add_node($outer_add);
+
+    # Call idealize on outer_add - it accesses left->left and left->right
+    $outer_add->idealize();
+
+    # Verify dependencies on grandchildren (x and c1)
+    my @x_deps = $x->get_deps();
+    my @c1_deps = $c1->get_deps();
+
+    # outer_add should register as dependent on x and c1 (the grandchildren)
+    ok((grep { $_ eq $outer_add->id } @x_deps), 'outer_add registered as dependent on grandchild x');
+    ok((grep { $_ eq $outer_add->id } @c1_deps), 'outer_add registered as dependent on grandchild c1');
+};
+
+subtest 'Phi.idealize registers dependencies on data input nodes' => sub {
+    # When Phi checks if all data inputs have the same op (operation pulling),
+    # it should register dependencies on those nodes
+    use Chalk::IR::Node::Region;
+    use Chalk::IR::Node::Phi;
+
+    my $graph = Chalk::IR::Graph->new();
+
+    # Create a region with two control inputs
+    my $ctrl1 = Chalk::IR::Node::Constant->new(value => 1, type => 'Control');
+    my $ctrl2 = Chalk::IR::Node::Constant->new(value => 1, type => 'Control');
+    my $region = Chalk::IR::Node::Region->new(inputs => [$ctrl1->id, $ctrl2->id]);
+
+    # Create two Add nodes that the Phi will select between
+    my $a = Chalk::IR::Node::Constant->new(value => 1, type => 'Integer');
+    my $b = Chalk::IR::Node::Constant->new(value => 2, type => 'Integer');
+    my $c = Chalk::IR::Node::Constant->new(value => 3, type => 'Integer');
+    my $d = Chalk::IR::Node::Constant->new(value => 4, type => 'Integer');
+
+    my $add1 = Chalk::IR::Node::Add->new(left => $a, right => $b);
+    my $add2 = Chalk::IR::Node::Add->new(left => $c, right => $d);
+
+    # Create Phi that selects between add1 and add2
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs => [$region->id, $add1->id, $add2->id],
+    );
+
+    $graph->add_node($ctrl1);
+    $graph->add_node($ctrl2);
+    $graph->add_node($region);
+    $graph->add_node($a);
+    $graph->add_node($b);
+    $graph->add_node($c);
+    $graph->add_node($d);
+    $graph->add_node($add1);
+    $graph->add_node($add2);
+    $graph->add_node($phi);
+
+    # Call idealize on phi - it checks the op of each data input
+    $phi->idealize($graph);
+
+    # Verify dependencies on data input nodes (add1 and add2)
+    my @add1_deps = $add1->get_deps();
+    my @add2_deps = $add2->get_deps();
+
+    ok((grep { $_ eq $phi->id } @add1_deps), 'phi registered as dependent on add1');
+    ok((grep { $_ eq $phi->id } @add2_deps), 'phi registered as dependent on add2');
+};


### PR DESCRIPTION
## Summary

- Add automatic `add_dep()` calls in `Add.pm` and `Phi.pm` peepholes when inspecting remote nodes
- Enables IterPeeps to re-queue dependent nodes for re-optimization when remote nodes change
- Adds 3 new tests verifying dependency registration without manual setup

## Changes

**Add.pm** (`idealize()`):
- Register dependency on right child before checking `$right->op eq 'Add'` for right-association
- Register dependency on left child before checking `$left->op eq 'Add'` for constant combining
- Register dependencies on grandchildren (`$left->left`, `$left->right`) when accessing them

**Phi.pm** (`idealize()`):
- Register dependencies on all data input nodes before checking their ops for operation pulling

## Test plan

- [x] New tests in `t/sea-of-nodes/iterpeeps-deps.t` verify automatic dependency registration
- [x] Sea of Nodes test suite passes (40 files, 579 tests)
- [x] Self-hosting test passes (192/192 files, 100%)

## Related Issues

Fixes #282