### PR TITLE
Chapter 13 Session 1: Type System Foundation (Nested References)

### DIFF
--- a/docs/plans/2025-12-05-class-type-system-foundation.md
+++ b/docs/plans/2025-12-05-class-type-system-foundation.md
@@ -1,0 +1,272 @@
+# Type System Foundation for Nested Class References
+
+**Date:** 2025-12-05
+**Issue:** #341 (Chapter 13 Session 1)
+**Author:** Design session with perigrin
+**Status:** Approved for implementation
+
+## Overview
+
+This design establishes the type system foundation for nested and recursive struct references in Chalk, following the Sea of Nodes Chapter 13 pattern with Chalk-specific naming conventions.
+
+## Goals
+
+1. Support self-referential class types (linked lists, binary trees)
+2. Support mutually recursive class types
+3. Handle forward references transparently via lazy resolution
+4. Distinguish nullable from non-nullable reference fields
+5. Provide foundation for IR node implementation (Session 2) and parser integration (Session 3)
+
+## Architecture Decision: Lazy Resolution
+
+We chose the **Lazy Resolution** approach (Sea of Nodes pattern):
+- Register placeholder types on first use
+- Fill placeholders when definitions are parsed
+- Auto-deepen on field access to resolve stale references
+
+**Alternatives considered:**
+- Eager resolution (no forward refs) - too restrictive
+- Two-pass resolution - requires significant parse restructuring
+
+## Components
+
+### 1. TypeRegistry
+
+**File:** `lib/Chalk/Grammar/Chalk/TypeRegistry.pm`
+
+**Purpose:** Singleton registry managing the class type namespace.
+
+**Storage:** Hash mapping qualified class names (strings) to Class type instances.
+
+**API:**
+```perl
+# Register a class type (prevents redefinition of complete classes)
+register($name, $class_obj)
+
+# Lookup class type (auto-creates placeholder if not found)
+lookup($name)
+
+# Check if class is registered
+has_class($name)
+
+# Check if class has complete field definitions
+is_complete($name)
+```
+
+**Lifecycle:**
+1. First reference: `lookup("Node")` auto-creates `Class("Node", fields: undef)`
+2. Definition parsed: `register("Node", Class("Node", fields: {...}))` replaces placeholder
+3. Field access: Auto-deepening fetches complete definition from registry
+
+**Singleton Access:** `TypeRegistry->instance()`
+
+### 2. Class Type
+
+**File:** `lib/Chalk/Grammar/Chalk/Type/Class.pm`
+
+**Purpose:** Represents instances of user-defined classes.
+
+**Fields:**
+```perl
+field $class_name :param :reader;  # Qualified identifier as string
+field $fields :param :reader;       # Hashref {field_name => Type} or undef
+```
+
+**Key Methods:**
+```perl
+method is_complete() {
+    return defined $fields;
+}
+
+method field_type($field_name) {
+    # Auto-deepening: delegate to registry if incomplete
+    unless (defined $fields) {
+        my $complete = TypeRegistry->instance->lookup($class_name);
+        return $complete->field_type($field_name);
+    }
+    return $fields->{$field_name} // die "No field $field_name";
+}
+
+method has_field($field_name) {
+    # Similar auto-deepening pattern
+}
+
+method is_subtype_of($other) {
+    # Nominal typing:
+    # Class("X") <: Class("X") (reflexive)
+    # Class("X") <: Object <: Ref <: Scalar <: Any
+    # Different classes are incompatible
+}
+```
+
+**Type Lattice Integration:**
+- `Class <: Object <: Ref <: Scalar <: Any`
+- Nominal subtyping (no structural subtyping in Session 1)
+
+**Forward References:**
+- Incomplete: `Class("Node", fields: undef)` - placeholder
+- Complete: `Class("Node", fields: {val => Int, next => Maybe(Class("Node"))})`
+
+### 3. Maybe Type
+
+**File:** `lib/Chalk/Grammar/Chalk/Type/Maybe.pm`
+
+**Purpose:** Wrapper type for nullable references (T or undef).
+
+**Fields:**
+```perl
+field $inner_type :param :reader;  # The wrapped type
+```
+
+**Key Methods:**
+```perl
+method unwrap() {
+    return $inner_type;
+}
+
+method is_subtype_of($other) {
+    # Maybe(T) <: Maybe(U) if T <: U
+    # Maybe(T) <: Undef
+}
+```
+
+**Usage Example:**
+```perl
+# Nullable reference field
+Class("Node", fields: {
+    val => Int,
+    next => Maybe(Class("Node"))
+})
+```
+
+**Note:** `Type?` syntax parser support is deferred to Session 3 (#343).
+
+### 4. Auto-Deepening Mechanism
+
+**Purpose:** Resolve stale forward references when accessing fields on incomplete Class types.
+
+**Implementation:** Built into `Class->field_type()` and similar methods (see Class Type section above).
+
+**Pattern:**
+1. Check if Class is complete (`defined $fields`)
+2. If incomplete, fetch complete definition from TypeRegistry
+3. Delegate operation to complete instance
+4. **No mutation** - just delegation (following Sea of Nodes pattern)
+
+**This handles circular references:**
+```perl
+# During parsing:
+# 1. See "Node" reference before definition -> create placeholder
+# 2. Parse definition, register complete type
+# 3. Field access on old placeholder -> auto-deepen to complete type
+```
+
+## Type Lattice Integration
+
+**Existing hierarchy:**
+```
+Any (top)
+├── Scalar
+│   ├── Str
+│   │   └── Num
+│   │       └── Int
+│   ├── Boolean
+│   ├── Undef
+│   └── Ref
+│       ├── ScalarRef
+│       ├── ArrayRef
+│       ├── HashRef
+│       ├── CodeRef
+│       └── Object  ← We extend here
+└── List
+    ├── Array
+    └── Hash
+```
+
+**New types:**
+```
+Object
+└── Class (parameterized by class_name and fields)
+
+Maybe (wrapper type, parameterized by inner_type)
+```
+
+**Subtyping examples:**
+- `Class("Node") <: Object <: Ref <: Scalar <: Any`
+- `Maybe(Class("Node")) <: Maybe(Object)` (if Class <: Object)
+- `Maybe(T) <: Undef` (can be undef)
+
+## Testing Strategy
+
+**Test File:** `t/types/class-types.t`
+
+**Coverage Areas:**
+
+1. **TypeRegistry:**
+   - Register and lookup complete classes
+   - Auto-create placeholders for forward references
+   - Replace placeholders with complete definitions
+   - Prevent redefinition of complete classes
+   - Singleton behavior
+
+2. **Class Type:**
+   - Create complete Class with fields
+   - Create incomplete Class (placeholder)
+   - Field type access on complete classes
+   - Auto-deepening on incomplete classes
+   - `is_complete()` method
+   - Subtyping relationships
+
+3. **Maybe Type:**
+   - Wrap types with Maybe
+   - Unwrap inner types
+   - Subtyping relationships
+
+4. **Integration:**
+   - Self-referential classes: linked list, binary tree
+   - Mutually recursive classes
+   - Forward reference resolution via auto-deepening
+   - Complex nested structures
+
+**TDD Workflow:**
+- Write failing test defining expected behavior
+- Implement minimal code to pass test
+- Verify test passes
+- Refactor while keeping tests green
+
+## Implementation Order
+
+Following TDD, implement in this order:
+
+1. **TypeRegistry skeleton** - test registration/lookup
+2. **Class type (complete only)** - test field access without forward refs
+3. **Class placeholders** - test incomplete classes
+4. **Auto-deepening** - test forward reference resolution
+5. **Maybe type** - test nullable wrapping
+6. **Integration tests** - test self-referential and mutually recursive classes
+
+Each step builds on previous foundation.
+
+## Out of Scope (Future Sessions)
+
+- **Session 2 (#342):** IR node extensions (NewNode, LoadNode, StoreNode)
+- **Session 3 (#343):** Parser integration (`Type?` syntax, class declarations)
+- Structural subtyping (only nominal subtyping in Session 1)
+- Class methods or inheritance
+- Runtime validation
+
+## Success Criteria
+
+1. ✅ Can define self-referential class types programmatically
+2. ✅ Can define mutually recursive class types programmatically
+3. ✅ Forward declarations resolve correctly via auto-deepening
+4. ✅ Nullable vs non-nullable types are distinguished
+5. ✅ All type system tests pass at 100%
+6. ✅ Foundation ready for IR node implementation (Session 2)
+
+## References
+
+- Issue #341: Chapter 13 Session 1
+- Issue #335: Parent issue (Chapter 13: Nested references)
+- Sea of Nodes Chapter 13: https://github.com/SeaOfNodes/Simple (reference implementation)
+- Existing Chalk type system: `lib/Chalk/Grammar/Chalk/Type/`

--- a/lib/Chalk/Grammar/Chalk/Type/Class.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Class.pm
@@ -16,7 +16,7 @@ class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
     }
 
     method name() {
-        return "Class($class_name)";
+        return "Class[$class_name]";
     }
 
     method has_field($field_name) {

--- a/lib/Chalk/Grammar/Chalk/Type/Class.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Class.pm
@@ -26,7 +26,7 @@ class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
             my $complete = Chalk::Grammar::Chalk::TypeRegistry->instance()->lookup($class_name);
 
             # Prevent infinite recursion if class is still incomplete
-            return 0 if $complete == $self || !$complete->is_complete();
+            return false if $complete == $self || !$complete->is_complete();
 
             return $complete->has_field($field_name);
         }

--- a/lib/Chalk/Grammar/Chalk/Type/Class.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Class.pm
@@ -62,12 +62,7 @@ class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
         }
 
         # Class <: Object <: Ref <: Scalar <: Any
-        return any { $other isa $_ } qw(
-            Chalk::Grammar::Chalk::Type::Object
-            Chalk::Grammar::Chalk::Type::Ref
-            Chalk::Grammar::Chalk::Type::Scalar
-            Chalk::Grammar::Chalk::Type::Any
-        );
+        return any { $other isa $_ } qw(Chalk::Grammar::Chalk::Type::Object Chalk::Grammar::Chalk::Type::Ref Chalk::Grammar::Chalk::Type::Scalar Chalk::Grammar::Chalk::Type::Any);
     }
 }
 

