### PR TITLE
feat(ir): Implement Cast node for type upcasting

### DIFF
--- a/lib/Chalk/IR/Node.pm
+++ b/lib/Chalk/IR/Node.pm
@@ -33,6 +33,7 @@ use Chalk::IR::Node::ArrayGet;
 use Chalk::IR::Node::ArraySet;
 use Chalk::IR::Node::HashGet;
 use Chalk::IR::Node::HashSet;
+use Chalk::IR::Node::Cast;
 
 class Chalk::IR::Node {
     field $id             :param :reader;
@@ -236,6 +237,7 @@ class Chalk::IR::Node {
             ArraySet   => 'Chalk::IR::Node::ArraySet',
             HashGet    => 'Chalk::IR::Node::HashGet',
             HashSet    => 'Chalk::IR::Node::HashSet',
+            Cast       => 'Chalk::IR::Node::Cast',
         );
 
         my $node_class = $op_to_class{$op};

--- a/lib/Chalk/IR/Node/Cast.pm
+++ b/lib/Chalk/IR/Node/Cast.pm
@@ -1,0 +1,93 @@
+# ABOUTME: Cast node for type upcasting (type refinement via join operation)
+# ABOUTME: Used after guard tests to lift/refine input type, can also be used for type assertions
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+
+class Chalk::IR::Node::Cast :isa(Chalk::IR::Node::Base) {
+    use Chalk::IR::Type::Top;
+
+    # Target type to cast to
+    field $target_type :param :reader;
+
+    # Control flow dependency (nullable for type assertions)
+    field $ctrl :param :reader = undef;
+
+    # Input value being cast
+    field $input :param :reader;
+
+    method op() { 'Cast' }
+
+    method to_hash() {
+        return {
+            id     => $self->id,
+            op     => 'Cast',
+            inputs => $self->inputs,
+            attributes => {
+                target_type => $target_type,
+            },
+        };
+    }
+
+    # Compute output type by joining input type with target type
+    # This produces the most precise type that satisfies both constraints
+    method compute() {
+        return Chalk::IR::Type::Top->top() unless $input;
+
+        my $input_type = $input->compute();
+
+        # Join the input type with the target type
+        return $input_type->join($target_type);
+    }
+
+    # Peephole optimization: eliminate redundant casts
+    # If the input already satisfies the target type, return the input directly
+    method peephole($graph = undef) {
+        return $self unless $graph;
+        return $self unless $input;
+
+        my $input_type = $input->compute();
+
+        # Check if input type is already a subtype of (or equal to) target type
+        # This uses the isa() method if available, otherwise checks type equality
+        if ($input_type->can('isa') && $input_type->isa($target_type)) {
+            # Input already satisfies target type - cast is redundant
+            return $input;
+        }
+
+        # For types without isa(), check if they're the same type
+        # or if the input is more specific (constant vs TOP)
+        if ($self->_type_satisfies($input_type, $target_type)) {
+            return $input;
+        }
+
+        return $self;
+    }
+
+    # Helper method to check if input_type satisfies target_type
+    method _type_satisfies($input_type, $target_type) {
+        # Same type reference = satisfies
+        return 1 if $input_type == $target_type;
+
+        # If target is TOP, everything satisfies it
+        return 1 if $target_type->can('is_top') && $target_type->is_top;
+
+        # If both are same class and input is constant while target is TOP,
+        # the constant satisfies the TOP type
+        if (ref($input_type) eq ref($target_type)) {
+            if ($input_type->can('is_constant') && $input_type->is_constant &&
+                $target_type->can('is_top') && $target_type->is_top) {
+                return 1;
+            }
+            # Same type, same value = satisfies
+            if ($input_type->can('is_constant') && $target_type->can('is_constant') &&
+                $input_type->is_constant && $target_type->is_constant) {
+                return $input_type->value == $target_type->value;
+            }
+        }
+
+        return 0;
+    }
+}
+
+1;

--- a/t/sea-of-nodes/node-cast.t
+++ b/t/sea-of-nodes/node-cast.t
@@ -1,0 +1,162 @@
+# ABOUTME: Tests for Cast node implementation (type upcasting/projection)
+# ABOUTME: Cast refines input type by joining with target type, used after guard tests
+
+use lib 'lib';
+use 5.42.0;
+use Test2::V0;
+use experimental qw(defer);
+defer { done_testing() }
+
+use Chalk::IR::Node::Cast;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Type::Integer;
+use Chalk::IR::Type::Top;
+use Chalk::IR::Graph;
+
+subtest 'Cast node construction' => sub {
+    my $ctrl = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Control',
+    );
+
+    my $input = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => 'Integer',
+    );
+
+    my $target_type = Chalk::IR::Type::Integer->constant(42);
+
+    my $cast = Chalk::IR::Node::Cast->new(
+        inputs      => [$ctrl->id, $input->id],
+        target_type => $target_type,
+        ctrl        => $ctrl,
+        input       => $input,
+    );
+
+    is $cast->op, 'Cast', 'Cast node has correct op';
+    ok defined $cast->target_type, 'Cast has target_type field';
+    ok defined $cast->ctrl, 'Cast has ctrl field';
+    ok defined $cast->input, 'Cast has input field';
+};
+
+subtest 'Cast compute() joins input and target types' => sub {
+    my $ctrl = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Control',
+    );
+
+    my $input = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => 'Integer',
+    );
+
+    # Target type: Integer constant 42
+    my $target_type = Chalk::IR::Type::Integer->constant(42);
+
+    my $cast = Chalk::IR::Node::Cast->new(
+        inputs      => [$ctrl->id, $input->id],
+        target_type => $target_type,
+        ctrl        => $ctrl,
+        input       => $input,
+    );
+
+    my $result_type = $cast->compute();
+    ok $result_type->is_constant, 'Cast computes constant type';
+    is $result_type->value, 42, 'Cast preserves constant value when types match';
+};
+
+subtest 'Cast peephole removes redundant cast' => sub {
+    plan 1;
+
+    my $ctrl = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Control',
+    );
+
+    my $input = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => 'Integer',
+    );
+
+    # Target type: Integer TOP (any integer)
+    my $target_type = Chalk::IR::Type::Integer->TOP();
+
+    my $cast = Chalk::IR::Node::Cast->new(
+        inputs      => [$ctrl->id, $input->id],
+        target_type => $target_type,
+        ctrl        => $ctrl,
+        input       => $input,
+    );
+
+    my $graph = Chalk::IR::Graph->new();
+    $graph->add_node($ctrl);
+    $graph->add_node($input);
+    $graph->add_node($cast);
+
+    # When input type satisfies target type, cast should be removed
+    my $optimized = $cast->peephole($graph);
+
+    # Cast should return the input node directly
+    is $optimized->id, $input->id, 'Redundant cast eliminated, returns input';
+};
+
+subtest 'Cast peephole preserves necessary cast' => sub {
+    plan 1;
+
+    my $ctrl = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Control',
+    );
+
+    my $input = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => 'Integer',
+    );
+
+    # Target type: Integer constant 7 (different from input)
+    my $target_type = Chalk::IR::Type::Integer->constant(7);
+
+    my $cast = Chalk::IR::Node::Cast->new(
+        inputs      => [$ctrl->id, $input->id],
+        target_type => $target_type,
+        ctrl        => $ctrl,
+        input       => $input,
+    );
+
+    my $graph = Chalk::IR::Graph->new();
+    $graph->add_node($ctrl);
+    $graph->add_node($input);
+    $graph->add_node($cast);
+
+    # When input type doesn't satisfy target type, cast should remain
+    my $optimized = $cast->peephole($graph);
+
+    # Cast should return itself
+    is $optimized->id, $cast->id, 'Necessary cast preserved';
+};
+
+subtest 'Cast to_hash includes attributes' => sub {
+    my $ctrl = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => 'Control',
+    );
+
+    my $input = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => 'Integer',
+    );
+
+    my $target_type = Chalk::IR::Type::Integer->constant(42);
+
+    my $cast = Chalk::IR::Node::Cast->new(
+        inputs      => [$ctrl->id, $input->id],
+        target_type => $target_type,
+        ctrl        => $ctrl,
+        input       => $input,
+    );
+
+    my $hash = $cast->to_hash();
+
+    is $hash->{op}, 'Cast', 'to_hash includes correct op';
+    ok defined $hash->{attributes}{target_type}, 'to_hash includes target_type attribute';
+};


### PR DESCRIPTION
## Summary
Implements the Cast node for Chapter 10 of Sea of Nodes, enabling type refinement through join operations. Cast is used after guard tests to lift input types or for type assertions.

## Changes
- **New file**: `lib/Chalk/IR/Node/Cast.pm` - Cast node implementation with type join computation and peephole optimization
- **New file**: `t/sea-of-nodes/node-cast.t` - Comprehensive test suite for Cast node
- **Modified**: `lib/Chalk/IR/Node.pm` - Added Cast to factory method and preload list

## Features
- Type computation via join of input and target types
- Peephole optimization to eliminate redundant casts when input already satisfies target type
- Integration with type lattice (join/meet operations)
- Comprehensive test coverage (5 test subtests, all passing)

## Test Results
```
t/sea-of-nodes/node-cast.t .. ok
All tests successful.
Files=1, Tests=5,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.04 cusr  0.01 csys =  0.06 CPU)
Result: PASS
```

## Related Issues
Fixes #258

## Reference
- Simple chapter10: https://github.com/SeaOfNodes/Simple/tree/main/chapter10
- Simple Cast.java: Type projection/upcasting for memory references