### PR TITLE
fix(gvn): Preserve polymorphic node types during GVN optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ nytprof/
 local/
 build/
 
+# Git worktrees
+.worktrees/
+
 # Editor files
 .vscode/
 .idea/

--- a/docs/plans/2025-12-17-gvn-clone-reconstruction-design.md
+++ b/docs/plans/2025-12-17-gvn-clone-reconstruction-design.md
@@ -1,0 +1,80 @@
+# GVN Clone-Based Reconstruction Design
+
+## Problem
+
+GVN (Global Value Numbering) optimizer breaks polymorphic node types when reconstructing nodes. After optimization, `Chalk::IR::Node::Add` becomes generic `Chalk::IR::Node`, causing test failures in:
+- `t/sea-of-nodes/gvn.t` (Test 8, Test 14)
+- `t/integration/app-default-ir-generation.t`
+
+Related issues: #385, #200
+
+## Root Cause
+
+`Chalk::IR::Node->from_hash()` only supports polymorphic reconstruction for `Constant` and `Start` nodes. All other ops fall back to generic `Chalk::IR::Node` because polymorphic constructors expect node objects, not node IDs.
+
+## Solution: Clone-Based Reconstruction
+
+Instead of reconstructing nodes from hash data, clone the original node and update its inputs/attributes.
+
+### 1. Add `clone_with_inputs()` to Chalk::IR::Node
+
+```perl
+method clone_with_inputs($new_inputs, $new_attributes = undef, $new_id = undef) {
+    my $class = blessed($self);
+
+    return $class->new(
+        id              => $new_id // $id,
+        op              => $op,
+        inputs          => $new_inputs,
+        attributes      => $new_attributes // $attributes,
+        source_info     => $source_info,
+        transform_chain => $transform_chain,
+    );
+}
+```
+
+Key: `blessed($self)` preserves the polymorphic class (Add, Multiply, etc.).
+
+### 2. Update GVN.pm
+
+Replace lines 86-96 in `run_gvn()`:
+
+```perl
+# Before (broken):
+my $new_node = Chalk::IR::Node->from_hash({...});
+
+# After (preserves polymorphism):
+my $new_node = $old_node->clone_with_inputs(\@new_inputs, $new_attributes);
+```
+
+### 3. Record Transform (Optional Enhancement)
+
+After cloning, record the GVN optimization:
+
+```perl
+if ($had_redirections) {
+    $new_node->record_transform('optimization', 'GVN',
+        context => "inputs redirected due to CSE"
+    );
+}
+```
+
+## Test Expectations
+
+| Test | Current | After Fix |
+|------|---------|-----------|
+| Test 8: Different constants not merged | FAIL | PASS |
+| Test 14: Polymorphic types preserved | FAIL | PASS |
+
+## Implementation Steps
+
+1. Add `clone_with_inputs()` method to `lib/Chalk/IR/Node.pm`
+2. Update `lib/Chalk/IR/Optimizer/GVN.pm` to use clone instead of from_hash
+3. Remove TODO markers from gvn.t tests
+4. Run full test suite to verify no regressions
+
+## Files Changed
+
+- `lib/Chalk/IR/Node.pm` - Add clone_with_inputs method
+- `lib/Chalk/IR/Optimizer/GVN.pm` - Use clone-based reconstruction
+- `t/sea-of-nodes/gvn.t` - Remove TODO markers after fix

--- a/docs/plans/2025-12-17-gvn-clone-reconstruction-design.md
+++ b/docs/plans/2025-12-17-gvn-clone-reconstruction-design.md
@@ -3,7 +3,7 @@
 ## Problem
 
 GVN (Global Value Numbering) optimizer breaks polymorphic node types when reconstructing nodes. After optimization, `Chalk::IR::Node::Add` becomes generic `Chalk::IR::Node`, causing test failures in:
-- `t/sea-of-nodes/gvn.t` (Test 8, Test 14)
+- `t/sea-of-nodes/gvn.t` (Test 8, Test 11, Test 14)
 - `t/integration/app-default-ir-generation.t`
 
 Related issues: #385, #200
@@ -12,18 +12,28 @@ Related issues: #385, #200
 
 `Chalk::IR::Node->from_hash()` only supports polymorphic reconstruction for `Constant` and `Start` nodes. All other ops fall back to generic `Chalk::IR::Node` because polymorphic constructors expect node objects, not node IDs.
 
-## Solution: Clone-Based Reconstruction
+Additionally, polymorphic node classes (Add, Multiply, etc.) are NOT subclasses of Chalk::IR::Node - they have their own constructors that require node objects for operands.
 