--- a/lib/Chalk/Grammar/Chalk/Type/Class.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Class.pm
@@ -1,0 +1,73 @@
+# ABOUTME: Class type representing user-defined class instances in Chalk type system
+# ABOUTME: Supports forward references via placeholders and auto-deepening for lazy resolution
+
+use 5.042;
+use experimental qw(class);
+
+class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
+    # Qualified class name as string
+    field $class_name :param :reader;
+
+    # Hashref {field_name => Type} or undef for placeholders
+    field $fields :param :reader = undef;
+
+    method is_complete() {
+        return defined $fields;
+    }
+
+    method name() {
+        return "Class($class_name)";
+    }
+
+    method has_field($field_name) {
+        # Auto-deepening: delegate to registry if incomplete
+        unless (defined $fields) {
+            require Chalk::Grammar::Chalk::TypeRegistry;
+            my $complete = Chalk::Grammar::Chalk::TypeRegistry->instance()->lookup($class_name);
+
+            # Prevent infinite recursion if class is still incomplete
+            return 0 if $complete == $self || !$complete->is_complete();
+
+            return $complete->has_field($field_name);
+        }
+
+        return exists $fields->{$field_name};
+    }
+
+    method field_type($field_name) {
+        # Auto-deepening: delegate to registry if incomplete
+        unless (defined $fields) {
+            require Chalk::Grammar::Chalk::TypeRegistry;
+            my $complete = Chalk::Grammar::Chalk::TypeRegistry->instance()->lookup($class_name);
+
+            # Prevent infinite recursion if class is still incomplete
+            unless ($complete != $self && $complete->is_complete()) {
+                die "Cannot access fields on incomplete class '$class_name'";
+            }
+
+            return $complete->field_type($field_name);
+        }
+
+        unless (exists $fields->{$field_name}) {
+            die "No field $field_name in class $class_name";
+        }
+
+        return $fields->{$field_name};
+    }
+
+    method is_subtype_of($other) {
+        # Nominal typing: Class("X") <: Class("X") (reflexive)
+        if (ref($other) eq 'Chalk::Grammar::Chalk::Type::Class') {
+            # Same class name => subtype (reflexive)
+            return $self->class_name() eq $other->class_name();
+        }
+
+        # Class <: Object <: Ref <: Scalar <: Any
+        return ref($other) eq 'Chalk::Grammar::Chalk::Type::Object' ||
+               ref($other) eq 'Chalk::Grammar::Chalk::Type::Ref' ||
+               ref($other) eq 'Chalk::Grammar::Chalk::Type::Scalar' ||
+               ref($other) eq 'Chalk::Grammar::Chalk::Type::Any';
+    }
+}
+
+1;

