### PR TITLE
Use Perl 5.42.0 builtin functions

### DIFF
--- a/lib/Chalk/Grammar/Chalk/Type/Coercion.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Coercion.pm
@@ -6,7 +6,7 @@ use experimental qw(class);
 use Chalk::Grammar::Chalk::Type::Code;
 
 class Chalk::Grammar::Chalk::Type::Coercion :isa(Chalk::Grammar::Chalk::Type::Code) {
-    use Scalar::Util qw(looks_like_number refaddr blessed);
+    use Scalar::Util qw(looks_like_number);
     use Chalk::Grammar::Chalk::Type::Exception;
     use Chalk::Grammar::Chalk::Type::Num;
     use Chalk::Grammar::Chalk::Type::Str;

--- a/lib/Chalk/IR/Node/Scope.pm
+++ b/lib/Chalk/IR/Node/Scope.pm
@@ -3,7 +3,6 @@
 use 5.42.0;
 use experimental qw(class builtin);
 use utf8;
-use Scalar::Util qw(refaddr);
 
 class Chalk::IR::Node::Scope {
     # Immutable Scope - all "mutation" methods return new Scope instances


### PR DESCRIPTION
## Summary

Remove unnecessary imports from `Scalar::Util` by using Perl 5.42.0 builtin functions `refaddr` and `blessed`.

## Changes

- **lib/Chalk/IR/Node/Scope.pm**: Remove `use Scalar::Util qw(refaddr)`
- **lib/Chalk/Grammar/Chalk/Type/Coercion.pm**: Remove `refaddr` and `blessed` from import, keep only `looks_like_number`

## Benefits

- Zero module imports for `refaddr` and `blessed` (now builtins)
- Better leverages modern Perl 5.42.0 features
- Maintains code clarity while reducing dependencies
- `looks_like_number` remains from core `Scalar::Util` (well-tested, handles all edge cases correctly)

## Testing

- Syntax check passed for both modified files
- No behavioral changes - builtins work identically to module versions

## Related

This continues the dependency reduction effort, following the same philosophy as using builtin `any` from `experimental keyword_any`.