### PR TITLE
feat(grammar): Add bitwise operators to Chalk grammar

### DIFF
--- a/docs/plans/2025-12-18-chapter14-narrow-types-design.md
+++ b/docs/plans/2025-12-18-chapter14-narrow-types-design.md
@@ -1,0 +1,173 @@
+# Chapter 14: Narrow Primitive Types - Design
+
+**Issue:** #336
+**Date:** 2025-12-18
+**Status:** Approved
+
+## Overview
+
+Implement Sea of Nodes Chapter 14: sub-word integer types (i8, i16, i32, u8, u16, u32) and narrow float (f32), with truncation, extension, and overflow handling.
+
+## Architecture Decision
+
+**Chosen approach:** Parameterized Integer type with `bits` and `signed` fields.
+
+Single `IR::Type::Integer` class handles all integer widths. Simpler than separate subtype classes, matches SoN reference implementation.
+
+## Type System Changes
+
+### Parameterized Integer
+
+```perl
+# IR::Type::Integer extended fields:
+field $bits   :param :reader = 64;     # 1, 8, 16, 32, 64
+field $signed :param :reader = 1;      # 1=signed, 0=unsigned
+field $min    :reader;                 # Computed from bits/signed
+field $max    :reader;                 # Computed from bits/signed
+```
+
+### Convenience Constructors
+
+```perl
+Chalk::IR::Type::Integer->i8()    # bits=>8, signed=>1
+Chalk::IR::Type::Integer->i16()   # bits=>16, signed=>1
+Chalk::IR::Type::Integer->i32()   # bits=>32, signed=>1
+Chalk::IR::Type::Integer->u8()    # bits=>8, signed=>0
+Chalk::IR::Type::Integer->u16()   # bits=>16, signed=>0
+Chalk::IR::Type::Integer->u32()   # bits=>32, signed=>0
+Chalk::IR::Type::Integer->bool()  # alias for u1
+```
+
+### Float32
+
+```perl
+# IR::Type::Float extended:
+field $bits :param :reader = 64;  # 32 or 64
+Chalk::IR::Type::Float->f32()     # bits=>32
+```
+
+### Range Tracking
+
+- `meet()` computes intersection of value ranges
+- `join()` computes union of value ranges
+- Overflow detection: `(x ^ (x + y)) < 0` for signed types
+
+## New IR Nodes
+
+### Truncation/Extension
+
+```perl
+# Truncate: narrow from wider to narrower (e.g., i64 -> i8)
+Chalk::IR::Node::Truncate->new(
+    operand => $wide_node,
+    target_type => Chalk::IR::Type::Integer->i8()
+)
+
+# SignExtend: widen signed (preserves sign bit)
+Chalk::IR::Node::SignExtend->new(
+    operand => $narrow_node,
+    target_type => Chalk::IR::Type::Integer->i64()
+)
+
+# ZeroExtend: widen unsigned (pads with zeros)
+Chalk::IR::Node::ZeroExtend->new(
+    operand => $narrow_node,
+    target_type => Chalk::IR::Type::Integer->i64()
+)
+```
+
+### Bitwise Operations
+
+```perl
+# BitAnd: lhs & rhs (NOT short-circuit)
+Chalk::IR::Node::BitAnd->new(left => $a, right => $b)
+
+# BitOr: lhs | rhs
+Chalk::IR::Node::BitOr->new(left => $a, right => $b)
+
+# BitXor: lhs ^ rhs
+Chalk::IR::Node::BitXor->new(left => $a, right => $b)
+
+# BitNot: ~operand
+Chalk::IR::Node::BitNot->new(operand => $a)
+```
+
+## Computation Model
+
+Per SoN Chapter 14:
+- All arithmetic performed in 64-bit
+- Truncate on assignment to narrower variable/field
+- Extend on load from narrower variable/field
+
+## Peephole Optimizations
+
+### Constant Folding (Truncate)
+
+```perl
+if ($operand->is_constant) {
+    my $val = $operand->value;
+    my $truncated = $val & $target_type->mask();
+    # Sign-extend if signed and high bit set
+    if ($target_type->signed && ($truncated & $target_type->sign_bit)) {
+        $truncated = $truncated | ~$target_type->mask();
+    }
+    return Constant->new(value => $truncated, type => $target_type);
+}
+```
+
+### Bitwise Identities
+
+```perl
+# BitAnd
+x & -1  -> x         # identity
+x & 0   -> 0         # annihilator
+x & x   -> x         # idempotent
+
+# BitOr
+x | 0   -> x         # identity
+x | -1  -> -1        # annihilator
+x | x   -> x         # idempotent
+
+# BitXor
+x ^ 0   -> x         # identity
+x ^ x   -> 0         # self-inverse
+```
+
+### Overflow Detection
+
+For ranged integer types in Add/Multiply:
+- Signed: `(x ^ (x + y)) < 0` when signs differ unexpectedly
+- Unsigned: `result < operand` indicates overflow
+- If overflow detected, widen result type to IntTop
+
+## Files to Create/Modify
+
+### New Files
+- `lib/Chalk/IR/Node/Truncate.pm`
+- `lib/Chalk/IR/Node/SignExtend.pm`
+- `lib/Chalk/IR/Node/ZeroExtend.pm`
+- `lib/Chalk/IR/Node/BitAnd.pm`
+- `lib/Chalk/IR/Node/BitOr.pm`
+- `lib/Chalk/IR/Node/BitXor.pm`
+- `lib/Chalk/IR/Node/BitNot.pm`
+- `t/ir/narrow-types.t`
+- `t/ir/bitwise-ops.t`
+
+### Modified Files
+- `lib/Chalk/IR/Type/Integer.pm` - add bits/signed/min/max fields
+- `lib/Chalk/IR/Type/Float.pm` - add bits field
+- `lib/Chalk/IR/Node/Add.pm` - overflow detection
+- `lib/Chalk/IR/Node/Multiply.pm` - overflow detection
+
+## Test Coverage
+
+- Type construction with all widths (i8, i16, i32, u8, u16, u32, f32)
+- Truncation semantics (value masking, sign extension)
+- Extension semantics (sign vs zero extend)
+- Bitwise operation correctness
+- Peephole optimization verification
+- Overflow detection edge cases
+
+## Reference
+
+https://github.com/SeaOfNodes/Simple (Chapter 14)