--- a/lib/Chalk/Grammar/Chalk/Type/Class.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Class.pm
@@ -2,7 +2,7 @@
 # ABOUTME: Supports forward references via placeholders and auto-deepening for lazy resolution
 
 use 5.042;
-use experimental qw(class);
+use experimental qw(class keyword_any);
 
 class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
     # Qualified class name as string
@@ -63,10 +63,12 @@ class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
         }
 
         # Class <: Object <: Ref <: Scalar <: Any
-        return ref($other) eq 'Chalk::Grammar::Chalk::Type::Object' ||
-               ref($other) eq 'Chalk::Grammar::Chalk::Type::Ref' ||
-               ref($other) eq 'Chalk::Grammar::Chalk::Type::Scalar' ||
-               ref($other) eq 'Chalk::Grammar::Chalk::Type::Any';
+        return any { $other isa $_ } qw(
+            Chalk::Grammar::Chalk::Type::Object
+            Chalk::Grammar::Chalk::Type::Ref
+            Chalk::Grammar::Chalk::Type::Scalar
+            Chalk::Grammar::Chalk::Type::Any
+        );
     }
 }
 

--- a/lib/Chalk/Grammar/Chalk/Type/Class.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Class.pm
@@ -57,7 +57,7 @@ class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
 
     method is_subtype_of($other) {
         # Nominal typing: Class("X") <: Class("X") (reflexive)
-        if (ref($other) eq 'Chalk::Grammar::Chalk::Type::Class') {
+        if ($other isa Chalk::Grammar::Chalk::Type::Class) {
             # Same class name => subtype (reflexive)
             return $self->class_name() eq $other->class_name();
         }

--- a/lib/Chalk/Grammar/Chalk/Type/Class.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Class.pm
@@ -62,7 +62,12 @@ class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
         }
 
         # Class <: Object <: Ref <: Scalar <: Any
-        return any { $other isa $_ } qw(Chalk::Grammar::Chalk::Type::Object Chalk::Grammar::Chalk::Type::Ref Chalk::Grammar::Chalk::Type::Scalar Chalk::Grammar::Chalk::Type::Any);
+        return any { $other isa $_ } (
+            'Chalk::Grammar::Chalk::Type::Object',
+            'Chalk::Grammar::Chalk::Type::Ref',
+            'Chalk::Grammar::Chalk::Type::Scalar',
+            'Chalk::Grammar::Chalk::Type::Any'
+        );
     }
 }
 

--- a/lib/Chalk/Grammar/Chalk/Type/Class.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Class.pm
@@ -3,6 +3,7 @@
 
 use 5.042;
 use experimental qw(class keyword_any);
+use Chalk::Grammar::Chalk::TypeRegistry;
 
 class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
     # Qualified class name as string
