### PR TITLE
refactor: Split TypeInference into SemanticValidation + grammar-specific rules

### DIFF
--- a/lib/Chalk/Grammar/Chalk/SemanticRules.pm
+++ b/lib/Chalk/Grammar/Chalk/SemanticRules.pm
@@ -1,0 +1,83 @@
+# ABOUTME: Chalk/Perl-specific semantic validation rules for parsing
+# ABOUTME: Encapsulates grammar-specific constraints like postfix conditional restrictions
+use 5.42.0;
+use experimental qw(class builtin keyword_any keyword_all);
+use utf8;
+use Chalk::Base;
+
+class Chalk::Grammar::Chalk::SemanticRules {
+    # Validate a packed SPPF node for semantic correctness
+    # Returns 1 if valid, 0 if invalid
+    method validate($packed) {
+        my $rule = $packed->rule;
+        return 1 unless $rule;  # Non-rule nodes valid by default
+
+        # VALIDATION: Statement -> Statement WS_OPT ConditionalKeyword WS_OPT Expression
+        # This is the postfix conditional modifier rule
+        # It should NOT apply when the base Statement is already a block-form conditional
+        if ($rule->lhs eq 'Statement' && $self->_is_postfix_conditional_rule($rule)) {
+            return $self->_validate_postfix_conditional($packed);
+        }
+
+        # Add more Chalk/Perl-specific validation rules here as needed:
+        # - No 'my' in expression context
+        # - Method call syntax validation
+        # - Package name validation
+        # - etc.
+
+        return 1;  # Default: valid
+    }
+
+    method _is_postfix_conditional_rule($rule) {
+        # Check if this is: Statement -> Statement WS_OPT ConditionalKeyword WS_OPT Expression
+        my $rhs = $rule->rhs;
+        return 0 unless $rhs && ref($rhs) eq 'ARRAY';
+        return 0 unless scalar($rhs->@*) == 5;
+
+        return ($rhs->[0] eq 'Statement' &&
+                $rhs->[1] eq 'WS_OPT' &&
+                $rhs->[2] eq 'ConditionalKeyword' &&
+                $rhs->[3] eq 'WS_OPT' &&
+                $rhs->[4] eq 'Expression');
+    }
+
+    method _validate_postfix_conditional($packed) {
+        my @children = $packed->children;
+        return 1 unless @children;
+
+        # First child should be the base Statement
+        my $base_stmt_node = $children[0];
+        return 1 unless $base_stmt_node && $base_stmt_node->isa('Chalk::ParseForest::SymbolNode');
+
+        # Check if base statement is a Block (which includes ConditionalStatement)
+        # If it is, this postfix application is INVALID
+        return !$self->_statement_is_block_form($base_stmt_node);
+    }
+
+    method _statement_is_block_form($stmt_node) {
+        # Check if Statement -> Block
+        my @packed = $stmt_node->packed_nodes;
+        return 0 unless @packed;
+
+        for my $packed (@packed) {
+            my $rule = $packed->rule;
+            next unless $rule;
+
+            # Statement -> Block rule
+            if ($rule->lhs eq 'Statement' && $self->_is_block_rule($rule)) {
+                return 1;  # Yes, this is a block-form statement
+            }
+        }
+
+        return 0;  # Not a block-form statement
+    }
+
+    method _is_block_rule($rule) {
+        my $rhs = $rule->rhs;
+        return 0 unless $rhs && ref($rhs) eq 'ARRAY';
+        return 0 unless scalar($rhs->@*) == 1;
+        return $rhs->[0] eq 'Block';
+    }
+}
+
+1;

--- a/lib/Chalk/Semiring/ChalkSyntax.pm
+++ b/lib/Chalk/Semiring/ChalkSyntax.pm
@@ -1,4 +1,4 @@
-# ABOUTME: Composite semiring for Chalk syntax validation (Boolean + Precedence + TypeInference)
+# ABOUTME: Composite semiring for Chalk syntax validation (Boolean + Precedence + SemanticValidation)
 # ABOUTME: Pure validation composite - no building, just filtering for valid parses
 use 5.42.0;
 use experimental qw(class builtin keyword_any keyword_all);
@@ -6,7 +6,8 @@ use utf8;
 use Chalk::Base;
 use Chalk::Semiring::Boolean;
 use Chalk::Semiring::Precedence;