-Instead of reconstructing nodes from hash data, clone the original node and update its inputs/attributes.
+## Solution: Clone-Based Reconstruction with Topological Sort
 
-### 1. Add `clone_with_inputs()` to Chalk::IR::Node
+Instead of reconstructing nodes from hash data, clone the original node and update its inputs using a node_map for lookup.
 
+### Key Challenges Solved
+
+1. **Polymorphic constructors need node objects, not IDs**: Polymorphic nodes like Add store actual node references (`$left`, `$right`), not just IDs.
+
+2. **Node ID mismatch**: Polymorphic nodes use `refaddr($self)` as their ID, which changes on clone. GVN needs to track old->new mappings.
+
+3. **Processing order**: Input nodes must be processed before nodes that use them. Implemented topological sort.
+
+### 1. Add `clone_with_inputs()` to Node Classes
+
+Base Node.pm (for nodes with explicit IDs):
 ```perl
-method clone_with_inputs($new_inputs, $new_attributes = undef, $new_id = undef) {
+method clone_with_inputs($new_inputs, $new_attributes = undef, $node_map = undef) {
     my $class = blessed($self);
-
     return $class->new(
-        id              => $new_id // $id,
+        id              => $id,
         op              => $op,
         inputs          => $new_inputs,
         attributes      => $new_attributes // $attributes,
@@ -33,48 +43,67 @@ method clone_with_inputs($new_inputs, $new_attributes = undef, $new_id = undef) 
 }
 ```
 
-Key: `blessed($self)` preserves the polymorphic class (Add, Multiply, etc.).
-
-### 2. Update GVN.pm
-
-Replace lines 86-96 in `run_gvn()`:
-
+Polymorphic nodes (Add, Multiply) look up operands from node_map:
 ```perl
-# Before (broken):
-my $new_node = Chalk::IR::Node->from_hash({...});
-
-# After (preserves polymorphism):
-my $new_node = $old_node->clone_with_inputs(\@new_inputs, $new_attributes);
-```
-
-### 3. Record Transform (Optional Enhancement)
-
-After cloning, record the GVN optimization:
-
-```perl
-if ($had_redirections) {
-    $new_node->record_transform('optimization', 'GVN',
-        context => "inputs redirected due to CSE"
+method clone_with_inputs($new_inputs, $new_attributes = undef, $node_map = undef) {
+    my $new_left = $node_map->{$new_inputs->[0]};
+    my $new_right = $node_map->{$new_inputs->[1]};
+    return Chalk::IR::Node::Add->new(
+        left        => $new_left,
+        right       => $new_right,
+        source_info => $source_info,
     );
 }
 ```
 
-## Test Expectations
+### 2. Update GVN.pm
 
-| Test | Current | After Fix |
-|------|---------|-----------|
-| Test 8: Different constants not merged | FAIL | PASS |
-| Test 14: Polymorphic types preserved | FAIL | PASS |
+1. Use topological sort (Kahn's algorithm) instead of string-sorted IDs
+2. Track old_id -> new_node mapping
+3. Pass node_map to clone_with_inputs
 
-## Implementation Steps
+```perl
+my @node_ids = $class->_topological_sort($graph);
+my %old_to_new_node;
 
-1. Add `clone_with_inputs()` method to `lib/Chalk/IR/Node.pm`
-2. Update `lib/Chalk/IR/Optimizer/GVN.pm` to use clone instead of from_hash
-3. Remove TODO markers from gvn.t tests
-4. Run full test suite to verify no regressions
+for my $node_id (@node_ids) {
+    # ... process node ...
+    if ($old_node->can('clone_with_inputs')) {
+        $new_node = $old_node->clone_with_inputs(\@new_inputs, $new_attributes, \%old_to_new_node);
+    } else {
+        # Fallback to generic Node
+    }
+    $old_to_new_node{$node_id} = $new_node;
+}
+```
+
+### 3. Topological Sort
+
+Ensures input nodes are processed before nodes that use them:
+```perl
+sub _topological_sort($class, $graph) {
+    # Kahn's algorithm - process nodes with in_degree=0 first
+    # When a node is processed, decrement in_degree of its dependents
+}
+```
+
+## Test Results
+
+| Test | Before | After |
+|------|--------|-------|
+| Test 8: Different constants not merged | FAIL (TODO) | PASS |
+| Test 11: Non-commutative order respected | FAIL (TODO) | PASS |
+| Test 14: Polymorphic types preserved | FAIL (TODO) | PASS |
 
 ## Files Changed
 
 - `lib/Chalk/IR/Node.pm` - Add clone_with_inputs method
-- `lib/Chalk/IR/Optimizer/GVN.pm` - Use clone-based reconstruction
+- `lib/Chalk/IR/Node/Add.pm` - Add clone_with_inputs for polymorphic clone
+- `lib/Chalk/IR/Node/Multiply.pm` - Add clone_with_inputs for polymorphic clone
+- `lib/Chalk/IR/Node/Constant.pm` - Add clone_with_inputs for polymorphic clone
+- `lib/Chalk/IR/Optimizer/GVN.pm` - Use clone-based reconstruction with topological sort
 - `t/sea-of-nodes/gvn.t` - Remove TODO markers after fix
+
+## Future Work
+
+For full polymorphic type preservation, add `clone_with_inputs` to all polymorphic node classes. Currently implemented for: Add, Multiply, Constant. Other nodes fall back to generic Chalk::IR::Node (loses polymorphism but maintains correctness).

--- a/lib/Chalk/IR/Node.pm
+++ b/lib/Chalk/IR/Node.pm
@@ -118,6 +118,23 @@ class Chalk::IR::Node {
         );
     }
 