--- a/docs/plans/2025-12-18-chapter15-arrays-design.md
+++ b/docs/plans/2025-12-18-chapter15-arrays-design.md
@@ -1,0 +1,202 @@
+# Chapter 15: Fixed-Length Arrays - Design
+
+**Issue:** #337
+**Date:** 2025-12-18
+**Status:** Approved
+
+## Overview
+
+Implement Sea of Nodes Chapter 15: single-dimensional fixed-length arrays with runtime bounds checking, dynamic allocation, and length operator.
+
+## Architecture Decision
+
+**Chosen approach:** Extend existing array nodes with length/type tracking and bounds checking.
+
+Leverages existing heap infrastructure from Perl-style arrays. Add optional `length` parameter for fixed arrays, with fallback to dynamic AV if growable arrays needed later.
+
+## Type Representation
+
+### TypeStruct with Implicit Fields
+
+Arrays represented as TypeStruct with special fields that cannot collide with user-defined fields:
+
+```perl
+# "#"  -> length (integer)
+# "[]" -> body (element type)
+
+Chalk::IR::Type::Struct->new(
+    fields => {
+        '#'  => Chalk::IR::Type::Integer->i64(),
+        '[]' => Chalk::IR::Type::Any->TOP(),  # Starts wide
+    }
+)
+```
+
+### Element Type Inference
+
+Element types tracked via TypeInference semiring, not annotations:
+
+```perl
+# When ArrayStore happens:
+# 1. Get current element type from array's type_env
+# 2. Meet with stored value's type
+# 3. Update type_env with narrower element type
+
+# Example flow:
+my @arr;                    # element_type = Any (top)
+$arr[0] = 1;               # element_type = meet(Any, Int) = Int
+$arr[1] = 2;               # element_type = meet(Int, Int) = Int
+$arr[2] = "x";             # element_type = meet(Int, Str) = Any (widens)
+```
+
+### Integration Point
+
+- TypeInference's `infer_type()` in ArrayStore rule tracks element types
+- Stored in `type_env` under array variable name with element suffix
+- e.g., `type_env->{'@arr:element'} = Int`
+
+## IR Node Modifications
+
+### NewArray - Extended
+
+```perl
+Chalk::IR::Node::NewArray->new(
+    length => $len_node,           # NEW: size expression (required for fixed)
+    element_type => $type,         # NEW: starts as Any, narrowed by inference
+    memory => $mem_node,           # Memory state input
+)
+# Returns: [pointer, new_memory_state]
+```
+
+### ArrayLength - New Node
+
+```perl
+Chalk::IR::Node::ArrayLength->new(
+    array => $array_ptr,
+)
+# Returns: integer length (the "#" field)
+# Peephole: if array is NewArray with constant length, fold to constant
+```
+
+### ArrayLoad - Bounds Checking
+
+```perl
+Chalk::IR::Node::ArrayLoad->new(
+    array => $array_ptr,
+    index => $index_node,
+    memory => $mem_node,
+    bounds_check => 1,             # NEW: enable runtime check
+)
+
+# On execute():
+# 1. Get array length from "#" field
+# 2. Check: 0 <= index < length
+# 3. If out of bounds -> Panic
+# 4. Otherwise load element
+```
+
+### ArrayStore - Bounds Checking
+
+```perl
+Chalk::IR::Node::ArrayStore->new(
+    array => $array_ptr,
+    index => $index_node,
+    value => $value_node,
+    memory => $mem_node,
+    bounds_check => 1,             # NEW: enable runtime check
+)
+# Same bounds checking as ArrayLoad
+```
+
+### Panic - New Node
+
+```perl
+Chalk::IR::Node::Panic->new(
+    message => "Array index out of bounds",
+    source_info => $loc,
+)
+# Terminates execution with error
+# Control flow: Never-like (no successor)
+```
+
+## Peephole Optimizations
+
+### ArrayLength Constant Folding
+
+```perl
+# In ArrayLength::peephole()
+if ($array->isa('NewArray') && $array->length->is_constant) {
+    return Constant->new(
+        value => $array->length->value,
+        type => Chalk::IR::Type::Integer->i64()
+    );
+}
+```
+
+### Bounds Check Elimination
+
+```perl
+# In ArrayLoad/ArrayStore::peephole()
+if ($index->is_constant && $array->length && $array->length->is_constant) {
+    my $i = $index->value;
+    my $len = $array->length->value;
+    if ($i >= 0 && $i < $len) {
+        # Safe - remove bounds check
+        $self->bounds_check(0);
+    } elsif ($i < 0 || $i >= $len) {
+        # Always fails - replace with Panic
+        return Panic->new(message => "Index $i out of bounds [0..$len)");
+    }
+}
+```
+
+### Dead Array Elimination
+
+Standard dead code elimination applies:
+- If NewArray result is never used (no loads/stores reference it)
+- And no side effects
+- Eliminate the allocation
+
+## Safety Mechanisms
+
+Per SoN Chapter 15, arrays are always safety checked:
+
+**Runtime checks:**
+- Out-of-bounds indexing (negative or >= length)
+- Invalid array creation (negative lengths)
+
+**Panic conditions:**
+```perl
+$arr[-1]        # Panic: negative index
+$arr[$len]      # Panic: index >= length
+my @a : len(-5) # Panic: negative length (if we add length syntax)
+```
+
+## Files to Create/Modify
+
+### New Files
+- `lib/Chalk/IR/Node/ArrayLength.pm`
+- `lib/Chalk/IR/Node/Panic.pm`
+- `t/ir/fixed-arrays.t`
+- `t/ir/bounds-checking.t`
+
+### Modified Files
+- `lib/Chalk/IR/Node/NewArray.pm` - add length, element_type fields
+- `lib/Chalk/IR/Node/ArrayLoad.pm` - add bounds_check field
+- `lib/Chalk/IR/Node/ArrayStore.pm` - add bounds_check field
+- `lib/Chalk/IR/Type/Struct.pm` - support `#` and `[]` field names
+- `lib/Chalk/Grammar/Chalk/Rule/ArrayStore.pm` - integrate with TypeInference
+
+## Test Coverage
+
+- Fixed array creation with length
+- ArrayLength operator
+- Bounds checking (valid indices)
+- Bounds checking (invalid indices -> Panic)
+- Element type inference through stores
+- Peephole optimizations (constant folding, check elimination)
+- Edge cases (empty arrays, single element, max index)
+
+## Reference
+
+https://github.com/SeaOfNodes/Simple (Chapter 15)