-use Chalk::Semiring::TypeInference;
+use Chalk::Semiring::SemanticValidation;
+use Chalk::Grammar::Chalk::SemanticRules;
 use Chalk::Semiring::Composite;
 
 class Chalk::Semiring::ChalkSyntax :isa(Chalk::Semiring) {
@@ -53,13 +54,17 @@ class Chalk::Semiring::ChalkSyntax :isa(Chalk::Semiring) {
             precedence_table => \@perl_precedence_table
         );
 
-        # Filter 3: TypeInference - Semantic constraint validation
-        my $type_sr = Chalk::Semiring::TypeInference->new();
+        # Filter 3: SemanticValidation - Semantic constraint validation
+        # Uses Chalk-specific semantic rules
+        my $semantic_rules = Chalk::Grammar::Chalk::SemanticRules->new();
+        my $semantic_sr = Chalk::Semiring::SemanticValidation->new(
+            rules => $semantic_rules
+        );
 
-        # Composite: Boolean + Precedence + TypeInference
+        # Composite: Boolean + Precedence + SemanticValidation
         # Pure validation - returns boolean success/failure
         $composite = Chalk::Semiring::Composite->new(
-            semirings => [$bool_sr, $precedence_sr, $type_sr]
+            semirings => [$bool_sr, $precedence_sr, $semantic_sr]
         );
     }
 

--- a/lib/Chalk/Semiring/SemanticValidation.pm
+++ b/lib/Chalk/Semiring/SemanticValidation.pm
@@ -1,0 +1,180 @@
+# ABOUTME: Generic semantic validation semiring for parse-time constraint checking
+# ABOUTME: Validates semantic constraints using pluggable grammar-specific rules
+use 5.42.0;
+use experimental qw(class builtin keyword_any keyword_all);
+use utf8;
+use Chalk::Base;
+
+class Chalk::Semiring::SemanticValidationElement :isa(Chalk::Element) {
+    use overload '""' => 'to_string';
+
+    field $valid :param :reader;  # Boolean: 1 = semantically valid, 0 = invalid
+    field $type :param :reader = undef;  # Inferred type (if known) - reserved for future use
+    field $sppf_node :param :reader = undef;  # SPPF node for examining parse structure
+    field $forest :param :reader = undef;  # Reference to SPPF forest
+    field $rules :param :reader = undef;  # Grammar-specific semantic rules
+
+    method to_string(@args) {
+        return $valid ? 'valid' : 'invalid';
+    }
+
+    method score() {
+        return $valid ? 1 : 0;
+    }
+
+    method equals($other, $swap = undef) {
+        return 0 unless ref($other) eq ref($self);
+        return 0 unless $valid == $other->valid;
+
+        # Compare types if both are defined (reserved for future type inference)
+        if (defined($type) && defined($other->type)) {
+            return 0 unless $type->equals($other->type);
+        } elsif (defined($type) || defined($other->type)) {
+            return 0;  # One defined, one not - not equal
+        }
+
+        return 1;
+    }
+
+    method add($other, $swap = undef) {
+        # Choose between alternative parses based on semantic validity
+        # Similar pattern to Precedence semiring
+
+        # Handle undef or wrong type
+        return $self unless defined $other;
+        return $self unless ref($other) && $other->can('valid');
+
+        # If self is invalid (add_id), return other
+        return $other if !$valid;
+
+        # If other is invalid, return self
+        return $self if !$other->valid;
+
+        # Both marked valid initially - validate their semantic constraints
+        my $self_valid = $self->_validate_semantic_constraints();
+        my $other_valid = $other->_validate_semantic_constraints();
+
+        if ($self_valid && !$other_valid) {
+            return $self;
+        } elsif ($other_valid && !$self_valid) {
+            return $other;
+        } elsif (!$self_valid && !$other_valid) {
+            # Neither valid - return add_id
+            return Chalk::Semiring::SemanticValidationElement->new(
+                valid => 0,
+                forest => $forest,
+                rules => $rules
+            );
+        } else {
+            # Both valid - prefer self (first alternative)
+            return $self;
+        }
+    }
+
+    method _validate_semantic_constraints() {
+        # If no SPPF node, assume valid
+        return 1 unless $sppf_node;
+
+        # If no rules provided, assume valid
+        return 1 unless $rules;
+
+        # Get all packed alternatives
+        my @packed_nodes = $sppf_node->packed_nodes;
+        return 1 unless @packed_nodes;
+
+        # Check if ANY packed alternative is semantically valid
+        for my $packed (@packed_nodes) {
+            if ($rules->validate($packed)) {
+                return 1;
+            }
+        }
+
+        return 0;  # No valid alternatives
+    }
+
+    method multiply($other, $swap = undef) {
+        # Semantic validation doesn't need special multiply logic
+        # Just combine the elements
+        return $self unless defined $other;
+        return $self unless ref($other) && $other->can('valid');
+
+        # If either is invalid, result is invalid
+        if (!$valid || !$other->valid) {
+            return Chalk::Semiring::SemanticValidationElement->new(
+                valid => 0,
+                forest => $forest,
+                rules => $rules
+            );
+        }
+
+        # Both valid - return self (could do type unification here later)
+        return $self;
+    }
+}
+
+class Chalk::Semiring::SemanticValidation :isa(Chalk::Semiring) {
+    field $rules :param :reader = undef;  # Grammar-specific semantic rules
+    field $forest :reader = undef;  # Shared SPPF forest
+    field $shared_context :param = undef;
+    field $mul_id :reader;  # Multiplicative identity (one)
+    field $add_id :reader;  # Additive identity (zero)
+
+    ADJUST {
+        # Extract forest from shared_context if provided
+        if ($shared_context && ref($shared_context) eq 'HASH') {
+            $forest = $shared_context->{forest};
+        }
+
+        # Initialize identity elements
+        $add_id = Chalk::Semiring::SemanticValidationElement->new(
+            valid => 0,
+            forest => $forest,
+            rules => $rules
+        );
+
+        $mul_id = Chalk::Semiring::SemanticValidationElement->new(
+            valid => 1,
+            forest => $forest,
+            rules => $rules
+        );
+    }
+
+    method zero() {
+        return $add_id;
+    }
+
+    method one() {
+        return $mul_id;
+    }
+
+    method from_symbol($symbol, $start_pos, $end_pos, $sppf_node = undef) {
+        # Find the corresponding SPPF node if we have a forest
+        my $actual_sppf_node = $sppf_node;
+
+        if ($forest && !$actual_sppf_node) {
+            my $key = "${symbol}|${start_pos}|${end_pos}";
+            my $nodes = $forest->nodes;
+            $actual_sppf_node = $nodes->{$key};
+        }
+
+        return Chalk::Semiring::SemanticValidationElement->new(
+            valid => 1,
+            sppf_node => $actual_sppf_node,
+            forest => $forest,
+            rules => $rules
+        );
+    }
+
+    method from_terminal($symbol, $start_pos, $end_pos) {
+        # Terminals are always valid
+        return $self->one();
+    }
+
+    method init_element_from_rule($rule, $start_pos = 0, $end_pos = 0, $matched_value = undef) {
+        # All rules start as valid (1) - they are syntactically correct
+        # Semantic validation happens in add() when choosing between alternatives
+        return $self->one();
+    }
+}
+
+1;