+    # Clone node with new inputs, preserving polymorphic class type
+    # Used by GVN optimizer to reconstruct nodes while maintaining Add, Multiply, etc. types
+    # Base implementation for ID-based nodes; polymorphic subclasses override
+    # $node_map is old_id -> new_node mapping for looking up input nodes
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $class = blessed($self);
+
+        return $class->new(
+            id              => $id,
+            op              => $op,
+            inputs          => $new_inputs,
+            attributes      => $new_attributes // $attributes,
+            source_info     => $source_info,
+            transform_chain => $transform_chain,
+        );
+    }
+
     # Placeholder for peephole optimization - returns self by default
     # Polymorphic node subclasses (Phi, Region, etc.) override this
     method peephole($graph = undef) {

--- a/lib/Chalk/IR/Node/Add.pm
+++ b/lib/Chalk/IR/Node/Add.pm
@@ -251,6 +251,23 @@ class Chalk::IR::Node::Add {
         return;
     }
 
+    # Clone with new inputs from node_map, preserving polymorphic Add type
+    # Used by GVN optimizer to reconstruct nodes
+    # $node_map is old_id -> new_node mapping
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $new_left = $node_map->{$new_inputs->[0]};
+        my $new_right = $node_map->{$new_inputs->[1]};
+
+        die "Left operand not found in node_map: $new_inputs->[0]" unless $new_left;
+        die "Right operand not found in node_map: $new_inputs->[1]" unless $new_right;
+
+        return Chalk::IR::Node::Add->new(
+            left        => $new_left,
+            right       => $new_right,
+            source_info => $source_info,
+        );
+    }
+
 }
 
 1;

--- a/lib/Chalk/IR/Node/Constant.pm
+++ b/lib/Chalk/IR/Node/Constant.pm
@@ -75,6 +75,18 @@ class Chalk::IR::Node::Constant {
         return;
     }
 
+    # Clone with new inputs, preserving polymorphic Constant type
+    # Used by GVN optimizer to reconstruct nodes
+    # $node_map unused for Constant since no inputs, but kept for API consistency
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        # Constant has no inputs, just clone with same value/type
+        return Chalk::IR::Node::Constant->new(
+            value       => $new_attributes->{value} // $value,
+            type        => $new_attributes->{type} // $type,
+            source_info => $source_info,
+        );
+    }
+
 }
 
 1;

--- a/lib/Chalk/IR/Node/Multiply.pm
+++ b/lib/Chalk/IR/Node/Multiply.pm
@@ -151,6 +151,23 @@ class Chalk::IR::Node::Multiply {
         return;
     }
 
+    # Clone with new inputs from node_map, preserving polymorphic Multiply type
+    # Used by GVN optimizer to reconstruct nodes
+    # $node_map is old_id -> new_node mapping
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $new_left = $node_map->{$new_inputs->[0]};
+        my $new_right = $node_map->{$new_inputs->[1]};
+
+        die "Left operand not found in node_map: $new_inputs->[0]" unless $new_left;
+        die "Right operand not found in node_map: $new_inputs->[1]" unless $new_right;
+
+        return Chalk::IR::Node::Multiply->new(
+            left        => $new_left,
+            right       => $new_right,
+            source_info => $source_info,
+        );
+    }
+
 }
 
 1;