--- a/grammar/chalk.bnf
+++ b/grammar/chalk.bnf
@@ -78,6 +78,10 @@
 %REGEX_MATCH_OP% = /=~|!~/
 %ASSIGN_OP% = /\/\/=|\|\|=|\+=|-=|\.=/
 %ARITHMETIC_OP% = /[+\-*\/]/
+%BITWISE_AND_OP% = /&(?!&)/
+%BITWISE_OR_OP% = /\|(?!\|)/
+%BITWISE_XOR_OP% = /\^/
+%SHIFT_OP% = /<<|>>/
 %ISA_COMPARE_OP% = /\bisa\b/
 
 # ============================================================================
@@ -270,6 +274,10 @@ Expression -> ComparisonOp
 Expression -> ConcatenationOp
 Expression -> RangeOp
 Expression -> ArithmeticOp
+Expression -> BitwiseAndOp
+Expression -> BitwiseOrOp
+Expression -> BitwiseXorOp
+Expression -> ShiftOp
 Expression -> Unary
 Expression -> Postfix
 
@@ -311,6 +319,13 @@ RangeOp -> Expression WS_OPT '..' WS_OPT Expression
 # Precedence handled by Precedence semiring
 ArithmeticOp -> Expression WS_OPT %ARITHMETIC_OP% WS_OPT Expression
 
+# Bitwise operators (left-associative)
+# Precedence handled by Precedence semiring: shift > and > xor > or
+BitwiseAndOp -> Expression WS_OPT %BITWISE_AND_OP% WS_OPT Expression
+BitwiseOrOp -> Expression WS_OPT %BITWISE_OR_OP% WS_OPT Expression
+BitwiseXorOp -> Expression WS_OPT %BITWISE_XOR_OP% WS_OPT Expression
+ShiftOp -> Expression WS_OPT %SHIFT_OP% WS_OPT Expression
+
 # Unary prefix operators (right-associative)
 Unary -> '!' WS_OPT Expression
 Unary -> 'not' WS_OPT Expression
@@ -319,6 +334,7 @@ Unary -> '+' WS_OPT Expression
 Unary -> '++' WS_OPT Expression
 Unary -> '--' WS_OPT Expression
 Unary -> '\\' WS_OPT Expression  # Reference operator: \$var, \@array, \%hash
+Unary -> '~' WS_OPT Expression   # Bitwise NOT operator
 
 # Postfix operators
 Postfix -> Variable '++'

--- a/lib/Chalk/Grammar/Chalk/Rule/BitwiseAndOp.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/BitwiseAndOp.pm
@@ -1,0 +1,80 @@
+# ABOUTME: Semantic action for BitwiseAndOp - bitwise AND operator
+# ABOUTME: Handles & operator with precedence validated by Precedence semiring
+
+use 5.42.0;
+use experimental 'class';
+use utf8;
+use Chalk::IR::Node::BitAnd;
+
+class Chalk::Grammar::Chalk::Rule::BitwiseAndOp :isa(Chalk::GrammarRule) {
+
+    method evaluate($context) {
+        # Grammar is: BitwiseAndOp -> Expression WS_OPT %BITWISE_AND_OP% WS_OPT Expression
+
+        # PRECEDENCE CHECK
+        my $composite_elem = $context->metadata_element;
+        if ($composite_elem && $composite_elem->can('elements')) {
+            my @elements = $composite_elem->elements->@*;
+            for my $elem (@elements) {
+                if ($elem->can('valid') && !$elem->valid) {
+                    return;
+                }
+            }
+        }
+
+        my $num_children = scalar(@{$context->children});
+        my $operator_idx;
+
+        # Find the & operator by scanning children
+        for my $i (0 .. $num_children - 1) {
+            my $child = $context->child($i);
+            if ($child isa Chalk::Grammar::Token::Operator) {
+                my $op_str = "$child";
+                if ($op_str eq '&') {
+                    $operator_idx = $i;
+                    last;
+                }
+            }
+        }
+
+        unless (defined $operator_idx) {
+            my @children_debug = map { defined $_ ? "$_" : '<undef>' } @{$context->children};
+            die "BitwiseAndOp matched but no & operator found in children: [@children_debug]";
+        }
+
+        # Extract left operand (first IR node before operator)
+        my $left;
+        for my $i (0 .. $operator_idx - 1) {
+            my $child = $context->child($i);
+            if (ref($child) && $child->can('id')) {
+                $left = $child;
+                last;
+            }
+        }
+
+        # Extract right operand (first IR node after operator)
+        my $right;
+        for my $i ($operator_idx + 1 .. $num_children - 1) {
+            my $child = $context->child($i);
+            if (ref($child) && $child->can('id')) {
+                $right = $child;
+                last;
+            }
+        }
+
+        unless ($left && $right) {
+            my @children_debug = map { defined $_ ? "$_" : '<undef>' } @{$context->children};
+            die "BitwiseAndOp found & at index $operator_idx but missing operands: "
+                . "left=" . (defined $left ? $left->id : '<undef>') . ", "
+                . "right=" . (defined $right ? $right->id : '<undef>') . ", "
+                . "children=[@children_debug]";
+        }
+
+        return Chalk::IR::Node::BitAnd->new(
+            left  => $left,
+            right => $right
+        )->peephole();
+    }
+}
+
+1;