@@ -22,7 +23,6 @@ class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
     method has_field($field_name) {
         # Auto-deepening: delegate to registry if incomplete
         unless (defined $fields) {
-            require Chalk::Grammar::Chalk::TypeRegistry;
             my $complete = Chalk::Grammar::Chalk::TypeRegistry->instance()->lookup($class_name);
 
             # Prevent infinite recursion if class is still incomplete
@@ -37,7 +37,6 @@ class Chalk::Grammar::Chalk::Type::Class :isa(Chalk::Grammar::Chalk::Type) {
     method field_type($field_name) {
         # Auto-deepening: delegate to registry if incomplete
         unless (defined $fields) {
-            require Chalk::Grammar::Chalk::TypeRegistry;
             my $complete = Chalk::Grammar::Chalk::TypeRegistry->instance()->lookup($class_name);
 
             # Prevent infinite recursion if class is still incomplete

--- a/lib/Chalk/Grammar/Chalk/Type/Maybe.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Maybe.pm
@@ -1,5 +1,5 @@
 # ABOUTME: Maybe type for nullable references (T or undef) in Chalk type system
-# ABOUTME: Wrapper type supporting covariant subtyping: Maybe(T) <: Maybe(U) if T <: U
+# ABOUTME: Wrapper type supporting covariant subtyping: Maybe[T] <: Maybe[U] if T <: U
 
 use 5.042;
 use experimental qw(class);
@@ -13,16 +13,16 @@ class Chalk::Grammar::Chalk::Type::Maybe :isa(Chalk::Grammar::Chalk::Type) {
     }
 
     method name() {
-        return 'Maybe(' . $inner_type->name() . ')';
+        return 'Maybe[' . $inner_type->name() . ']';
     }
 
     method is_subtype_of($other) {
-        # Maybe(T) <: Maybe(U) if T <: U (covariant)
+        # Maybe[T] <: Maybe[U] if T <: U (covariant)
         if (ref($other) eq 'Chalk::Grammar::Chalk::Type::Maybe') {
             return $inner_type->is_subtype_of($other->inner_type());
         }
 
-        # Maybe(T) <: Undef (can be undef)
+        # Maybe[T] <: Undef (can be undef)
         return ref($other) eq 'Chalk::Grammar::Chalk::Type::Undef';
     }
 }

--- a/lib/Chalk/Grammar/Chalk/Type/Maybe.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Maybe.pm
@@ -18,12 +18,12 @@ class Chalk::Grammar::Chalk::Type::Maybe :isa(Chalk::Grammar::Chalk::Type) {
 
     method is_subtype_of($other) {
         # Maybe[T] <: Maybe[U] if T <: U (covariant)
-        if (ref($other) eq 'Chalk::Grammar::Chalk::Type::Maybe') {
+        if ($other isa Chalk::Grammar::Chalk::Type::Maybe) {
             return $inner_type->is_subtype_of($other->inner_type());
         }
 
         # Maybe[T] <: Undef (can be undef)
-        return ref($other) eq 'Chalk::Grammar::Chalk::Type::Undef';
+        return $other isa Chalk::Grammar::Chalk::Type::Undef;
     }
 }
 

--- a/lib/Chalk/Grammar/Chalk/Type/Maybe.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Maybe.pm
@@ -1,0 +1,30 @@
+# ABOUTME: Maybe type for nullable references (T or undef) in Chalk type system
+# ABOUTME: Wrapper type supporting covariant subtyping: Maybe(T) <: Maybe(U) if T <: U
+
+use 5.042;
+use experimental qw(class);
+
+class Chalk::Grammar::Chalk::Type::Maybe :isa(Chalk::Grammar::Chalk::Type) {
+    # The wrapped type
+    field $inner_type :param :reader;
+
+    method unwrap() {
+        return $inner_type;
+    }
+
+    method name() {
+        return 'Maybe(' . $inner_type->name() . ')';
+    }
+
+    method is_subtype_of($other) {
+        # Maybe(T) <: Maybe(U) if T <: U (covariant)
+        if (ref($other) eq 'Chalk::Grammar::Chalk::Type::Maybe') {
+            return $inner_type->is_subtype_of($other->inner_type());
+        }
+
+        # Maybe(T) <: Undef (can be undef)
+        return ref($other) eq 'Chalk::Grammar::Chalk::Type::Undef';
+    }
+}
+
+1;

--- a/lib/Chalk/Grammar/Chalk/TypeRegistry.pm
+++ b/lib/Chalk/Grammar/Chalk/TypeRegistry.pm
@@ -2,6 +2,7 @@
 # ABOUTME: Maps qualified class names to Class type instances, supporting lazy resolution
 use 5.042;
 use experimental qw(class);
+use Chalk::Grammar::Chalk::Type::Class;
 
 class Chalk::Grammar::Chalk::TypeRegistry {
     # Registry storage: class_name => Class instance
@@ -35,7 +36,6 @@ class Chalk::Grammar::Chalk::TypeRegistry {
         return $registry{$name} if exists $registry{$name};
 
         # Auto-create placeholder for forward reference
-        require Chalk::Grammar::Chalk::Type::Class;
         my $placeholder = Chalk::Grammar::Chalk::Type::Class->new(
             class_name => $name,
             fields => undef  # incomplete

--- a/lib/Chalk/Grammar/Chalk/TypeRegistry.pm
+++ b/lib/Chalk/Grammar/Chalk/TypeRegistry.pm
@@ -1,0 +1,65 @@
+# ABOUTME: Singleton registry managing class type namespace for forward references
+# ABOUTME: Maps qualified class names to Class type instances, supporting lazy resolution
+use 5.042;
+use experimental qw(class);
+
+class Chalk::Grammar::Chalk::TypeRegistry {
+    # Registry storage: class_name => Class instance
+    field %registry;
+
+    # Initialize registry
+    ADJUST {
+        %registry = ();
+    }
+
+    # Singleton accessor (class method)
+    sub instance {
+        my $class = shift // __PACKAGE__;
+        state $singleton = Chalk::Grammar::Chalk::TypeRegistry->new();
+        return $singleton;
+    }
+
+    # Reset singleton (for testing)
+    method reset() {
+        %registry = ();
+    }
+
+    # Register a class type (prevents redefinition of complete classes)
+    method register($name, $class_obj) {
+        # Check if trying to redefine a complete class
+        if (exists $registry{$name} && $registry{$name}->is_complete()) {
+            die "Cannot redefine complete class '$name'";
+        }
+
+        $registry{$name} = $class_obj;
+        return $class_obj;
+    }
+
+    # Lookup class type (auto-creates placeholder if not found)
+    method lookup($name) {
+        # Return existing class if found
+        return $registry{$name} if exists $registry{$name};
+
+        # Auto-create placeholder for forward reference
+        require Chalk::Grammar::Chalk::Type::Class;
+        my $placeholder = Chalk::Grammar::Chalk::Type::Class->new(
+            class_name => $name,
+            fields => undef  # incomplete
+        );
+        $registry{$name} = $placeholder;
+        return $placeholder;
+    }
+
+    # Check if class is registered
+    method has_class($name) {
+        return exists $registry{$name};
+    }
+
+    # Check if class has complete field definitions
+    method is_complete($name) {
+        return 0 unless exists $registry{$name};
+        return $registry{$name}->is_complete();
+    }
+}
+
+1;

--- a/lib/Chalk/Grammar/Chalk/TypeRegistry.pm
+++ b/lib/Chalk/Grammar/Chalk/TypeRegistry.pm
@@ -51,7 +51,7 @@ class Chalk::Grammar::Chalk::TypeRegistry {
 
     # Check if class has complete field definitions
     method is_complete($name) {
-        return 0 unless exists $registry{$name};
+        return false unless exists $registry{$name};
         return $registry{$name}->is_complete();
     }
 }

--- a/lib/Chalk/Grammar/Chalk/TypeRegistry.pm
+++ b/lib/Chalk/Grammar/Chalk/TypeRegistry.pm
@@ -7,14 +7,8 @@ class Chalk::Grammar::Chalk::TypeRegistry {
     # Registry storage: class_name => Class instance
     field %registry;
 
-    # Initialize registry
-    ADJUST {
-        %registry = ();
-    }
-
     # Singleton accessor (class method)
-    sub instance {
-        my $class = shift // __PACKAGE__;
+    sub instance($class = __PACKAGE__) {
         state $singleton = Chalk::Grammar::Chalk::TypeRegistry->new();
         return $singleton;
     }

--- a/t/types/class-types.t
+++ b/t/types/class-types.t
@@ -22,8 +22,7 @@ use lib 'lib';
     use Chalk::Grammar::Chalk::Type::Class;
     use Chalk::Grammar::Chalk::Type::Int;
 
-    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
-    $registry->reset();  # Clear for fresh test
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->new();
 
     # Register a complete class
     my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
@@ -45,8 +44,7 @@ use lib 'lib';
 {
     use Chalk::Grammar::Chalk::TypeRegistry;
 
-    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
-    $registry->reset();
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->new();
 
     ok(!$registry->has_class('Node'), 'Node not registered');
 
@@ -65,8 +63,7 @@ use lib 'lib';
     use Chalk::Grammar::Chalk::Type::Class;
     use Chalk::Grammar::Chalk::Type::Int;
 
-    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
-    $registry->reset();
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->new();
 
     my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
     my $class1 = Chalk::Grammar::Chalk::Type::Class->new(

--- a/t/types/class-types.t
+++ b/t/types/class-types.t
@@ -1,0 +1,395 @@
+# ABOUTME: Tests for Class type system foundation: TypeRegistry, Class, Maybe types
+# ABOUTME: Tests forward references, auto-deepening, and nullable references
+use 5.042;
+use experimental qw(class);
+
+use Test::More;
+use lib 'lib';
+
+# Test 1: TypeRegistry singleton
+{
+    use_ok('Chalk::Grammar::Chalk::TypeRegistry');
+
+    my $registry1 = Chalk::Grammar::Chalk::TypeRegistry->instance();
+    my $registry2 = Chalk::Grammar::Chalk::TypeRegistry->instance();
+
+    is($registry1, $registry2, 'TypeRegistry is a singleton');
+}
+
+# Test 2: TypeRegistry basic registration and lookup
+{
+    use Chalk::Grammar::Chalk::TypeRegistry;
+    use Chalk::Grammar::Chalk::Type::Class;
+    use Chalk::Grammar::Chalk::Type::Int;
+
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
+    $registry->reset();  # Clear for fresh test
+
+    # Register a complete class
+    my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
+    my $point_class = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Point',
+        fields => { x => $int_type, y => $int_type }
+    );
+
+    ok(!$registry->has_class('Point'), 'Point not registered yet');
+    $registry->register('Point', $point_class);
+    ok($registry->has_class('Point'), 'Point is now registered');
+    ok($registry->is_complete('Point'), 'Point is complete');
+
+    my $looked_up = $registry->lookup('Point');
+    is($looked_up, $point_class, 'lookup returns registered class');
+}
+
+# Test 3: TypeRegistry auto-creates placeholders
+{
+    use Chalk::Grammar::Chalk::TypeRegistry;
+
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
+    $registry->reset();
+
+    ok(!$registry->has_class('Node'), 'Node not registered');
+
+    # Lookup non-existent class should auto-create placeholder
+    my $placeholder = $registry->lookup('Node');
+    ok(defined($placeholder), 'lookup auto-creates placeholder');
+    ok($registry->has_class('Node'), 'Node now registered as placeholder');
+    ok(!$registry->is_complete('Node'), 'Node placeholder is incomplete');
+    is($placeholder->class_name(), 'Node', 'placeholder has correct name');
+    ok(!$placeholder->is_complete(), 'placeholder is incomplete');
+}
+
+# Test 4: TypeRegistry prevents redefinition of complete classes
+{
+    use Chalk::Grammar::Chalk::TypeRegistry;
+    use Chalk::Grammar::Chalk::Type::Class;
+    use Chalk::Grammar::Chalk::Type::Int;
+
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
+    $registry->reset();
+
+    my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
+    my $class1 = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Foo',
+        fields => { x => $int_type }
+    );
+
+    $registry->register('Foo', $class1);
+
+    # Attempt to redefine complete class should die
+    my $class2 = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Foo',
+        fields => { y => $int_type }
+    );
+
+    eval { $registry->register('Foo', $class2); };
+    like($@, qr/Cannot redefine complete class/, 'prevents redefinition of complete class');
+}
+
+# Test 5: Class type field access (complete classes)
+{
+    use Chalk::Grammar::Chalk::Type::Class;
+    use Chalk::Grammar::Chalk::Type::Int;
+    use Chalk::Grammar::Chalk::Type::Str;
+
+    my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
+    my $str_type = Chalk::Grammar::Chalk::Type::Str->new();
+
+    my $person_class = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Person',
+        fields => {
+            name => $str_type,
+            age => $int_type
+        }
+    );
+
+    ok($person_class->is_complete(), 'Person class is complete');
+    ok($person_class->has_field('name'), 'has_field detects name field');
+    ok($person_class->has_field('age'), 'has_field detects age field');
+    ok(!$person_class->has_field('address'), 'has_field returns false for missing field');
+
+    is($person_class->field_type('name'), $str_type, 'field_type returns correct type for name');
+    is($person_class->field_type('age'), $int_type, 'field_type returns correct type for age');
+
+    eval { $person_class->field_type('address'); };
+    like($@, qr/No field address/, 'field_type dies for missing field');
+}
+
+# Test 6: Class type placeholders cannot access fields directly
+{
+    use Chalk::Grammar::Chalk::Type::Class;
+
+    my $placeholder = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Node',
+        fields => undef
+    );
+
+    ok(!$placeholder->is_complete(), 'placeholder is incomplete');
+    ok(!$placeholder->has_field('val'), 'placeholder has_field returns false');
+}
+
+# Test 7: Auto-deepening resolves forward references
+{
+    use Chalk::Grammar::Chalk::TypeRegistry;
+    use Chalk::Grammar::Chalk::Type::Class;
+    use Chalk::Grammar::Chalk::Type::Int;
+
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
+    $registry->reset();
+
+    # Step 1: Create forward reference (placeholder)
+    my $node_placeholder = $registry->lookup('Node');
+    ok(!$node_placeholder->is_complete(), 'Node starts as placeholder');
+
+    # Step 2: Register complete Node definition
+    my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
+    my $node_complete = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Node',
+        fields => { val => $int_type }
+    );
+    $registry->register('Node', $node_complete);
+
+    # Step 3: Access field on old placeholder should auto-deepen
+    ok($node_placeholder->has_field('val'), 'auto-deepening: has_field works on old placeholder');
+    is($node_placeholder->field_type('val'), $int_type, 'auto-deepening: field_type works on old placeholder');
+}
+
+# Test 8: Class subtyping relationships
+{
+    use Chalk::Grammar::Chalk::Type::Class;
+    use Chalk::Grammar::Chalk::Type::Object;
+    use Chalk::Grammar::Chalk::Type::Ref;
+    use Chalk::Grammar::Chalk::Type::Scalar;
+    use Chalk::Grammar::Chalk::Type::Any;
+    use Chalk::Grammar::Chalk::Type::Int;
+
+    my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
+    my $node_class = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Node',
+        fields => { val => $int_type }
+    );
+
+    my $point_class = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Point',
+        fields => { x => $int_type, y => $int_type }
+    );
+
+    my $object_type = Chalk::Grammar::Chalk::Type::Object->new();
+    my $ref_type = Chalk::Grammar::Chalk::Type::Ref->new();
+    my $scalar_type = Chalk::Grammar::Chalk::Type::Scalar->new();
+    my $any_type = Chalk::Grammar::Chalk::Type::Any->new();
+
+    # Class <: Class (reflexive)
+    ok($node_class->is_subtype_of($node_class), 'Class <: Class (reflexive)');
+
+    # Class <: Object <: Ref <: Scalar <: Any
+    ok($node_class->is_subtype_of($object_type), 'Class <: Object');
+    ok($node_class->is_subtype_of($ref_type), 'Class <: Ref');
+    ok($node_class->is_subtype_of($scalar_type), 'Class <: Scalar');
+    ok($node_class->is_subtype_of($any_type), 'Class <: Any');
+
+    # Different classes are incompatible (nominal typing)
+    ok(!$node_class->is_subtype_of($point_class), 'Node <!: Point (nominal typing)');
+    ok(!$point_class->is_subtype_of($node_class), 'Point <!: Node (nominal typing)');
+}
+
+# Test 9: Maybe type basic operations
+{
+    use Chalk::Grammar::Chalk::Type::Maybe;
+    use Chalk::Grammar::Chalk::Type::Int;
+    use Chalk::Grammar::Chalk::Type::Class;
+
+    my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
+    my $maybe_int = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $int_type);
+
+    is($maybe_int->inner_type(), $int_type, 'Maybe wraps inner type');
+    is($maybe_int->unwrap(), $int_type, 'unwrap returns inner type');
+    is($maybe_int->name(), 'Maybe(Int)', 'Maybe name includes inner type');
+
+    # Test with Class type
+    my $node_class = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Node',
+        fields => { val => $int_type }
+    );
+    my $maybe_node = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $node_class);
+
+    is($maybe_node->inner_type(), $node_class, 'Maybe wraps Class type');
+    is($maybe_node->name(), 'Maybe(Class(Node))', 'Maybe name with Class');
+}
+
+# Test 10: Maybe type subtyping
+{
+    use Chalk::Grammar::Chalk::Type::Maybe;
+    use Chalk::Grammar::Chalk::Type::Int;
+    use Chalk::Grammar::Chalk::Type::Num;
+    use Chalk::Grammar::Chalk::Type::Str;
+    use Chalk::Grammar::Chalk::Type::Undef;
+
+    my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
+    my $num_type = Chalk::Grammar::Chalk::Type::Num->new();
+    my $str_type = Chalk::Grammar::Chalk::Type::Str->new();
+    my $undef_type = Chalk::Grammar::Chalk::Type::Undef->new();
+
+    my $maybe_int = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $int_type);
+    my $maybe_num = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $num_type);
+    my $maybe_str = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $str_type);
+
+    # Maybe(T) <: Maybe(T) (reflexive)
+    ok($maybe_int->is_subtype_of($maybe_int), 'Maybe(T) <: Maybe(T) reflexive');
+
+    # Maybe(T) <: Maybe(U) if T <: U (covariant)
+    # Int <: Num, so Maybe(Int) <: Maybe(Num)
+    ok($maybe_int->is_subtype_of($maybe_num), 'Maybe(Int) <: Maybe(Num) covariance');
+
+    # But not the reverse
+    ok(!$maybe_num->is_subtype_of($maybe_int), 'Maybe(Num) <!: Maybe(Int)');
+
+    # Incompatible inner types (use Class types which use nominal typing)
+    use Chalk::Grammar::Chalk::Type::Class;
+    my $node_class = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Node',
+        fields => {}
+    );
+    my $point_class = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Point',
+        fields => {}
+    );
+    my $maybe_node = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $node_class);
+    my $maybe_point = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $point_class);
+
+    ok(!$maybe_node->is_subtype_of($maybe_point), 'Maybe(Node) <!: Maybe(Point) with incompatible classes');
+
+    # Maybe(T) <: Undef (can be undef)
+    ok($maybe_int->is_subtype_of($undef_type), 'Maybe(T) <: Undef');
+}
+
+# Test 11: Integration - Self-referential linked list
+{
+    use Chalk::Grammar::Chalk::TypeRegistry;
+    use Chalk::Grammar::Chalk::Type::Class;
+    use Chalk::Grammar::Chalk::Type::Maybe;
+    use Chalk::Grammar::Chalk::Type::Int;
+
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
+    $registry->reset();
+
+    # Define LinkedList: { val: Int, next: Maybe(LinkedList) }
+    my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
+
+    # Step 1: Forward reference for self-reference
+    my $list_ref = $registry->lookup('LinkedList');  # Creates placeholder
+
+    # Step 2: Create Maybe(LinkedList) using placeholder
+    my $maybe_list = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $list_ref);
+
+    # Step 3: Register complete LinkedList definition
+    my $list_complete = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'LinkedList',
+        fields => {
+            val => $int_type,
+            next => $maybe_list
+        }
+    );
+    $registry->register('LinkedList', $list_complete);
+
+    # Step 4: Verify structure
+    ok($registry->is_complete('LinkedList'), 'LinkedList is complete');
+    ok($list_ref->has_field('val'), 'LinkedList has val field (auto-deepening)');
+    ok($list_ref->has_field('next'), 'LinkedList has next field (auto-deepening)');
+
+    my $next_type = $list_ref->field_type('next');
+    is(ref($next_type), 'Chalk::Grammar::Chalk::Type::Maybe', 'next field is Maybe type');
+    is($next_type->unwrap()->class_name(), 'LinkedList', 'next wraps LinkedList (self-reference works)');
+}
+
+# Test 12: Integration - Self-referential binary tree
+{
+    use Chalk::Grammar::Chalk::TypeRegistry;
+    use Chalk::Grammar::Chalk::Type::Class;
+    use Chalk::Grammar::Chalk::Type::Maybe;
+    use Chalk::Grammar::Chalk::Type::Int;
+
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
+    $registry->reset();
+
+    # Define TreeNode: { val: Int, left: Maybe(TreeNode), right: Maybe(TreeNode) }
+    my $int_type = Chalk::Grammar::Chalk::Type::Int->new();
+    my $tree_ref = $registry->lookup('TreeNode');
+
+    my $maybe_tree = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $tree_ref);
+
+    my $tree_complete = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'TreeNode',
+        fields => {
+            val => $int_type,
+            left => $maybe_tree,
+            right => $maybe_tree
+        }
+    );
+    $registry->register('TreeNode', $tree_complete);
+
+    ok($registry->is_complete('TreeNode'), 'TreeNode is complete');
+    ok($tree_ref->has_field('left'), 'TreeNode has left field');
+    ok($tree_ref->has_field('right'), 'TreeNode has right field');
+
+    my $left_type = $tree_ref->field_type('left');
+    my $right_type = $tree_ref->field_type('right');
+    is($left_type->unwrap()->class_name(), 'TreeNode', 'left wraps TreeNode');
+    is($right_type->unwrap()->class_name(), 'TreeNode', 'right wraps TreeNode');
+}
+
+# Test 13: Integration - Mutually recursive classes
+{
+    use Chalk::Grammar::Chalk::TypeRegistry;
+    use Chalk::Grammar::Chalk::Type::Class;
+    use Chalk::Grammar::Chalk::Type::Maybe;
+    use Chalk::Grammar::Chalk::Type::Int;
+
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
+    $registry->reset();
+
+    # Define mutually recursive: Person -> Company -> Person
+    # Person: { name: Str, employer: Maybe(Company) }
+    # Company: { name: Str, ceo: Maybe(Person) }
+
+    use Chalk::Grammar::Chalk::Type::Str;
+    my $str_type = Chalk::Grammar::Chalk::Type::Str->new();
+
+    # Create forward references
+    my $person_ref = $registry->lookup('Person');
+    my $company_ref = $registry->lookup('Company');
+
+    # Define Person with Maybe(Company)
+    my $maybe_company = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $company_ref);
+    my $person_complete = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Person',
+        fields => {
+            name => $str_type,
+            employer => $maybe_company
+        }
+    );
+    $registry->register('Person', $person_complete);
+
+    # Define Company with Maybe(Person)
+    my $maybe_person = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $person_ref);
+    my $company_complete = Chalk::Grammar::Chalk::Type::Class->new(
+        class_name => 'Company',
+        fields => {
+            name => $str_type,
+            ceo => $maybe_person
+        }
+    );
+    $registry->register('Company', $company_complete);
+
+    # Verify mutual references work via auto-deepening
+    ok($person_ref->has_field('employer'), 'Person has employer field');
+    ok($company_ref->has_field('ceo'), 'Company has ceo field');
+
+    my $employer_type = $person_ref->field_type('employer');
+    is($employer_type->unwrap()->class_name(), 'Company', 'Person.employer is Company');
+
+    my $ceo_type = $company_ref->field_type('ceo');
+    is($ceo_type->unwrap()->class_name(), 'Person', 'Company.ceo is Person');
+}
+
+done_testing();

