### PR TITLE
feat(ir): Implement memory slices via type-based alias analysis (#259)

### DIFF
--- a/docs/memory-slices-chalk-approach.md
+++ b/docs/memory-slices-chalk-approach.md
@@ -1,0 +1,561 @@
+# Memory Slices and Alias Classes: Chalk's Approach
+
+**Date:** 2025-12-03
+**Issue:** #259 - Chapter 10: Implement Memory Slices and Alias Classes
+**Status:** Implemented (Adapted to Chalk's Architecture)
+
+## Executive Summary
+
+Chalk implements the **conceptual goals** of Simple's Chapter 10 memory slices using a **label-based approach** that integrates naturally with Chalk's heapless context architecture. Instead of explicit memory edges in the IR graph, Chalk uses **type namespaces in context labels** to prove non-aliasing.
+
+## Background: Simple's Chapter 10
+
+### Simple's Approach
+Simple introduces memory slicing for type-based alias analysis (TBAA):
+
+- **Memory slices**: Separate SSA memory values per struct field type
+- **Alias classes**: Integer IDs assigned to each field in each struct
+- **Memory threading**: Memory types flow through Load/Store as explicit inputs/outputs
+- **Optimization**: Independent alias classes enable store-store elimination and load forwarding
+
+### Key Concept
+> "Memory in different alias classes never aliases; memory in the same alias class always aliases."
+
+This enables the compiler to prove that operations on different struct fields cannot interfere, allowing aggressive reordering and elimination.
+
+## Chalk's Heapless Architecture
+
+Chalk uses a fundamentally different memory model:
+
+```perl
+# Everything is a context closure
+my $ctx = sub ($label) {
+    return $value if $label eq 'lexical:$x';
+    return $parent_ctx->($label);
+};
+
+# Collections ARE contexts with namespaced labels
+'lexical:@arr'  → ArrayValue(context with 'index:0', 'index:1', ...)
+'lexical:%hash' → HashValue(context with 'key:foo', 'key:bar', ...)
+```
+
+**No separate heap layer** - collections are nested contexts, not heap-allocated structures.
+
+See `docs/memory-model.md` for full details.
+
+## Adapting Memory Slices to Chalk
+
+### The Core Insight
+
+**In Simple**: Alias classes partition memory into slices
+**In Chalk**: Type namespaces partition context labels into non-aliasing sets
+
+These are **semantically equivalent**:
+
+| Simple | Chalk |
+|--------|-------|
+| Memory slice for alias_class 1 | Context labels with type namespace `Int` |
+| Memory slice for alias_class 2 | Context labels with type namespace `Str` |
+| Different alias classes don't alias | Different type namespaces can't collide |
+
+### Implementation Strategy
+
+#### 1. Type-Based Context Labels
+
+Extend context labels to include type information:
+
+```perl
+# Phase 5 namespace pattern (from memory-model.md)
+'lexical:$x'         # Old: untyped label
+'lexical:Int:$x'     # New: typed label for integer variable
+'lexical:Str:$x'     # New: typed label for string variable (different namespace!)
+'lexical:ArrayRef:$x' # New: typed label for array reference
+```
+
+**Implementation**: `Chalk::IR::Context->make_typed_label($namespace, $type, $name)`
+
+```perl
+use Chalk::IR::Context;
+
+my $int_label = Chalk::IR::Context->make_typed_label('lexical', 'Int', '$x');
+# Returns: 'lexical:Int:$x'
+
+my $str_label = Chalk::IR::Context->make_typed_label('lexical', 'Str', '$x');
+# Returns: 'lexical:Str:$x'
+
+# These labels are guaranteed to be different!
+$int_label ne $str_label  # TRUE
+```
+
+#### 2. Memory Type with Alias Classes
+
+The `Memory` type already supports `alias_class` parameter:
+
+```perl
+use Chalk::IR::Type::Memory;
+
+# Memory slice for field type 1
+my $mem1 = Chalk::IR::Type::Memory->new(alias_class => 1);
+
+# Memory slice for field type 2
+my $mem2 = Chalk::IR::Type::Memory->new(alias_class => 2);
+
+# Different alias classes meet to TOP (no aliasing)
+my $result = $mem1->meet($mem2);
+$result->is_top();  # TRUE - they don't alias
+```
+
+**Lattice operations**:
+- `meet()`: Finds most specific (intersection) - different alias classes → TOP
+- `join()`: Finds least specific (union) - different alias classes → TOP
+
+#### 3. Field Operations with Alias Classes
+
+`FieldLoad` and `FieldStore` now track alias classes:
+
+```perl
+use Chalk::IR::Node::FieldStore;
+
+# Store to field 'x' (alias_class 1)
+my $store = Chalk::IR::Node::FieldStore->new(
+    inputs => [$object_id, $field_id, $value_id],
+    object_id => $object_id,
+    field_id => $field_id,
+    value_id => $value_id,
+    alias_class => 1,  # Field 'x' assigned alias class 1
+);
+
+# compute() returns Memory type
+my $mem_type = $store->compute($graph);
+$mem_type->alias_class;  # Returns: 1
+```
+
+**Key properties**:
+- Each field gets a unique `alias_class` value
+- Same field across instances uses same `alias_class` (can alias)
+- Different fields use different `alias_class` (proven non-aliasing)
+- Missing `alias_class` defaults to `undef` (MemTOP - conservative)
+
+## Comparison: Simple vs Chalk
+
+### Memory Model
+
+| Aspect | Simple | Chalk |
+|--------|--------|-------|
+| Architecture | Heap-based with pointers | Heapless context closures |
+| Allocation | `New` node creates heap object | `NewObject` allocates heap_id in Environment |
+| Field access | Memory × Pointer × Field → Value | heap_id × field → Value via environment lookup |
+| Aliasing | Memory slice per alias class | Type namespace per variable type |
+| Memory edges | Explicit in IR graph | Implicit in environment state |
+
+### Alias Analysis
+
+| Aspect | Simple | Chalk |
+|--------|--------|-------|
+| Mechanism | Alias class integers | Type namespaces in labels |
+| Assignment | Per struct field type | Per variable/field type |
+| Non-aliasing proof | Different alias class IDs | Different label prefixes |
+| Representation | Memory type with alias_class | Context label with type component |
+
+### Optimization Opportunities
+
+**Both enable**:
+- ✅ Store-store elimination (same field, consecutive stores)
+- ✅ Load-after-store forwarding (load immediately after store to same field)
+- ✅ Parallel memory access (different fields can't interfere)
+- ✅ Dead memory elimination (unused memory slices)
+
+**Chalk-specific advantages**:
+- ✅ Label-based analysis works at compile-time (string comparison)
+- ✅ No need for separate memory threading (environment handles it)
+- ✅ Simpler IR (no memory edges in graph)
+
+## Implementation Files
+
+### Core Infrastructure
+
+1. **`lib/Chalk/IR/Context.pm`**
+   - `make_typed_label($namespace, $type, $name)` - Creates type-namespaced labels
+   - Returns labels like `'lexical:Int:$x'`
+
+2. **`lib/Chalk/IR/Type/Memory.pm`**
+   - `$alias_class` field for memory slice identification
+   - `meet()` and `join()` operations for alias analysis
+   - TOP/BOTTOM singletons for lattice
+
+3. **`lib/Chalk/IR/Node/FieldLoad.pm`**
+   - `$alias_class` field (optional)
+   - `compute($graph)` returns `Memory` type with alias_class
+
+4. **`lib/Chalk/IR/Node/FieldStore.pm`**
+   - `$alias_class` field (optional)
+   - `compute($graph)` returns `Memory` type with alias_class
+
+### Tests
+
+1. **`t/ir-type-based-aliasing.t`** (6 tests)
+   - Type-based label creation
+   - Namespace isolation
+   - Context storage without aliasing
+
+2. **`t/ir-memory-alias-classes.t`** (13 tests)
+   - Memory type lattice operations
+   - Alias class meet/join semantics
+   - Field-level alias tracking
+
+3. **`t/ir-field-alias-classes.t`** (8 tests)
+   - Field operation type computation
+   - Alias class propagation
+   - Non-aliasing verification
+
+4. **`t/interpreter/cek-object-operations.t`** (8 tests, existing)
+   - Backward compatibility with untyped operations
+   - Execution semantics unchanged
+
+## Usage Example
+
+### Scenario: Point Struct with Two Fields
+
+```perl
+# Pseudo-Perl representing the IR
+class Point {
+    has Int $.x;  # Assigned alias_class 1
+    has Int $.y;  # Assigned alias_class 2
+}
+
+my $p = Point.new(x => 10, y => 20);
+$p.x = 42;  # Store to alias_class 1
+$p.y = 99;  # Store to alias_class 2
+say $p.x;   # Load from alias_class 1
+```
+
+### IR Construction
+
+```perl
+use Chalk::IR::Node::NewObject;
+use Chalk::IR::Node::FieldStore;
+use Chalk::IR::Node::FieldLoad;
+
+# Allocate Point object
+my $new_obj = Chalk::IR::Node::NewObject->new(inputs => []);
+
+# Field constants
+my $field_x = Constant('x');
+my $field_y = Constant('y');
+my $val_10 = Constant(10);
+my $val_20 = Constant(20);
+
+# Store to x field (alias_class 1)
+my $store_x = Chalk::IR::Node::FieldStore->new(
+    inputs => [$new_obj->id, $field_x->id, $val_10->id],
+    object_id => $new_obj->id,
+    field_id => $field_x->id,
+    value_id => $val_10->id,
+    alias_class => 1,  # Point.x
+);
+
+# Store to y field (alias_class 2)
+my $store_y = Chalk::IR::Node::FieldStore->new(
+    inputs => [$store_x->id, $field_y->id, $val_20->id],
+    object_id => $store_x->id,
+    field_id => $field_y->id,
+    value_id => $val_20->id,
+    alias_class => 2,  # Point.y
+);
+
+# Load from x field (alias_class 1)
+my $load_x = Chalk::IR::Node::FieldLoad->new(
+    inputs => [$store_y->id, $field_x->id],
+    object_id => $store_y->id,
+    field_id => $field_x->id,
+    alias_class => 1,  # Point.x
+);
+```
+
+### Type Computation
+
+```perl
+my $store_x_type = $store_x->compute($graph);
+# Returns: Memory(alias_class => 1)
+
+my $store_y_type = $store_y->compute($graph);
+# Returns: Memory(alias_class => 2)
+
+# Prove non-aliasing
+my $meet = $store_x_type->meet($store_y_type);
+$meet->is_top();  # TRUE - different fields don't alias
+```
+
+### Optimization Enabled
+
+```perl
+# Original IR:
+#   store_x: Point.x = 10  (alias_class 1)
+#   store_y: Point.y = 20  (alias_class 2)
+#   load_x: read Point.x   (alias_class 1)
+
+# Optimization: Load-after-store forwarding
+# Since load_x has alias_class 1 and store_x has alias_class 1,
+# and store_y has alias_class 2 (doesn't interfere),
+# we can forward the value 10 directly to load_x.
+
+# Optimized IR:
+#   store_x: Point.x = 10  (alias_class 1)
+#   store_y: Point.y = 20  (alias_class 2)
+#   load_x: ← eliminated, replaced with Constant(10)
+```
+
+## Future Work
+
+### Phase 5: Type Namespace Migration
+
+Migrate all context label generation to use typed labels:
+
+```perl
+# Current (Phase 4):
+my $ctx = extend_context($ctx, 'lexical:$x', $value);
+
+# Future (Phase 5):
+my $label = make_typed_label('lexical', 'Int', '$x');
+my $ctx = extend_context($ctx, $label, $value);
+```
+
+**Benefits**:
+- Compile-time non-aliasing proofs via string comparison
+- More aggressive constant propagation
+- Type-directed optimization passes
+
+### Alias Class Assignment Algorithm
+
+Develop systematic alias class assignment:
+
+```perl
+# Strategy 1: Per-field assignment
+#   Point.x → 1
+#   Point.y → 2
+#   Circle.radius → 3
+#   Circle.center → 4
+
+# Strategy 2: Per-type assignment (more conservative)
+#   All Int fields → 1
+#   All Str fields → 2
+#   All ArrayRef fields → 3
+```
+
+**Trade-offs**:
+- Per-field: More precise, more classes
+- Per-type: Coarser, fewer classes, simpler
+
+### Peephole Optimizations
+
+Implement memory-aware peepholes:
+
+1. **Store-Store Elimination**
+   ```perl
+   # Before:
+   FieldStore(obj, 'x', 10, alias_class => 1)
+   FieldStore(obj, 'x', 20, alias_class => 1)  # Same alias class!
+
+   # After:
+   FieldStore(obj, 'x', 20, alias_class => 1)  # First store eliminated
+   ```
+
+2. **Load-After-Store Forwarding**
+   ```perl
+   # Before:
+   store = FieldStore(obj, 'x', 42, alias_class => 1)
+   load = FieldLoad(obj, 'x', alias_class => 1)  # Same alias class!
+
+   # After:
+   store = FieldStore(obj, 'x', 42, alias_class => 1)
+   load → Constant(42)  # Load replaced with constant
+   ```
+
+3. **Cross-Field Independence**
+   ```perl
+   # Before (cannot optimize - must check alias classes):
+   FieldStore(obj, 'x', 10, alias_class => 1)
+   FieldStore(obj, 'y', 20, alias_class => 2)  # Different alias class
+   FieldLoad(obj, 'x', alias_class => 1)
+
+   # After (safe to reorder since different alias classes):
+   FieldStore(obj, 'x', 10, alias_class => 1)
+   FieldLoad(obj, 'x', alias_class => 1)  # Can move past store to y
+   FieldStore(obj, 'y', 20, alias_class => 2)
+   ```
+
+## Correctness Guarantees
+
+### Type Safety
+
+**Invariant 1**: Labels with different type components cannot collide
+
+```perl
+'lexical:Int:$x' ne 'lexical:Str:$x'  # Always TRUE
+```
+
+**Proof**: String prefixes guarantee lexical separation.
+
+### Alias Safety
+
+**Invariant 2**: Different alias classes prove non-aliasing
+
+```perl
+my $mem1 = Memory(alias_class => 1);
+my $mem2 = Memory(alias_class => 2);
+
+$mem1->meet($mem2)->is_top();  # Always TRUE
+```
+
+**Proof**: Type lattice meet operation for different alias classes = TOP.
+
+### Execution Semantics
+
+**Invariant 3**: Adding `alias_class` doesn't change execution behavior
+
+```perl
+# Without alias_class
+FieldStore(obj, field, value)
+
+# With alias_class
+FieldStore(obj, field, value, alias_class => 1)
+
+# execute() method ignores alias_class - same runtime behavior
+```
+
+**Proof**: `execute()` method doesn't use `alias_class` field (compile-time only).
+
+## Comparison to Simple's Memory Edges
+
+### Simple's Approach: Explicit Memory Threading
+
+```java
+// Simplified Java-like IR
+Start start = new Start();
+Memory mem0 = start.memory();  // Initial memory state
+
+// Store creates new memory state
+Store store1 = new Store(mem0, ptr, field, value, ALIAS_1);
+Memory mem1 = store1.memory();  // Updated memory
+
+// Load depends on memory state
+Load load = new Load(mem1, ptr, field, ALIAS_1);
+Memory mem2 = load.memory();
+
+// Return collects all memory slices
+Return ret = new Return(ctrl, value, mem2);
+```
+
+**Properties**:
+- Memory is explicit SSA value
+- Stores/Loads are chained via memory edges
+- Different alias classes can be parallel (no edge dependency)
+
+### Chalk's Approach: Implicit Environment State
+
+```perl
+# Chalk IR
+my $start = Start();
+
+# FieldStore doesn't thread memory explicitly
+my $store = FieldStore(
+    object => $obj,
+    field => 'x',
+    value => 42,
+    alias_class => 1,  # Type metadata only
+);
+
+# Environment tracks heap state implicitly
+# execute() mutates environment, not memory edges
+$env->set_heap($heap_id, 'x', 42);
+
+# FieldLoad reads from environment
+my $load = FieldLoad(
+    object => $obj,
+    field => 'x',
+    alias_class => 1,
+);
+my $value = $env->lookup_heap($heap_id, 'x');
+```
+
+**Properties**:
+- Memory is implicit in `Environment.heap_ctxs`
+- No explicit memory edges in IR graph
+- `alias_class` is type metadata for optimization only
+- Execution uses environment state, not memory threading
+
+### Why Chalk's Approach Works
+
+**Key insight**: Chalk's heapless architecture makes memory threading unnecessary.
+
+In Simple:
+- Heap is separate from IR
+- Memory edges track which heap state to use
+- Necessary for correctness
+
+In Chalk:
+- No separate heap - heap IS context closures
+- Environment tracks all state
+- Memory edges would be redundant
+- `alias_class` provides optimization metadata without changing execution
+
+## Testing Strategy
+
+### Unit Tests
+- ✅ `t/ir-type-based-aliasing.t` - Label-based non-aliasing
+- ✅ `t/ir-memory-alias-classes.t` - Memory type lattice
+- ✅ `t/ir-field-alias-classes.t` - Field operation types
+
+### Integration Tests
+- ✅ `t/interpreter/cek-object-operations.t` - Backward compatibility
+- 🔲 Peephole optimization tests (future)
+- 🔲 End-to-end struct tests with parser (future)
+
+### Property Tests (Future)
+```perl
+# Property: Different types never alias
+for all type1, type2 where type1 != type2:
+    label1 = make_typed_label('lexical', type1, '$x')
+    label2 = make_typed_label('lexical', type2, '$x')
+    assert label1 != label2
+
+# Property: Same type, same name = same label
+for all type, name:
+    label1 = make_typed_label('lexical', type, name)
+    label2 = make_typed_label('lexical', type, name)
+    assert label1 == label2
+
+# Property: Different alias classes never alias
+for all ac1, ac2 where ac1 != ac2:
+    mem1 = Memory(alias_class => ac1)
+    mem2 = Memory(alias_class => ac2)
+    assert mem1.meet(mem2).is_top()
+```
+
+## Conclusion
+
+Chalk implements the **semantic goals** of Simple's Chapter 10 memory slicing using a **label-based approach** that integrates naturally with the heapless context architecture. Instead of explicit memory edges, Chalk uses:
+
+1. **Type namespaces in context labels** (`lexical:Int:$x` vs `lexical:Str:$x`)
+2. **Alias classes in field operations** (same field → same class, different fields → different classes)
+3. **Memory type lattice** (different classes meet to TOP, proving non-aliasing)
+
+This achieves the same optimization opportunities (store elimination, load forwarding, parallelization) while maintaining Chalk's architectural simplicity.
+
+**Status**: ✅ Core implementation complete, ready for peephole optimization phase.
+
+## References
+
+### Chalk Documentation
+- `docs/memory-model.md` - Heapless context architecture
+- Issue #259 - Memory slices and alias classes
+- Issue #287 - Chapter 10 parent issue
+
+### Simple/Sea of Nodes
+- [Simple Chapter 10](https://github.com/SeaOfNodes/Simple/tree/main/chapter10) - Original memory slice design
+- Cliff Click's Sea of Nodes papers
+
+### Related Concepts
+- Type-Based Alias Analysis (TBAA)
+- SSA form and memory effects
+- Alias analysis in compilers

--- a/lib/Chalk/IR/Context.pm
+++ b/lib/Chalk/IR/Context.pm
@@ -26,6 +26,12 @@ class Chalk::IR::Context {
         return "${namespace}:${name}";
     }
 
+    # Creates a typed label for alias analysis (e.g., "lexical:Int:$x", "lexical:Str:$x")
+    # Different types create different labels, preventing false aliasing
+    sub make_typed_label($class, $namespace, $type, $name) {
+        return "${namespace}:${type}:${name}";
+    }
+
     # Creates index label for array elements (e.g., "index:0", "index:1")
     sub make_index_label($class, $index) {
         return "index:${index}";

--- a/lib/Chalk/IR/Node/FieldLoad.pm
+++ b/lib/Chalk/IR/Node/FieldLoad.pm
@@ -7,19 +7,30 @@ use utf8;
 class Chalk::IR::Node::FieldLoad :isa(Chalk::IR::Node::Base) {
     field $object_id :param :reader;
     field $field_id :param :reader;
+    field $alias_class :param :reader = undef;
 
     method op() { 'FieldLoad' }
 
     method to_hash() {
+        my %attrs = (
+            object_id => $object_id,
+            field_id => $field_id,
+        );
+        $attrs{alias_class} = $alias_class if defined $alias_class;
+
         return {
             id     => $self->id,
             op     => 'FieldLoad',
             inputs => $self->inputs,
-            attributes => {
-                object_id => $object_id,
-                field_id => $field_id,
-            },
+            attributes => \%attrs,
         };
+    }
+
+    method compute($graph) {
+        use Chalk::IR::Type::Memory;
+        return Chalk::IR::Type::Memory->new(
+            alias_class => $alias_class,
+        );
     }
 
     method execute($context) {

--- a/lib/Chalk/IR/Node/FieldStore.pm
+++ b/lib/Chalk/IR/Node/FieldStore.pm
@@ -8,20 +8,31 @@ class Chalk::IR::Node::FieldStore :isa(Chalk::IR::Node::Base) {
     field $object_id :param :reader;
     field $field_id :param :reader;
     field $value_id :param :reader;
+    field $alias_class :param :reader = undef;
 
     method op() { 'FieldStore' }
 
     method to_hash() {
+        my %attrs = (
+            object_id => $object_id,
+            field_id => $field_id,
+            value_id => $value_id,
+        );
+        $attrs{alias_class} = $alias_class if defined $alias_class;
+
         return {
             id     => $self->id,
             op     => 'FieldStore',
             inputs => $self->inputs,
-            attributes => {
-                object_id => $object_id,
-                field_id => $field_id,
-                value_id => $value_id,
-            },
+            attributes => \%attrs,
         };
+    }
+
+    method compute($graph) {
+        use Chalk::IR::Type::Memory;
+        return Chalk::IR::Type::Memory->new(
+            alias_class => $alias_class,
+        );
     }
 
     method execute($context) {

--- a/t/ir-field-alias-classes.t
+++ b/t/ir-field-alias-classes.t
@@ -1,0 +1,164 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests field operation type computation with alias classes
+# ABOUTME: Verifies FieldLoad/FieldStore compute() returns correct Memory types
+use 5.42.0;
+use lib 'lib';
+use Test::More tests => 8;
+use Chalk::IR::Graph;
+use Chalk::IR::Node::NewObject;
+use Chalk::IR::Node::FieldLoad;
+use Chalk::IR::Node::FieldStore;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Type::Memory;
+
+# Test 1: FieldStore compute() returns Memory type with alias_class
+{
+    my $graph = Chalk::IR::Graph->new();
+    my $new_obj = Chalk::IR::Node::NewObject->new(inputs => []);
+    my $field = Chalk::IR::Node::Constant->new(value => 'x', type => 'string');
+    my $value = Chalk::IR::Node::Constant->new(value => 42, type => 'int');
+
+    # Field "x" assigned alias_class 1
+    my $store = Chalk::IR::Node::FieldStore->new(
+        inputs => [$new_obj->id, $field->id, $value->id],
+        object_id => $new_obj->id,
+        field_id => $field->id,
+        value_id => $value->id,
+        alias_class => 1,
+    );
+
+    $graph->add_node($new_obj);
+    $graph->add_node($field);
+    $graph->add_node($value);
+    $graph->add_node($store);
+
+    my $type = $store->compute($graph);
+
+    isa_ok($type, 'Chalk::IR::Type::Memory', 'FieldStore compute() returns Memory type');
+    is($type->alias_class, 1, 'Memory type has correct alias_class');
+}
+
+# Test 2: FieldLoad compute() returns Memory type with alias_class
+{
+    my $graph = Chalk::IR::Graph->new();
+    my $new_obj = Chalk::IR::Node::NewObject->new(inputs => []);
+    my $field = Chalk::IR::Node::Constant->new(value => 'y', type => 'string');
+
+    # Field "y" assigned alias_class 2
+    my $load = Chalk::IR::Node::FieldLoad->new(
+        inputs => [$new_obj->id, $field->id],
+        object_id => $new_obj->id,
+        field_id => $field->id,
+        alias_class => 2,
+    );
+
+    $graph->add_node($new_obj);
+    $graph->add_node($field);
+    $graph->add_node($load);
+
+    my $type = $load->compute($graph);
+
+    isa_ok($type, 'Chalk::IR::Type::Memory', 'FieldLoad compute() returns Memory type');
+    is($type->alias_class, 2, 'Memory type has correct alias_class');
+}
+
+# Test 3: Different fields have different alias classes
+{
+    my $graph = Chalk::IR::Graph->new();
+    my $new_obj = Chalk::IR::Node::NewObject->new(inputs => []);
+    my $field_x = Chalk::IR::Node::Constant->new(value => 'x', type => 'string');
+    my $field_y = Chalk::IR::Node::Constant->new(value => 'y', type => 'string');
+    my $value = Chalk::IR::Node::Constant->new(value => 42, type => 'int');
+
+    my $store_x = Chalk::IR::Node::FieldStore->new(
+        inputs => [$new_obj->id, $field_x->id, $value->id],
+        object_id => $new_obj->id,
+        field_id => $field_x->id,
+        value_id => $value->id,
+        alias_class => 1,
+    );
+
+    my $store_y = Chalk::IR::Node::FieldStore->new(
+        inputs => [$new_obj->id, $field_y->id, $value->id],
+        object_id => $new_obj->id,
+        field_id => $field_y->id,
+        value_id => $value->id,
+        alias_class => 2,
+    );
+
+    $graph->add_node($new_obj);
+    $graph->add_node($field_x);
+    $graph->add_node($field_y);
+    $graph->add_node($value);
+    $graph->add_node($store_x);
+    $graph->add_node($store_y);
+
+    my $type_x = $store_x->compute($graph);
+    my $type_y = $store_y->compute($graph);
+
+    # Different fields don't alias
+    my $meet = $type_x->meet($type_y);
+    ok($meet->is_top, 'Different field alias classes meet to TOP (no aliasing)');
+}
+
+# Test 4: Same field across operations uses same alias class
+{
+    my $graph = Chalk::IR::Graph->new();
+    my $new_obj = Chalk::IR::Node::NewObject->new(inputs => []);
+    my $field = Chalk::IR::Node::Constant->new(value => 'x', type => 'string');
+    my $value = Chalk::IR::Node::Constant->new(value => 42, type => 'int');
+
+    my $store = Chalk::IR::Node::FieldStore->new(
+        inputs => [$new_obj->id, $field->id, $value->id],
+        object_id => $new_obj->id,
+        field_id => $field->id,
+        value_id => $value->id,
+        alias_class => 1,
+    );
+
+    my $load = Chalk::IR::Node::FieldLoad->new(
+        inputs => [$store->id, $field->id],
+        object_id => $store->id,
+        field_id => $field->id,
+        alias_class => 1,
+    );
+
+    $graph->add_node($new_obj);
+    $graph->add_node($field);
+    $graph->add_node($value);
+    $graph->add_node($store);
+    $graph->add_node($load);
+
+    my $store_type = $store->compute($graph);
+    my $load_type = $load->compute($graph);
+
+    # Same field CAN alias
+    my $meet = $store_type->meet($load_type);
+    is($meet->alias_class, 1, 'Same field alias classes meet to that class (can alias)');
+}
+
+# Test 5: Missing alias_class defaults to undefined (TOP)
+{
+    my $graph = Chalk::IR::Graph->new();
+    my $new_obj = Chalk::IR::Node::NewObject->new(inputs => []);
+    my $field = Chalk::IR::Node::Constant->new(value => 'x', type => 'string');
+    my $value = Chalk::IR::Node::Constant->new(value => 42, type => 'int');
+
+    # No alias_class specified
+    my $store = Chalk::IR::Node::FieldStore->new(
+        inputs => [$new_obj->id, $field->id, $value->id],
+        object_id => $new_obj->id,
+        field_id => $field->id,
+        value_id => $value->id,
+    );
+
+    $graph->add_node($new_obj);
+    $graph->add_node($field);
+    $graph->add_node($value);
+    $graph->add_node($store);
+
+    my $type = $store->compute($graph);
+
+    isa_ok($type, 'Chalk::IR::Type::Memory', 'FieldStore without alias_class returns Memory');
+    ok(!defined($type->alias_class), 'Missing alias_class defaults to undefined (TOP)');
+}

--- a/t/ir-memory-alias-classes.t
+++ b/t/ir-memory-alias-classes.t
@@ -1,0 +1,138 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests Memory type alias class integration with Chalk's context model
+# ABOUTME: Verifies alias_class enables optimization by proving non-aliasing
+use 5.42.0;
+use lib 'lib';
+use Test::More tests => 13;
+use Chalk::IR::Type::Memory;
+
+# Test 1: Memory type with alias class
+{
+    my $mem1 = Chalk::IR::Type::Memory->new(alias_class => 1);
+    is($mem1->alias_class, 1, 'Memory created with alias_class 1');
+}
+
+# Test 2: Different alias classes don't alias
+{
+    my $mem1 = Chalk::IR::Type::Memory->new(alias_class => 1);
+    my $mem2 = Chalk::IR::Type::Memory->new(alias_class => 2);
+
+    my $result = $mem1->meet($mem2);
+
+    ok($result->is_top, 'Different alias classes meet to MemTop (no aliasing)');
+}
+
+# Test 3: Same alias class can alias
+{
+    my $mem1 = Chalk::IR::Type::Memory->new(alias_class => 1);
+    my $mem2 = Chalk::IR::Type::Memory->new(alias_class => 1);
+
+    my $result = $mem1->meet($mem2);
+
+    is($result->alias_class, 1, 'Same alias classes meet to that class');
+}
+
+# Test 4: Memory TOP has no specific alias class
+{
+    my $mem_top = Chalk::IR::Type::Memory->TOP();
+
+    ok($mem_top->is_top, 'Memory TOP is top');
+    ok(!defined($mem_top->alias_class), 'Memory TOP has no alias_class');
+}
+
+# Test 5: Memory BOTTOM absorbs everything
+{
+    my $mem1 = Chalk::IR::Type::Memory->new(alias_class => 1);
+    my $mem_bot = Chalk::IR::Type::Memory->BOTTOM();
+
+    my $result = $mem1->meet($mem_bot);
+
+    ok($result->is_bottom, 'Memory meet MemBot = MemBot');
+}
+
+# Test 6: Join of different alias classes = TOP
+{
+    my $mem1 = Chalk::IR::Type::Memory->new(alias_class => 1);
+    my $mem2 = Chalk::IR::Type::Memory->new(alias_class => 2);
+
+    my $result = $mem1->join($mem2);
+
+    ok($result->is_top, 'Different alias classes join to MemTop');
+}
+
+# Test 7: Join of same alias class preserves it
+{
+    my $mem1 = Chalk::IR::Type::Memory->new(alias_class => 1);
+    my $mem2 = Chalk::IR::Type::Memory->new(alias_class => 1);
+
+    my $result = $mem1->join($mem2);
+
+    is($result->alias_class, 1, 'Same alias classes join to that class');
+}
+
+# Test 8: MemTop meet specific class = specific class
+{
+    my $mem_top = Chalk::IR::Type::Memory->TOP();
+    my $mem1 = Chalk::IR::Type::Memory->new(alias_class => 1);
+
+    my $result = $mem_top->meet($mem1);
+
+    is($result->alias_class, 1, 'MemTop meet specific = specific');
+}
+
+# Test 9: MemBot join specific class = specific class
+{
+    my $mem_bot = Chalk::IR::Type::Memory->BOTTOM();
+    my $mem1 = Chalk::IR::Type::Memory->new(alias_class => 1);
+
+    my $result = $mem_bot->join($mem1);
+
+    is($result->alias_class, 1, 'MemBot join specific = specific');
+}
+
+# Test 10: Alias class assignment via field type
+# In Chalk's model, each field type gets an alias class
+# For example: "Point.x" (Int field) = alias_class 1
+#              "Point.y" (Int field) = alias_class 2
+#              "Circle.radius" (Int field) = alias_class 3
+{
+    # Simulate alias class assignment
+    my %field_to_alias = (
+        'Point.x' => 1,
+        'Point.y' => 2,
+        'Circle.radius' => 3,
+    );
+
+    my $point_x_mem = Chalk::IR::Type::Memory->new(alias_class => $field_to_alias{'Point.x'});
+    my $point_y_mem = Chalk::IR::Type::Memory->new(alias_class => $field_to_alias{'Point.y'});
+
+    # Different fields don't alias
+    my $result = $point_x_mem->meet($point_y_mem);
+    ok($result->is_top, 'Different struct fields have different alias classes');
+}
+
+# Test 11: Same field across instances uses same alias class
+{
+    # Both Point instances share alias_class for 'x' field
+    my %field_to_alias = (
+        'Point.x' => 1,
+        'Point.y' => 2,
+    );
+
+    my $point1_x_mem = Chalk::IR::Type::Memory->new(alias_class => $field_to_alias{'Point.x'});
+    my $point2_x_mem = Chalk::IR::Type::Memory->new(alias_class => $field_to_alias{'Point.x'});
+
+    # Same field across instances CAN alias
+    my $result = $point1_x_mem->meet($point2_x_mem);
+    is($result->alias_class, 1, 'Same field across instances can alias');
+}
+
+# Test 12: Undefined alias_class treated as TOP
+{
+    my $mem_undef = Chalk::IR::Type::Memory->new();
+    my $mem1 = Chalk::IR::Type::Memory->new(alias_class => 1);
+
+    my $result = $mem_undef->meet($mem1);
+
+    is($result->alias_class, 1, 'Undefined alias_class (TOP) meet specific = specific');
+}

--- a/t/ir-type-based-aliasing.t
+++ b/t/ir-type-based-aliasing.t
@@ -1,0 +1,42 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests type-based alias analysis for context labels
+# ABOUTME: Verifies different types use separate namespaces preventing false aliasing
+use 5.42.0;
+use lib 'lib';
+use Test::More tests => 6;
+use Chalk::IR::Context;
+
+# Test 1: Same variable name with different types creates different labels
+{
+    my $int_label = Chalk::IR::Context->make_typed_label('lexical', 'Int', '$x');
+    my $str_label = Chalk::IR::Context->make_typed_label('lexical', 'Str', '$x');
+
+    isnt($int_label, $str_label, 'Int and Str variables with same name have different labels');
+    like($int_label, qr/Int/, 'Int label contains type');
+    like($str_label, qr/Str/, 'Str label contains type');
+}
+
+# Test 2: Same type, same name = same label (can alias)
+{
+    my $label1 = Chalk::IR::Context->make_typed_label('lexical', 'Int', '$x');
+    my $label2 = Chalk::IR::Context->make_typed_label('lexical', 'Int', '$x');
+
+    is($label1, $label2, 'Same type and name produce identical labels');
+}
+
+# Test 3: Context isolation via type namespaces
+{
+    my $ctx = Chalk::IR::Context->empty_context();
+
+    # Store Int value at lexical:Int:$x
+    my $int_label = Chalk::IR::Context->make_typed_label('lexical', 'Int', '$x');
+    $ctx = Chalk::IR::Context->extend_context($ctx, $int_label, 42);
+
+    # Store Str value at lexical:Str:$x
+    my $str_label = Chalk::IR::Context->make_typed_label('lexical', 'Str', '$x');
+    $ctx = Chalk::IR::Context->extend_context($ctx, $str_label, 'hello');
+
+    # Both values coexist without aliasing
+    is($ctx->($int_label), 42, 'Int value stored correctly');
+    is($ctx->($str_label), 'hello', 'Str value stored correctly (no aliasing)');
+}


### PR DESCRIPTION
## Summary

Implements Simple's Chapter 10 memory slice concept adapted to Chalk's heapless context architecture.

Instead of explicit memory edges in the IR graph, uses **type namespaces in context labels** to prove non-aliasing. This achieves the same optimization goals (store-store elimination, load forwarding, parallel memory access) while maintaining Chalk's architectural simplicity.

## Changes

### Core Implementation

1. **Type-namespaced context labels** (`lib/Chalk/IR/Context.pm`)
   - Added `make_typed_label($namespace, $type, $name)` method
   - Returns labels like `'lexical:Int:$x'` vs `'lexical:Str:$x'`
   - Different types = different labels = proven non-aliasing

2. **Alias class support in field operations**
   - Added `alias_class` parameter to `FieldLoad.pm` and `FieldStore.pm`
   - Added `compute()` methods returning `Memory` type with alias_class
   - Backward compatible (alias_class is optional, defaults to undef/TOP)

3. **Memory type lattice** (already existed in `Type/Memory.pm`)
   - `meet()` and `join()` operations for alias analysis
   - Different alias classes meet to TOP (proven non-aliasing)
   - Same alias class preserves class (can alias)

### Testing

- **t/ir-type-based-aliasing.t** (6 tests) - Label-based non-aliasing
- **t/ir-memory-alias-classes.t** (13 tests) - Memory type lattice operations
- **t/ir-field-alias-classes.t** (8 tests) - Field operation type computation
- All existing tests pass (verified backward compatibility)

### Documentation

- **docs/memory-slices-chalk-approach.md** - Complete design rationale
  - Comparison to Simple's approach
  - Chalk-specific adaptation
  - Usage examples
  - Future optimization opportunities

## Comparison: Simple vs Chalk

| Aspect | Simple Chapter 10 | Chalk Implementation |
|--------|------------------|---------------------|
| Non-aliasing proof | Different alias class IDs | Different type namespaces in labels |
| Memory edges | Explicit SSA edges | Implicit in environment state |
| Optimization | Store-store, load forwarding | Same optimizations enabled |
| Architecture | Heap-based with pointers | Heapless context closures |

## Test Results

```
t/ir-type-based-aliasing.t ........ ok (6 tests)
t/ir-memory-alias-classes.t ....... ok (13 tests)
t/ir-field-alias-classes.t ........ ok (8 tests)
t/interpreter/cek-object-operations.t .. ok (8 tests, existing)
```

All new tests pass. Existing object operation tests pass (backward compatible).

## Files Changed

- **lib/Chalk/IR/Context.pm** - Added `make_typed_label()` method
- **lib/Chalk/IR/Node/FieldLoad.pm** - Added `alias_class` and `compute()`
- **lib/Chalk/IR/Node/FieldStore.pm** - Added `alias_class` and `compute()`
- **docs/memory-slices-chalk-approach.md** - Architecture documentation
- **t/ir-type-based-aliasing.t** - New test file
- **t/ir-memory-alias-classes.t** - New test file
- **t/ir-field-alias-classes.t** - New test file

**Total: 7 files changed, 942 insertions(+), 9 deletions(-)**

## Related Issues

Fixes #259 - Chapter 10: Implement Memory Slices and Alias Classes
Part of #287 - Complete Chapter 10: User-defined structures and memory

## Next Steps

Future work for complete Chapter 10 support:

1. **Alias class assignment algorithm** - Systematic assignment of alias_class values per field type
2. **Peephole optimizations** - Store-store elimination, load-after-store forwarding
3. **Phase 5 migration** - Migrate all context labels to use `make_typed_label()`
4. **Parser integration** - Struct type declarations and field type tracking