--- a/lib/Chalk/Grammar/Chalk/Rule/BitwiseOrOp.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/BitwiseOrOp.pm
@@ -1,0 +1,80 @@
+# ABOUTME: Semantic action for BitwiseOrOp - bitwise OR operator
+# ABOUTME: Handles | operator with precedence validated by Precedence semiring
+
+use 5.42.0;
+use experimental 'class';
+use utf8;
+use Chalk::IR::Node::BitOr;
+
+class Chalk::Grammar::Chalk::Rule::BitwiseOrOp :isa(Chalk::GrammarRule) {
+
+    method evaluate($context) {
+        # Grammar is: BitwiseOrOp -> Expression WS_OPT %BITWISE_OR_OP% WS_OPT Expression
+
+        # PRECEDENCE CHECK
+        my $composite_elem = $context->metadata_element;
+        if ($composite_elem && $composite_elem->can('elements')) {
+            my @elements = $composite_elem->elements->@*;
+            for my $elem (@elements) {
+                if ($elem->can('valid') && !$elem->valid) {
+                    return;
+                }
+            }
+        }
+
+        my $num_children = scalar(@{$context->children});
+        my $operator_idx;
+
+        # Find the | operator by scanning children
+        for my $i (0 .. $num_children - 1) {
+            my $child = $context->child($i);
+            if ($child isa Chalk::Grammar::Token::Operator) {
+                my $op_str = "$child";
+                if ($op_str eq '|') {
+                    $operator_idx = $i;
+                    last;
+                }
+            }
+        }
+
+        unless (defined $operator_idx) {
+            my @children_debug = map { defined $_ ? "$_" : '<undef>' } @{$context->children};
+            die "BitwiseOrOp matched but no | operator found in children: [@children_debug]";
+        }
+
+        # Extract left operand (first IR node before operator)
+        my $left;
+        for my $i (0 .. $operator_idx - 1) {
+            my $child = $context->child($i);
+            if (ref($child) && $child->can('id')) {
+                $left = $child;
+                last;
+            }
+        }
+
+        # Extract right operand (first IR node after operator)
+        my $right;
+        for my $i ($operator_idx + 1 .. $num_children - 1) {
+            my $child = $context->child($i);
+            if (ref($child) && $child->can('id')) {
+                $right = $child;
+                last;
+            }
+        }
+
+        unless ($left && $right) {
+            my @children_debug = map { defined $_ ? "$_" : '<undef>' } @{$context->children};
+            die "BitwiseOrOp found | at index $operator_idx but missing operands: "
+                . "left=" . (defined $left ? $left->id : '<undef>') . ", "
+                . "right=" . (defined $right ? $right->id : '<undef>') . ", "
+                . "children=[@children_debug]";
+        }
+
+        return Chalk::IR::Node::BitOr->new(
+            left  => $left,
+            right => $right
+        )->peephole();
+    }
+}
+
+1;

--- a/lib/Chalk/Grammar/Chalk/Rule/BitwiseXorOp.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/BitwiseXorOp.pm
@@ -1,0 +1,80 @@
+# ABOUTME: Semantic action for BitwiseXorOp - bitwise XOR operator
+# ABOUTME: Handles ^ operator with precedence validated by Precedence semiring
+
+use 5.42.0;
+use experimental 'class';
+use utf8;
+use Chalk::IR::Node::BitXor;
+
+class Chalk::Grammar::Chalk::Rule::BitwiseXorOp :isa(Chalk::GrammarRule) {
+
+    method evaluate($context) {
+        # Grammar is: BitwiseXorOp -> Expression WS_OPT %BITWISE_XOR_OP% WS_OPT Expression
+
+        # PRECEDENCE CHECK
+        my $composite_elem = $context->metadata_element;
+        if ($composite_elem && $composite_elem->can('elements')) {
+            my @elements = $composite_elem->elements->@*;
+            for my $elem (@elements) {
+                if ($elem->can('valid') && !$elem->valid) {
+                    return;
+                }
+            }
+        }
+
+        my $num_children = scalar(@{$context->children});
+        my $operator_idx;
+
+        # Find the ^ operator by scanning children
+        for my $i (0 .. $num_children - 1) {
+            my $child = $context->child($i);
+            if ($child isa Chalk::Grammar::Token::Operator) {
+                my $op_str = "$child";
+                if ($op_str eq '^') {
+                    $operator_idx = $i;
+                    last;
+                }
+            }
+        }
+
+        unless (defined $operator_idx) {
+            my @children_debug = map { defined $_ ? "$_" : '<undef>' } @{$context->children};
+            die "BitwiseXorOp matched but no ^ operator found in children: [@children_debug]";
+        }
+
+        # Extract left operand (first IR node before operator)
+        my $left;
+        for my $i (0 .. $operator_idx - 1) {
+            my $child = $context->child($i);
+            if (ref($child) && $child->can('id')) {
+                $left = $child;
+                last;
+            }
+        }
+
+        # Extract right operand (first IR node after operator)
+        my $right;
+        for my $i ($operator_idx + 1 .. $num_children - 1) {
+            my $child = $context->child($i);
+            if (ref($child) && $child->can('id')) {
+                $right = $child;
+                last;
+            }
+        }
+
+        unless ($left && $right) {
+            my @children_debug = map { defined $_ ? "$_" : '<undef>' } @{$context->children};
+            die "BitwiseXorOp found ^ at index $operator_idx but missing operands: "
+                . "left=" . (defined $left ? $left->id : '<undef>') . ", "
+                . "right=" . (defined $right ? $right->id : '<undef>') . ", "
+                . "children=[@children_debug]";
+        }
+
+        return Chalk::IR::Node::BitXor->new(
+            left  => $left,
+            right => $right
+        )->peephole();
+    }
+}
+
+1;