--- a/t/types/class-types.t
+++ b/t/types/class-types.t
@@ -204,7 +204,7 @@ use lib 'lib';
 
     is($maybe_int->inner_type(), $int_type, 'Maybe wraps inner type');
     is($maybe_int->unwrap(), $int_type, 'unwrap returns inner type');
-    is($maybe_int->name(), 'Maybe(Int)', 'Maybe name includes inner type');
+    is($maybe_int->name(), 'Maybe[Int]', 'Maybe name includes inner type');
 
     # Test with Class type
     my $node_class = Chalk::Grammar::Chalk::Type::Class->new(
@@ -214,7 +214,7 @@ use lib 'lib';
     my $maybe_node = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $node_class);
 
     is($maybe_node->inner_type(), $node_class, 'Maybe wraps Class type');
-    is($maybe_node->name(), 'Maybe(Class(Node))', 'Maybe name with Class');
+    is($maybe_node->name(), 'Maybe[Class[Node]]', 'Maybe name with Class');
 }
 
 # Test 10: Maybe type subtyping
@@ -234,15 +234,15 @@ use lib 'lib';
     my $maybe_num = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $num_type);
     my $maybe_str = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $str_type);
 
-    # Maybe(T) <: Maybe(T) (reflexive)
-    ok($maybe_int->is_subtype_of($maybe_int), 'Maybe(T) <: Maybe(T) reflexive');
+    # Maybe[T] <: Maybe[T] (reflexive)
+    ok($maybe_int->is_subtype_of($maybe_int), 'Maybe[T] <: Maybe[T] reflexive');
 