--- a/lib/Chalk/Semiring/TypeInference.pm
+++ b/lib/Chalk/Semiring/TypeInference.pm
@@ -1,241 +1,61 @@
-# ABOUTME: Type Inference semiring for semantic validation during parsing
-# ABOUTME: Validates type correctness and semantic constraints like statement modifiers
+# ABOUTME: DEPRECATED - Use Chalk::Semiring::SemanticValidation instead
+# ABOUTME: This module exists for backwards compatibility and delegates to SemanticValidation
 use 5.42.0;
 use experimental qw(class builtin keyword_any keyword_all);
 use utf8;
 use Chalk::Base;
+use Chalk::Semiring::SemanticValidation;
+use Chalk::Grammar::Chalk::SemanticRules;
 
-class Chalk::Semiring::TypeInferenceElement :isa(Chalk::Element) {
-    use overload '""' => 'to_string';
-
-    field $valid :param :reader;  # Boolean: 1 = semantically valid, 0 = invalid
-    field $type :param :reader = undef;  # Inferred type (if known)
-    field $sppf_node :param :reader = undef;  # SPPF node for examining parse structure
-    field $forest :param :reader = undef;  # Reference to SPPF forest
-    field $context :param :reader = undef;  # Parse context for rule information
-
-    method to_string(@args) {
-        return $valid ? 'valid' : 'invalid';
-    }
-
-    method score() {
-        return $valid ? 1 : 0;
-    }
-
-    method equals($other, $swap = undef) {
-        return 0 unless ref($other) eq ref($self);
-        return 0 unless $valid == $other->valid;
-
-        # Compare types if both are defined
-        if (defined($type) && defined($other->type)) {
-            return 0 unless $type->equals($other->type);
-        } elsif (defined($type) || defined($other->type)) {
-            return 0;  # One defined, one not - not equal
-        }
-
-        return 1;
-    }
-
-    method add($other, $swap = undef) {
-        # Choose between alternative parses based on semantic validity
-        # Similar pattern to Precedence semiring
-
-        # Handle undef or wrong type
-        return $self unless defined $other;
-        return $self unless ref($other) && $other->can('valid');
-
-        # If self is invalid (add_id), return other
-        return $other if !$valid;
-
-        # If other is invalid, return self
-        return $self if !$other->valid;
-
-        # Both marked valid initially - validate their semantic constraints
-        my $self_valid = $self->_validate_semantic_constraints();
-        my $other_valid = $other->_validate_semantic_constraints();
-
-        if ($self_valid && !$other_valid) {
-            return $self;
-        } elsif ($other_valid && !$self_valid) {
-            return $other;
-        } elsif (!$self_valid && !$other_valid) {
-            # Neither valid - return add_id
-            return Chalk::Semiring::TypeInferenceElement->new(
-                valid => 0,
-                forest => $forest
-            );
-        } else {
-            # Both valid - prefer self (first alternative)
-            return $self;
-        }
-    }
-
-    method _validate_semantic_constraints() {
-        # If no SPPF node, assume valid
-        return 1 unless $sppf_node;
-
-        # Get all packed alternatives
-        my @packed_nodes = $sppf_node->packed_nodes;
-        return 1 unless @packed_nodes;
-
-        # Check if ANY packed alternative is semantically valid
-        for my $packed (@packed_nodes) {
-            if ($self->_validate_packed_node($packed)) {
-                return 1;
-            }
-        }
-
-        return 0;  # No valid alternatives
-    }
-
-    method _validate_packed_node($packed) {
-        my $rule = $packed->rule;
-        return 1 unless $rule;  # Non-rule nodes valid by default
-
-        # VALIDATION: Statement -> Statement WS_OPT ConditionalKeyword WS_OPT Expression
-        # This is the postfix conditional modifier rule
-        # It should NOT apply when the base Statement is already a block-form conditional
-        if ($rule->lhs eq 'Statement' && $self->_is_postfix_conditional_rule($rule)) {
-            return $self->_validate_postfix_conditional($packed);
-        }
-
-        # Add more validation rules here as needed
-        # - Type checking for operations
-        # - Return type validation
-        # - Variable scope validation
-        # etc.
-
-        return 1;  # Default: valid
-    }
-
-    method _is_postfix_conditional_rule($rule) {
-        # Check if this is: Statement -> Statement WS_OPT ConditionalKeyword WS_OPT Expression
-        my $rhs = $rule->rhs;
-        return 0 unless $rhs && ref($rhs) eq 'ARRAY';
-        return 0 unless scalar($rhs->@*) == 5;
-
-        return ($rhs->[0] eq 'Statement' &&
-                $rhs->[1] eq 'WS_OPT' &&
-                $rhs->[2] eq 'ConditionalKeyword' &&
-                $rhs->[3] eq 'WS_OPT' &&
-                $rhs->[4] eq 'Expression');
-    }
-
-    method _validate_postfix_conditional($packed) {
-        my @children = $packed->children;
-        return 1 unless @children;
-
-        # First child should be the base Statement
-        my $base_stmt_node = $children[0];
-        return 1 unless $base_stmt_node && $base_stmt_node->isa('Chalk::ParseForest::SymbolNode');
-
-        # Check if base statement is a Block (which includes ConditionalStatement)
-        # If it is, this postfix application is INVALID
-        return !$self->_statement_is_block_form($base_stmt_node);
-    }
-
-    method _statement_is_block_form($stmt_node) {
-        # Check if Statement -> Block
-        my @packed = $stmt_node->packed_nodes;
-        return 0 unless @packed;
-
-        for my $packed (@packed) {
-            my $rule = $packed->rule;
-            next unless $rule;
-
-            # Statement -> Block rule
-            if ($rule->lhs eq 'Statement' && $self->_is_block_rule($rule)) {
-                return 1;  # Yes, this is a block-form statement
-            }
-        }
-
-        return 0;  # Not a block-form statement
-    }
-
-    method _is_block_rule($rule) {
-        my $rhs = $rule->rhs;
-        return 0 unless $rhs && ref($rhs) eq 'ARRAY';
-        return 0 unless scalar($rhs->@*) == 1;
-        return $rhs->[0] eq 'Block';
-    }
-
-    method multiply($other, $swap = undef) {
-        # Type inference doesn't need special multiply logic
-        # Just combine the elements
-        return $self unless defined $other;
-        return $self unless ref($other) && $other->can('valid');
-
-        # If either is invalid, result is invalid
-        if (!$valid || !$other->valid) {
-            return Chalk::Semiring::TypeInferenceElement->new(
-                valid => 0,
-                forest => $forest
-            );
-        }
-
-        # Both valid - return self (could do type unification here later)
-        return $self;
-    }
+# DEPRECATED: TypeInferenceElement is now SemanticValidationElement
+# This alias exists for backwards compatibility with existing tests
+class Chalk::Semiring::TypeInferenceElement :isa(Chalk::Semiring::SemanticValidationElement) {
 }
 
+# DEPRECATED: TypeInference is now SemanticValidation
+# This wrapper exists for backwards compatibility with existing tests
 class Chalk::Semiring::TypeInference :isa(Chalk::Semiring) {
-    field $forest :reader = undef;  # Shared SPPF forest
+    field $delegate :reader;  # Delegate to SemanticValidation
     field $shared_context :param = undef;
-    field $mul_id :reader;  # Multiplicative identity (one)
-    field $add_id :reader;  # Additive identity (zero)
 
     ADJUST {
-        # Extract forest from shared_context if provided
-        if ($shared_context && ref($shared_context) eq 'HASH') {
-            $forest = $shared_context->{forest};
-        }
+        # Create Chalk-specific semantic rules for backwards compatibility
+        my $rules = Chalk::Grammar::Chalk::SemanticRules->new();
 
-        # Initialize identity elements
-        $add_id = Chalk::Semiring::TypeInferenceElement->new(
-            valid => 0,
-            forest => $forest
-        );
-
-        $mul_id = Chalk::Semiring::TypeInferenceElement->new(
-            valid => 1,
-            forest => $forest
+        # Create the new SemanticValidation semiring
+        $delegate = Chalk::Semiring::SemanticValidation->new(
+            rules => $rules,
+            shared_context => $shared_context
         );
     }
 
+    # Delegate all semiring methods to SemanticValidation
     method zero() {
-        return $add_id;
+        return $delegate->zero();
     }
 
     method one() {
-        return $mul_id;
+        return $delegate->one();
     }
 
     method from_symbol($symbol, $start_pos, $end_pos, $sppf_node = undef) {
-        # Find the corresponding SPPF node if we have a forest
-        my $actual_sppf_node = $sppf_node;
-
-        if ($forest && !$actual_sppf_node) {
-            my $key = "${symbol}|${start_pos}|${end_pos}";
-            my $nodes = $forest->nodes;
-            $actual_sppf_node = $nodes->{$key};
-        }
-
-        return Chalk::Semiring::TypeInferenceElement->new(
-            valid => 1,
-            sppf_node => $actual_sppf_node,
-            forest => $forest
-        );
+        return $delegate->from_symbol($symbol, $start_pos, $end_pos, $sppf_node);
     }
 
     method from_terminal($symbol, $start_pos, $end_pos) {
-        # Terminals are always valid
-        return $self->one();
+        return $delegate->from_terminal($symbol, $start_pos, $end_pos);
     }
 
     method init_element_from_rule($rule, $start_pos = 0, $end_pos = 0, $matched_value = undef) {
-        # All rules start as valid (1) - they are syntactically correct
-        # Semantic validation happens in add() when choosing between alternatives
-        return $self->one();
+        return $delegate->init_element_from_rule($rule, $start_pos, $end_pos, $matched_value);
+    }
+
+    method mul_id() {
+        return $delegate->mul_id();
+    }
+
+    method add_id() {
+        return $delegate->add_id();
     }
 }
 

--- a/t/semiring/chalk-syntax.t
+++ b/t/semiring/chalk-syntax.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # ABOUTME: Test ChalkSyntax semiring for syntax and precedence validation
-# ABOUTME: Verifies Boolean+Precedence+TypeInference composition for pure validation
+# ABOUTME: Verifies Boolean+Precedence+SemanticValidation composition for pure validation
 use 5.42.0;
 use Test2::V0;
 use FindBin qw($RealBin);
@@ -26,13 +26,13 @@ subtest 'ChalkSyntax semiring creation' => sub {
     ok $semiring->composite, 'Has composite semiring';
     ok $semiring->grammar, 'Has grammar reference';
 
-    # Check that composite has Boolean + Precedence + TypeInference semirings
+    # Check that composite has Boolean + Precedence + SemanticValidation semirings
     my $semirings = $semiring->composite->semirings;
     is scalar(@$semirings), 3, 'Composite has three semirings';
 
     isa_ok $semirings->[0], ['Chalk::Semiring::Boolean'], 'First semiring is Boolean';
     isa_ok $semirings->[1], ['Chalk::Semiring::Precedence'], 'Second semiring is Precedence';
-    isa_ok $semirings->[2], ['Chalk::Semiring::TypeInference'], 'Third semiring is TypeInference';
+    isa_ok $semirings->[2], ['Chalk::Semiring::SemanticValidation'], 'Third semiring is SemanticValidation';
 };
 
 subtest 'ChalkSyntax identity elements' => sub {


### PR DESCRIPTION
## Summary

Renamed `Chalk::Semiring::TypeInference` to `Chalk::Semiring::SemanticValidation` and extracted Chalk/Perl-specific validation logic to `Chalk::Grammar::Chalk::SemanticRules`.

This refactoring addresses the issues raised in #331:
- **Misleading name**: `TypeInference` didn't do type inference, it did semantic validation
- **Grammar-specific logic in generic semiring**: Postfix conditional validation was hardcoded

## Architecture Changes

### Before
```perl
# In ChalkSyntax:
my $type_sr = Chalk::Semiring::TypeInference->new();  # Hardcoded Chalk/Perl rules

# In TypeInference semiring:
method _validate_packed_node($packed) {
    # Hardcoded Chalk/Perl rule: no postfix conditionals on blocks
    if ($rule->lhs eq 'Statement' && $self->_is_postfix_conditional_rule($rule)) {
        return $self->_validate_postfix_conditional($packed);
    }
}
```

### After
```perl
# In ChalkSyntax:
my $semantic_rules = Chalk::Grammar::Chalk::SemanticRules->new();  # Pluggable
my $semantic_sr = Chalk::Semiring::SemanticValidation->new(
    rules => $semantic_rules
);

# Generic semiring delegates to rules:
class Chalk::Semiring::SemanticValidation {
    field $rules :param :reader;  # Grammar-specific rules
    method _validate_semantic_constraints() {
        return $rules->validate($packed);
    }
}

# Grammar-specific rules in separate module:
class Chalk::Grammar::Chalk::SemanticRules {
    method validate($packed) {
        # Perl-specific semantic constraints
    }
}
```

## Benefits

1. **Clear separation of concerns**: Semiring = generic validation mechanism, Rules = grammar-specific constraints
2. **Reusability**: Other grammars can use `SemanticValidation` semiring with their own rule sets
3. **Extensibility**: Easy to add new Perl-specific semantic rules without modifying semiring
4. **Correct naming**: `SemanticValidation` accurately describes what it does
5. **Follows existing pattern**: Matches how `Precedence` semiring works with precedence tables

## Files Changed

- **Created** `lib/Chalk/Semiring/SemanticValidation.pm` - Generic, pluggable semantic validation semiring
- **Created** `lib/Chalk/Grammar/Chalk/SemanticRules.pm` - Chalk/Perl-specific validation rules
- **Modified** `lib/Chalk/Semiring/ChalkSyntax.pm` - Uses new architecture
- **Modified** `lib/Chalk/Semiring/TypeInference.pm` - Now backwards-compatible delegation wrapper  
- **Modified** `t/semiring/chalk-syntax.t` - Updated test expectations

## Backwards Compatibility

The old `TypeInference` module remains as a delegation wrapper, so existing code continues to work without changes.

## Test Results

✅ All TypeInference tests pass (using compatibility wrapper)
✅ ChalkSyntax tests pass with new architecture
✅ Test expectations updated to reflect new naming

Fixes #331