--- a/lib/Chalk/Grammar/Chalk/Rule/ShiftOp.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/ShiftOp.pm
@@ -1,0 +1,91 @@
+# ABOUTME: Semantic action for ShiftOp - bitwise shift operators
+# ABOUTME: Handles << and >> operators with precedence validated by Precedence semiring
+
+use 5.42.0;
+use experimental 'class';
+use utf8;
+use Chalk::IR::Node::BitShiftLeft;
+use Chalk::IR::Node::BitShiftRight;
+
+class Chalk::Grammar::Chalk::Rule::ShiftOp :isa(Chalk::GrammarRule) {
+
+    method evaluate($context) {
+        # Grammar is: ShiftOp -> Expression WS_OPT %SHIFT_OP% WS_OPT Expression
+
+        # PRECEDENCE CHECK
+        my $composite_elem = $context->metadata_element;
+        if ($composite_elem && $composite_elem->can('elements')) {
+            my @elements = $composite_elem->elements->@*;
+            for my $elem (@elements) {
+                if ($elem->can('valid') && !$elem->valid) {
+                    return;
+                }
+            }
+        }
+
+        my $num_children = scalar(@{$context->children});
+        my $operator_idx;
+        my $operator;
+
+        # Find the << or >> operator by scanning children
+        for my $i (0 .. $num_children - 1) {
+            my $child = $context->child($i);
+            if ($child isa Chalk::Grammar::Token::Operator) {
+                my $op_str = "$child";
+                if ($op_str eq '<<' || $op_str eq '>>') {
+                    $operator = $op_str;
+                    $operator_idx = $i;
+                    last;
+                }
+            }
+        }
+
+        unless (defined $operator_idx) {
+            my @children_debug = map { defined $_ ? "$_" : '<undef>' } @{$context->children};
+            die "ShiftOp matched but no << or >> operator found in children: [@children_debug]";
+        }
+
+        # Extract left operand (first IR node before operator)
+        my $left;
+        for my $i (0 .. $operator_idx - 1) {
+            my $child = $context->child($i);
+            if (ref($child) && $child->can('id')) {
+                $left = $child;
+                last;
+            }
+        }
+
+        # Extract right operand (first IR node after operator)
+        my $right;
+        for my $i ($operator_idx + 1 .. $num_children - 1) {
+            my $child = $context->child($i);
+            if (ref($child) && $child->can('id')) {
+                $right = $child;
+                last;
+            }
+        }
+
+        unless ($left && $right) {
+            my @children_debug = map { defined $_ ? "$_" : '<undef>' } @{$context->children};
+            die "ShiftOp found $operator at index $operator_idx but missing operands: "
+                . "left=" . (defined $left ? $left->id : '<undef>') . ", "
+                . "right=" . (defined $right ? $right->id : '<undef>') . ", "
+                . "children=[@children_debug]";
+        }
+
+        if ($operator eq '<<') {
+            return Chalk::IR::Node::BitShiftLeft->new(
+                left  => $left,
+                right => $right
+            )->peephole();
+        }
+        else {
+            return Chalk::IR::Node::BitShiftRight->new(
+                left  => $left,
+                right => $right
+            )->peephole();
+        }
+    }
+}
+
+1;

--- a/lib/Chalk/Grammar/Chalk/Rule/Unary.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Unary.pm
@@ -1,5 +1,5 @@
 # ABOUTME: Semantic action for Unary - handles both prefix and postfix unary operators
-# ABOUTME: Phase 4: Flattened from Unary + Postfix - handles prefix (!, -, +, \, ++, --) and postfix (++, --)
+# ABOUTME: Phase 4: Flattened from Unary + Postfix - handles prefix (!, ~, -, +, \, ++, --) and postfix (++, --)
 
 use 5.42.0;
 use experimental 'class';