-    # Maybe(T) <: Maybe(U) if T <: U (covariant)
-    # Int <: Num, so Maybe(Int) <: Maybe(Num)
-    ok($maybe_int->is_subtype_of($maybe_num), 'Maybe(Int) <: Maybe(Num) covariance');
+    # Maybe[T] <: Maybe[U] if T <: U (covariant)
+    # Int <: Num, so Maybe[Int] <: Maybe[Num]
+    ok($maybe_int->is_subtype_of($maybe_num), 'Maybe[Int] <: Maybe[Num] covariance');
 
     # But not the reverse
-    ok(!$maybe_num->is_subtype_of($maybe_int), 'Maybe(Num) <!: Maybe(Int)');
+    ok(!$maybe_num->is_subtype_of($maybe_int), 'Maybe[Num] <!: Maybe[Int]');
 
     # Incompatible inner types (use Class types which use nominal typing)
     use Chalk::Grammar::Chalk::Type::Class;
@@ -257,10 +257,10 @@ use lib 'lib';
     my $maybe_node = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $node_class);
     my $maybe_point = Chalk::Grammar::Chalk::Type::Maybe->new(inner_type => $point_class);
 
-    ok(!$maybe_node->is_subtype_of($maybe_point), 'Maybe(Node) <!: Maybe(Point) with incompatible classes');
+    ok(!$maybe_node->is_subtype_of($maybe_point), 'Maybe[Node] <!: Maybe[Point] with incompatible classes');
 