--- a/lib/Chalk/IR/Optimizer/GVN.pm
+++ b/lib/Chalk/IR/Optimizer/GVN.pm
@@ -26,8 +26,9 @@ class Chalk::IR::Optimizer::GVN {
         # Redirection map: duplicate_node_id => canonical_node_id
         my $redirections = {};
 
-        # Get all nodes in a consistent order (we'll process them by ID order)
-        my @node_ids = sort keys($graph->nodes->%*);
+        # Get all nodes in topological order (inputs before nodes that use them)
+        # This ensures when cloning a node, its inputs are already in new_graph
+        my @node_ids = $class->_topological_sort($graph);
 
         # Phase 1: Compute value numbers for all nodes
         for my $node_id (@node_ids) {
@@ -57,6 +58,9 @@ class Chalk::IR::Optimizer::GVN {
         # Track which nodes have been copied to new graph
         my %copied;
 
+        # Track old ID -> new node mapping (needed for polymorphic nodes with refaddr IDs)
+        my %old_to_new_node;
+
         # Copy nodes that aren't redirected, applying redirections to inputs
         for my $node_id (@node_ids) {
             # Skip nodes that are being redirected away
@@ -83,17 +87,26 @@ class Chalk::IR::Optimizer::GVN {
                 $redirections
             );
 
-            # Reconstruct node preserving polymorphic type, source_info, and transform_chain
-            # Use from_hash() factory to create correct node class
-            my $chain = $old_node->transform_chain // [];
-            my $new_node = Chalk::IR::Node->from_hash({
-                id              => $node_id,
-                op              => $old_node->op,
-                inputs          => \@new_inputs,
-                attributes      => $new_attributes,
-                source_info     => $old_node->source_info,
-                transform_chain => $chain,
-            });
+            # Reconstruct node preserving polymorphic type via clone_with_inputs()
+            # Pass old_to_new_node mapping so polymorphic nodes can find their input nodes
+            # Fall back to generic Node for classes without clone_with_inputs
+            my $new_node;
+            if ($old_node->can('clone_with_inputs')) {
+                $new_node = $old_node->clone_with_inputs(\@new_inputs, \%old_to_new_node, $new_attributes);
+            } else {
+                # Fallback: create generic Node (loses polymorphic type)
+                $new_node = Chalk::IR::Node->new(
+                    id              => $node_id,
+                    op              => $old_node->op,
+                    inputs          => \@new_inputs,
+                    attributes      => $new_attributes,
+                    source_info     => $old_node->source_info,
+                    transform_chain => $old_node->transform_chain // [],
+                );
+            }
+
+            # Track old->new mapping for polymorphic node lookup
+            $old_to_new_node{$node_id} = $new_node;
 
             # Record GVN optimization if node's inputs were redirected
             my $had_redirections = 0;
@@ -272,6 +285,50 @@ class Chalk::IR::Optimizer::GVN {
         }
 
         return \%new_attrs;
+    }
+
+    # Topological sort: return node IDs in dependency order (inputs before users)
+    # Uses Kahn's algorithm for stable, linear-time sorting
+    sub _topological_sort($class, $graph) {
+        my %in_degree;     # node_id => number of unprocessed inputs
+        my %dependents;    # node_id => [list of nodes that depend on this one]
+
+        # Initialize in-degrees and build dependency graph
+        for my $node_id (keys $graph->nodes->%*) {
+            my $node = $graph->get_node($node_id);
+            next unless $node;
+
+            $in_degree{$node_id} //= 0;
+
+            for my $input_id ($node->inputs->@*) {
+                next unless defined $input_id;
+                # Track that $node_id depends on $input_id
+                push $dependents{$input_id}->@*, $node_id;
+                $in_degree{$node_id}++;
+            }
+        }
+
+        # Start with nodes that have no dependencies (in_degree == 0)
+        my @queue = sort grep { $in_degree{$_} == 0 } keys %in_degree;
+        my @sorted;
+
+        while (@queue) {
+            my $node_id = shift @queue;
+            push @sorted, $node_id;
+
+            # Reduce in-degree of dependents
+            for my $dependent_id ($dependents{$node_id}->@*) {
+                $in_degree{$dependent_id}--;
+                if ($in_degree{$dependent_id} == 0) {
+                    # Insert in sorted position for stability
+                    my $i = 0;
+                    $i++ while $i < @queue && $queue[$i] lt $dependent_id;
+                    splice @queue, $i, 0, $dependent_id;
+                }
+            }
+        }
+
+        return @sorted;
     }
 }
 

--- a/lib/Chalk/IR/Optimizer/GVN.pm
+++ b/lib/Chalk/IR/Optimizer/GVN.pm
@@ -5,6 +5,9 @@ use 5.42.0;
 use experimental qw(class builtin keyword_any keyword_all);
 use utf8;
 
+use Chalk::IR::Node;
+use Chalk::IR::Graph;
+
 class Chalk::IR::Optimizer::GVN {
 
     # Instance method for pipeline compatibility

--- a/t/sea-of-nodes/gvn.t
+++ b/t/sea-of-nodes/gvn.t
@@ -344,8 +344,6 @@ subtest 'Commutativity in Multiply operations' => sub {
 };
 
 # Test 5: Different constants should NOT be merged
-TODO: {
-local $TODO = "see issue #200";
 subtest 'Different constants are not merged' => sub {
     my $graph = Chalk::IR::Graph->new();
 
@@ -394,7 +392,6 @@ subtest 'Different constants are not merged' => sub {
     ok($optimized->get_node('node_2'), 'Second constant still exists');
     is($metrics->{nodes_eliminated}, 0, 'No nodes eliminated (constants differ)');
 };
-} # end TODO
 
 # Test 6: Same constants SHOULD be merged
 subtest 'Identical constants are merged' => sub {
@@ -520,8 +517,6 @@ subtest 'GVN is idempotent' => sub {
 };
 
 # Test 8: Non-commutative operations (Subtract) should respect order
-TODO: {
-local $TODO = "see issue #200";
 subtest 'Non-commutative operations respect order' => sub {
     my $graph = Chalk::IR::Graph->new();
 
@@ -594,7 +589,6 @@ subtest 'Non-commutative operations respect order' => sub {
     is($metrics->{nodes_eliminated}, 0,
        'No elimination for non-commutative operations with different order');
 };
-} # end TODO
 
 # Test 9: Proj nodes with different indices should not merge
 subtest 'Proj nodes respect index differences' => sub {
@@ -795,8 +789,6 @@ subtest 'Complex expression optimization' => sub {
 };
 
 # Test: GVN preserves polymorphic node types
-TODO: {
-local $TODO = "see issue #200";
 subtest 'GVN preserves polymorphic node types' => sub {
     use Chalk::IR::Node::Constant;
     use Chalk::IR::Node::Add;
@@ -888,6 +880,5 @@ subtest 'GVN preserves polymorphic node types' => sub {
     ok($add_nodes[0]->can('execute'), 'Polymorphic Add has execute() method');
     ok($multiply_nodes[0]->can('execute'), 'Polymorphic Multiply has execute() method');
 };
-} # end TODO
 
 done_testing();


### PR DESCRIPTION
## Summary

- Fix GVN optimizer breaking polymorphic node types (Add, Multiply, etc.)
- Add `clone_with_inputs()` method to preserve class types during reconstruction
- Implement topological sort for proper dependency ordering
- Track old->new node mapping for polymorphic node lookup

## Problem

GVN was reconstructing nodes using `from_hash()` which only supported Constant and Start for polymorphic reconstruction. All other ops fell back to generic `Chalk::IR::Node`, losing polymorphic behavior like `execute()` methods.

## Solution

1. **Clone-based reconstruction**: Each polymorphic node class implements `clone_with_inputs()` that looks up operands from a node_map
2. **Topological sort**: Process nodes in dependency order so inputs exist before nodes that use them
3. **Node mapping**: Track old_id -> new_node since polymorphic nodes generate new IDs (refaddr) on clone

## Changes

| File | Change |
|------|--------|
| `lib/Chalk/IR/Node.pm` | Add base `clone_with_inputs()` method |
| `lib/Chalk/IR/Node/Add.pm` | Add polymorphic `clone_with_inputs()` |
| `lib/Chalk/IR/Node/Multiply.pm` | Add polymorphic `clone_with_inputs()` |
| `lib/Chalk/IR/Node/Constant.pm` | Add polymorphic `clone_with_inputs()` |
| `lib/Chalk/IR/Optimizer/GVN.pm` | Use clone-based reconstruction + topological sort |
| `t/sea-of-nodes/gvn.t` | Remove TODO markers from tests 8, 11, 14 |

## Test Plan

- [x] All 14 GVN tests pass
- [x] Tests 8, 11, 14 no longer need TODO markers
- [x] Integration test `app-default-ir-generation.t` passes
- [ ] CI passes full test suite

## Related Issues

Fixes #385
Related: #200