@@ -8,6 +8,7 @@ class Chalk::Grammar::Chalk::Rule::Unary :isa(Chalk::GrammarRule) {
     method evaluate($context) {
         use Chalk::IR::Node::Negate;
         use Chalk::IR::Node::Not;
+        use Chalk::IR::Node::BitNot;
         use Chalk::IR::Node::PreIncrement;
         use Chalk::IR::Node::PreDecrement;
         use Chalk::IR::Node::PostIncrement;
@@ -79,6 +80,8 @@ class Chalk::Grammar::Chalk::Rule::Unary :isa(Chalk::GrammarRule) {
         } elsif ($operator eq '+') {
             # Unary + is a no-op, just pass through
             return $operand;
+        } elsif ($operator eq '~') {
+            return Chalk::IR::Node::BitNot->new(operand => $operand)->peephole();
         } elsif ($operator eq '\\') {
             # Reference node exists but needs wiring up here
             # For now, just pass through

--- a/lib/Chalk/IR/Node/BitAnd.pm
+++ b/lib/Chalk/IR/Node/BitAnd.pm
@@ -1,0 +1,105 @@
+# ABOUTME: BitAnd node performs bitwise AND operation
+# ABOUTME: NOT short-circuit like logical And - evaluates both operands
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+
+class Chalk::IR::Node::BitAnd {
+    field $left :param :reader;
+    field $right :param :reader;
+    field $source_info :param :reader = undef;
+    field $transform_chain :reader = [];
+
+    # Dependency tracking for peephole re-optimization
+    field $_deps = [];
+
+    method add_dep($dependent_node_id) {
+        push $_deps->@*, $dependent_node_id;
+    }
+
+    method get_deps() {
+        return $_deps->@*;
+    }
+
+    method id() { refaddr($self) }
+
+    method inputs() {
+        return [ $left->id, $right->id ];
+    }
+
+    method op() { 'BitAnd' }
+
+    method to_hash() {
+        return {
+            id => $self->id,
+            op => 'BitAnd',
+            inputs => $self->inputs,
+            attributes => {
+                left_id => $left->id,
+                right_id => $right->id,
+            },
+        };
+    }
+
+    method peephole($graph = undef) {
+        # Constant folding
+        if ($left isa Chalk::IR::Node::Constant &&
+            $right isa Chalk::IR::Node::Constant) {
+
+            my $lval = $left->value;
+            my $rval = $right->value;
+
+            # Identity: x & -1 = x
+            return $left if $rval == -1;
+            return $right if $lval == -1;
+
+            # Annihilator: x & 0 = 0
+            if ($lval == 0 || $rval == 0) {
+                use Chalk::IR::Node::Constant;
+                return Chalk::IR::Node::Constant->new(
+                    value => 0,
+                    type => $left->type // Chalk::IR::Type::Integer->i64()
+                );
+            }
+
+            use Chalk::IR::Node::Constant;
+            return Chalk::IR::Node::Constant->new(
+                value => $lval & $rval,
+                type => $left->type // Chalk::IR::Type::Integer->i64()
+            );
+        }
+
+        return $self;
+    }
+
+    method compute_type() {
+        return $left->compute_type if $left->can('compute_type');
+        use Chalk::IR::Type::Integer;
+        return Chalk::IR::Type::Integer->TOP();
+    }
+
+    # Compatibility methods
+    method attributes() {
+        return $self->to_hash()->{attributes};
+    }
+
+    method record_transform(@args) {
+        return;
+    }
+
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $new_left = $node_map->{$new_inputs->[0]};
+        my $new_right = $node_map->{$new_inputs->[1]};
+
+        die "Left operand not found in node_map: $new_inputs->[0]" unless $new_left;
+        die "Right operand not found in node_map: $new_inputs->[1]" unless $new_right;
+
+        return Chalk::IR::Node::BitAnd->new(
+            left        => $new_left,
+            right       => $new_right,
+            source_info => $source_info,
+        );
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Node/BitNot.pm
+++ b/lib/Chalk/IR/Node/BitNot.pm
@@ -1,0 +1,90 @@
+# ABOUTME: BitNot node performs bitwise NOT (complement) operation
+# ABOUTME: Unary operator that inverts all bits
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+
+class Chalk::IR::Node::BitNot {
+    field $operand :param :reader;
+    field $source_info :param :reader = undef;
+    field $transform_chain :reader = [];
+
+    # Dependency tracking for peephole re-optimization
+    field $_deps = [];
+
+    method add_dep($dependent_node_id) {
+        push $_deps->@*, $dependent_node_id;
+    }
+
+    method get_deps() {
+        return $_deps->@*;
+    }
+
+    method id() { refaddr($self) }
+
+    method inputs() {
+        return [ $operand->id ];
+    }
+
+    method op() { 'BitNot' }
+
+    method to_hash() {
+        return {
+            id => $self->id,
+            op => 'BitNot',
+            inputs => $self->inputs,
+            attributes => {},
+        };
+    }
+
+    method peephole($graph = undef) {
+        # Constant folding
+        if ($operand isa Chalk::IR::Node::Constant) {
+            my $val = $operand->value;
+            my $result;
+            {
+                use integer;
+                $result = ~$val;
+            }
+            use Chalk::IR::Node::Constant;
+            return Chalk::IR::Node::Constant->new(
+                value => $result,
+                type => $operand->type // Chalk::IR::Type::Integer->i64()
+            );
+        }
+
+        # Double negation: ~~x = x
+        if ($operand isa Chalk::IR::Node::BitNot) {
+            return $operand->operand;
+        }
+
+        return $self;
+    }
+
+    method compute_type() {
+        return $operand->compute_type if $operand->can('compute_type');
+        use Chalk::IR::Type::Integer;
+        return Chalk::IR::Type::Integer->TOP();
+    }
+
+    # Compatibility methods
+    method attributes() {
+        return $self->to_hash()->{attributes};
+    }
+
+    method record_transform(@args) {
+        return;
+    }
+
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $new_operand = $node_map->{$new_inputs->[0]};
+        die "Operand not found in node_map: $new_inputs->[0]" unless $new_operand;
+
+        return Chalk::IR::Node::BitNot->new(
+            operand     => $new_operand,
+            source_info => $source_info,
+        );
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Node/BitOr.pm
+++ b/lib/Chalk/IR/Node/BitOr.pm
@@ -1,0 +1,104 @@
+# ABOUTME: BitOr node performs bitwise OR operation
+# ABOUTME: NOT short-circuit like logical Or - evaluates both operands
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+
+class Chalk::IR::Node::BitOr {
+    field $left :param :reader;
+    field $right :param :reader;
+    field $source_info :param :reader = undef;
+    field $transform_chain :reader = [];
+
+    # Dependency tracking for peephole re-optimization
+    field $_deps = [];
+
+    method add_dep($dependent_node_id) {
+        push $_deps->@*, $dependent_node_id;
+    }
+
+    method get_deps() {
+        return $_deps->@*;
+    }
+
+    method id() { refaddr($self) }
+
+    method inputs() {
+        return [ $left->id, $right->id ];
+    }
+
+    method op() { 'BitOr' }
+
+    method to_hash() {
+        return {
+            id => $self->id,
+            op => 'BitOr',
+            inputs => $self->inputs,
+            attributes => {
+                left_id => $left->id,
+                right_id => $right->id,
+            },
+        };
+    }
+
+    method peephole($graph = undef) {
+        if ($left isa Chalk::IR::Node::Constant &&
+            $right isa Chalk::IR::Node::Constant) {
+
+            my $lval = $left->value;
+            my $rval = $right->value;
+
+            # Identity: x | 0 = x
+            return $left if $rval == 0;
+            return $right if $lval == 0;
+
+            # Annihilator: x | -1 = -1
+            if ($lval == -1 || $rval == -1) {
+                use Chalk::IR::Node::Constant;
+                return Chalk::IR::Node::Constant->new(
+                    value => -1,
+                    type => $left->type // Chalk::IR::Type::Integer->i64()
+                );
+            }
+
+            use Chalk::IR::Node::Constant;
+            return Chalk::IR::Node::Constant->new(
+                value => $lval | $rval,
+                type => $left->type // Chalk::IR::Type::Integer->i64()
+            );
+        }
+
+        return $self;
+    }
+
+    method compute_type() {
+        return $left->compute_type if $left->can('compute_type');
+        use Chalk::IR::Type::Integer;
+        return Chalk::IR::Type::Integer->TOP();
+    }
+
+    # Compatibility methods
+    method attributes() {
+        return $self->to_hash()->{attributes};
+    }
+
+    method record_transform(@args) {
+        return;
+    }
+
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $new_left = $node_map->{$new_inputs->[0]};
+        my $new_right = $node_map->{$new_inputs->[1]};
+
+        die "Left operand not found in node_map: $new_inputs->[0]" unless $new_left;
+        die "Right operand not found in node_map: $new_inputs->[1]" unless $new_right;
+
+        return Chalk::IR::Node::BitOr->new(
+            left        => $new_left,
+            right       => $new_right,
+            source_info => $source_info,
+        );
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Node/BitShiftLeft.pm
+++ b/lib/Chalk/IR/Node/BitShiftLeft.pm
@@ -1,0 +1,104 @@
+# ABOUTME: BitShiftLeft node performs bitwise left shift operation
+# ABOUTME: Shifts bits left by specified amount (x << n)
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+
+class Chalk::IR::Node::BitShiftLeft {
+    field $left :param :reader;
+    field $right :param :reader;
+    field $source_info :param :reader = undef;
+    field $transform_chain :reader = [];
+
+    # Dependency tracking for peephole re-optimization
+    field $_deps = [];
+
+    method add_dep($dependent_node_id) {
+        push $_deps->@*, $dependent_node_id;
+    }
+
+    method get_deps() {
+        return $_deps->@*;
+    }
+
+    method id() { refaddr($self) }
+
+    method inputs() {
+        return [ $left->id, $right->id ];
+    }
+
+    method op() { 'BitShiftLeft' }
+
+    method to_hash() {
+        return {
+            id => $self->id,
+            op => 'BitShiftLeft',
+            inputs => $self->inputs,
+            attributes => {
+                left_id => $left->id,
+                right_id => $right->id,
+            },
+        };
+    }
+
+    method peephole($graph = undef) {
+        # Constant folding
+        if ($left isa Chalk::IR::Node::Constant &&
+            $right isa Chalk::IR::Node::Constant) {
+
+            my $lval = $left->value;
+            my $rval = $right->value;
+
+            # Identity: x << 0 = x
+            return $left if $rval == 0;
+
+            # Zero shift: 0 << n = 0
+            if ($lval == 0) {
+                use Chalk::IR::Node::Constant;
+                return Chalk::IR::Node::Constant->new(
+                    value => 0,
+                    type => $left->type // Chalk::IR::Type::Integer->i64()
+                );
+            }
+
+            use Chalk::IR::Node::Constant;
+            return Chalk::IR::Node::Constant->new(
+                value => $lval << $rval,
+                type => $left->type // Chalk::IR::Type::Integer->i64()
+            );
+        }
+
+        return $self;
+    }
+
+    method compute_type() {
+        return $left->compute_type if $left->can('compute_type');
+        use Chalk::IR::Type::Integer;
+        return Chalk::IR::Type::Integer->TOP();
+    }
+
+    # Compatibility methods
+    method attributes() {
+        return $self->to_hash()->{attributes};
+    }
+
+    method record_transform(@args) {
+        return;
+    }
+
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $new_left = $node_map->{$new_inputs->[0]};
+        my $new_right = $node_map->{$new_inputs->[1]};
+
+        die "Left operand not found in node_map: $new_inputs->[0]" unless $new_left;
+        die "Right operand not found in node_map: $new_inputs->[1]" unless $new_right;
+
+        return Chalk::IR::Node::BitShiftLeft->new(
+            left        => $new_left,
+            right       => $new_right,
+            source_info => $source_info,
+        );
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Node/BitShiftRight.pm
+++ b/lib/Chalk/IR/Node/BitShiftRight.pm
@@ -1,0 +1,104 @@
+# ABOUTME: BitShiftRight node performs bitwise right shift operation
+# ABOUTME: Shifts bits right by specified amount (x >> n)
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+
+class Chalk::IR::Node::BitShiftRight {
+    field $left :param :reader;
+    field $right :param :reader;
+    field $source_info :param :reader = undef;
+    field $transform_chain :reader = [];
+
+    # Dependency tracking for peephole re-optimization
+    field $_deps = [];
+
+    method add_dep($dependent_node_id) {
+        push $_deps->@*, $dependent_node_id;
+    }
+
+    method get_deps() {
+        return $_deps->@*;
+    }
+
+    method id() { refaddr($self) }
+
+    method inputs() {
+        return [ $left->id, $right->id ];
+    }
+
+    method op() { 'BitShiftRight' }
+
+    method to_hash() {
+        return {
+            id => $self->id,
+            op => 'BitShiftRight',
+            inputs => $self->inputs,
+            attributes => {
+                left_id => $left->id,
+                right_id => $right->id,
+            },
+        };
+    }
+
+    method peephole($graph = undef) {
+        # Constant folding
+        if ($left isa Chalk::IR::Node::Constant &&
+            $right isa Chalk::IR::Node::Constant) {
+
+            my $lval = $left->value;
+            my $rval = $right->value;
+
+            # Identity: x >> 0 = x
+            return $left if $rval == 0;
+
+            # Zero shift: 0 >> n = 0
+            if ($lval == 0) {
+                use Chalk::IR::Node::Constant;
+                return Chalk::IR::Node::Constant->new(
+                    value => 0,
+                    type => $left->type // Chalk::IR::Type::Integer->i64()
+                );
+            }
+
+            use Chalk::IR::Node::Constant;
+            return Chalk::IR::Node::Constant->new(
+                value => $lval >> $rval,
+                type => $left->type // Chalk::IR::Type::Integer->i64()
+            );
+        }
+
+        return $self;
+    }
+
+    method compute_type() {
+        return $left->compute_type if $left->can('compute_type');
+        use Chalk::IR::Type::Integer;
+        return Chalk::IR::Type::Integer->TOP();
+    }
+
+    # Compatibility methods
+    method attributes() {
+        return $self->to_hash()->{attributes};
+    }
+
+    method record_transform(@args) {
+        return;
+    }
+
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $new_left = $node_map->{$new_inputs->[0]};
+        my $new_right = $node_map->{$new_inputs->[1]};
+
+        die "Left operand not found in node_map: $new_inputs->[0]" unless $new_left;
+        die "Right operand not found in node_map: $new_inputs->[1]" unless $new_right;
+
+        return Chalk::IR::Node::BitShiftRight->new(
+            left        => $new_left,
+            right       => $new_right,
+            source_info => $source_info,
+        );
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Node/BitXor.pm
+++ b/lib/Chalk/IR/Node/BitXor.pm
@@ -1,0 +1,104 @@
+# ABOUTME: BitXor node performs bitwise XOR operation
+# ABOUTME: Includes identity (x ^ 0 = x) and self-inverse (x ^ x = 0) optimizations
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+
+class Chalk::IR::Node::BitXor {
+    field $left :param :reader;
+    field $right :param :reader;
+    field $source_info :param :reader = undef;
+    field $transform_chain :reader = [];
+
+    # Dependency tracking for peephole re-optimization
+    field $_deps = [];
+
+    method add_dep($dependent_node_id) {
+        push $_deps->@*, $dependent_node_id;
+    }
+
+    method get_deps() {
+        return $_deps->@*;
+    }
+
+    method id() { refaddr($self) }
+
+    method inputs() {
+        return [ $left->id, $right->id ];
+    }
+
+    method op() { 'BitXor' }
+
+    method to_hash() {
+        return {
+            id => $self->id,
+            op => 'BitXor',
+            inputs => $self->inputs,
+            attributes => {
+                left_id => $left->id,
+                right_id => $right->id,
+            },
+        };
+    }
+
+    method peephole($graph = undef) {
+        if ($left isa Chalk::IR::Node::Constant &&
+            $right isa Chalk::IR::Node::Constant) {
+
+            my $lval = $left->value;
+            my $rval = $right->value;
+
+            # Identity: x ^ 0 = x
+            return $left if $rval == 0;
+            return $right if $lval == 0;
+
+            use Chalk::IR::Node::Constant;
+            return Chalk::IR::Node::Constant->new(
+                value => $lval ^ $rval,
+                type => $left->type // Chalk::IR::Type::Integer->i64()
+            );
+        }
+
+        # Self-inverse: x ^ x = 0 (same node reference)
+        if (refaddr($left) == refaddr($right)) {
+            use Chalk::IR::Node::Constant;
+            return Chalk::IR::Node::Constant->new(
+                value => 0,
+                type => $left->compute_type // Chalk::IR::Type::Integer->i64()
+            );
+        }
+
+        return $self;
+    }
+
+    method compute_type() {
+        return $left->compute_type if $left->can('compute_type');
+        use Chalk::IR::Type::Integer;
+        return Chalk::IR::Type::Integer->TOP();
+    }
+
+    # Compatibility methods
+    method attributes() {
+        return $self->to_hash()->{attributes};
+    }
+
+    method record_transform(@args) {
+        return;
+    }
+
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $new_left = $node_map->{$new_inputs->[0]};
+        my $new_right = $node_map->{$new_inputs->[1]};
+
+        die "Left operand not found in node_map: $new_inputs->[0]" unless $new_left;
+        die "Right operand not found in node_map: $new_inputs->[1]" unless $new_right;
+
+        return Chalk::IR::Node::BitXor->new(
+            left        => $new_left,
+            right       => $new_right,
+            source_info => $source_info,
+        );
+    }
+}
+
+1;

--- a/t/grammar/bitwise-operators.t
+++ b/t/grammar/bitwise-operators.t
@@ -1,0 +1,66 @@
+# ABOUTME: Tests for bitwise operator parsing in Chalk grammar
+# ABOUTME: Verifies &, |, ^, ~, <<, >> operators parse correctly
+use 5.42.0;
+use Test::More;
+use lib 'lib';
+use utf8;
+
+use Chalk::Grammar;
+use Chalk::Grammar::BNF;
+use Chalk::Semiring::ChalkSyntax;
+use Chalk::Parser;
+
+# Load grammar
+my $grammar_file = 'grammar/chalk.bnf';
+open my $fh, '<:utf8', $grammar_file or die "Cannot open $grammar_file: $!";
+my $bnf_content = do { local $/; <$fh> };
+close $fh;
+
+my $grammar = Chalk::Grammar->build_from_bnf($bnf_content, "Program", "Chalk");
+my $semiring = Chalk::Semiring::ChalkSyntax->new(grammar => $grammar);
+
+sub parses_ok {
+    my ($code, $name) = @_;
+    my $parser = Chalk::Parser->new(grammar => $grammar, semiring => $semiring);
+    my $result = $parser->parse_string($code);
+    ok($result, $name);
+}
+
+# Test bitwise AND
+parses_ok('$a & $b;', 'Bitwise AND: $a & $b');
+parses_ok('$x & 0xFF;', 'Bitwise AND with hex literal');
+parses_ok('1 & 2 & 3;', 'Chained bitwise AND');
+
+# Test bitwise OR
+parses_ok('$a | $b;', 'Bitwise OR: $a | $b');
+parses_ok('$x | 0x0F;', 'Bitwise OR with hex literal');
+
+# Test bitwise XOR
+parses_ok('$a ^ $b;', 'Bitwise XOR: $a ^ $b');
+parses_ok('$x ^ 1;', 'Bitwise XOR with constant');
+
+# Test bitwise NOT (unary ~)
+parses_ok('~$a;', 'Bitwise NOT: ~$a');
+parses_ok('~0;', 'Bitwise NOT of zero');
+parses_ok('~~$x;', 'Double bitwise NOT');
+
+# Test left shift
+parses_ok('$a << $b;', 'Left shift: $a << $b');
+parses_ok('1 << 8;', 'Left shift constant');
+parses_ok('$x << 2;', 'Left shift by 2');
+
+# Test right shift
+parses_ok('$a >> $b;', 'Right shift: $a >> $b');
+parses_ok('256 >> 4;', 'Right shift constant');
+parses_ok('$x >> 1;', 'Right shift by 1');
+
+# Test mixed expressions
+parses_ok('($a & $b) | $c;', 'Mixed AND/OR with parens');
+parses_ok('$x << 2 | $y;', 'Shift with OR');
+parses_ok('~$a & $b;', 'NOT with AND');
+
+# Test with arithmetic
+parses_ok('$a + $b & $c;', 'Addition and AND');
+parses_ok('1 << ($n - 1);', 'Shift with arithmetic in parens');
+
+done_testing();


### PR DESCRIPTION
## Summary

Add support for bitwise operators (`&`, `|`, `^`, `~`, `<<`, `>>`) to the Chalk grammar. This enables self-hosting of IR node files that use these operators.

## Changes

**Grammar (chalk.bnf):**
- Add patterns: `BITWISE_AND_OP`, `BITWISE_OR_OP`, `BITWISE_XOR_OP`, `SHIFT_OP`
- Add rules: `BitwiseAndOp`, `BitwiseOrOp`, `BitwiseXorOp`, `ShiftOp`
- Add Expression alternatives for new operator rules
- Add `~` unary operator to Unary rule

**IR Nodes (6 new files):**
- `BitAnd.pm`, `BitOr.pm`, `BitXor.pm`, `BitNot.pm` (from Chapter 14 design)
- `BitShiftLeft.pm`, `BitShiftRight.pm` (new)

**Semantic Actions (4 new files):**
- `BitwiseAndOp.pm`, `BitwiseOrOp.pm`, `BitwiseXorOp.pm`, `ShiftOp.pm`
- Updated `Unary.pm` for `~` operator

## Motivation

This fixes CI failures in PR #422 (Chapter 14 - Narrow Types) where the self-hosting test fails because files like `BitAnd.pm`, `Truncate.pm`, and `Integer.pm` use bitwise operators that weren't in the grammar.

## Test plan

- [x] New test: `t/grammar/bitwise-operators.t` (21 tests)
- [x] Verified all 7 previously-failing PR 422 files now parse
- [x] All 242 grammar tests pass
- [x] No regressions

## Related Issues

Fixes CI failures in:
- PR #422 (Chapter 14 - Narrow Types)