-    # Maybe(T) <: Undef (can be undef)
-    ok($maybe_int->is_subtype_of($undef_type), 'Maybe(T) <: Undef');
+    # Maybe[T] <: Undef (can be undef)
+    ok($maybe_int->is_subtype_of($undef_type), 'Maybe[T] <: Undef');
 }
 
 # Test 11: Integration - Self-referential linked list


### PR DESCRIPTION
## Summary

Implements the type system foundation for nested and recursive struct references (Issue #341, Chapter 13 Session 1).

## Components Implemented

**1. TypeRegistry** - Singleton registry managing class type namespace
**2. Class Type** - Represents instances of user-defined classes with auto-deepening  
**3. Maybe Type** - Nullable wrapper for optional references

## Test Coverage

✅ **56 tests, 100% pass rate** (`t/types/class-types.t`)

## Files Changed

- lib/Chalk/Grammar/Chalk/TypeRegistry.pm (+65 lines)
- lib/Chalk/Grammar/Chalk/Type/Class.pm (+74 lines)
- lib/Chalk/Grammar/Chalk/Type/Maybe.pm (+30 lines)
- t/types/class-types.t (+396 lines)
- docs/plans/2025-12-05-class-type-system-foundation.md (+272 lines)

**Total: 837 insertions**

## Success Criteria Met

- ✅ Can define self-referential class types
- ✅ Can define mutually recursive class types
- ✅ Forward declarations resolve correctly
- ✅ Nullable vs non-nullable types distinguished
- ✅ All tests pass at 100%
- ✅ Foundation ready for Session 2

## Related Issues

Fixes #341
Part of #335
Blocks #342, #343