### PR TITLE
fix(ir): Propagate IntBot through arithmetic operations (#220)

### DIFF
--- a/lib/Chalk/IR/Node/Add.pm
+++ b/lib/Chalk/IR/Node/Add.pm
@@ -86,6 +86,14 @@ class Chalk::IR::Node::Add {
         my $left_type = $left->compute();
         my $right_type = $right->compute();
 
+        # Error propagation: IntBot absorbs through arithmetic
+        if ($left_type isa Chalk::IR::Type::Integer && $left_type->is_bottom) {
+            return Chalk::IR::Type::Integer->BOTTOM();
+        }
+        if ($right_type isa Chalk::IR::Type::Integer && $right_type->is_bottom) {
+            return Chalk::IR::Type::Integer->BOTTOM();
+        }
+
         if ($left_type->is_constant && $right_type->is_constant) {
             return Chalk::IR::Type::Integer->constant(
                 $left_type->value + $right_type->value

--- a/lib/Chalk/IR/Node/Divide.pm
+++ b/lib/Chalk/IR/Node/Divide.pm
@@ -86,6 +86,14 @@ class Chalk::IR::Node::Divide {
         my $left_type = $left->compute();
         my $right_type = $right->compute();
 
+        # Error propagation: IntBot absorbs through arithmetic
+        if ($left_type isa Chalk::IR::Type::Integer && $left_type->is_bottom) {
+            return Chalk::IR::Type::Integer->BOTTOM();
+        }
+        if ($right_type isa Chalk::IR::Type::Integer && $right_type->is_bottom) {
+            return Chalk::IR::Type::Integer->BOTTOM();
+        }
+
         if ($left_type->is_constant && $right_type->is_constant) {
             my $divisor = $right_type->value;
             # Division by zero yields IntBot (error state)

--- a/lib/Chalk/IR/Node/Multiply.pm
+++ b/lib/Chalk/IR/Node/Multiply.pm
@@ -86,6 +86,14 @@ class Chalk::IR::Node::Multiply {
         my $left_type = $left->compute();
         my $right_type = $right->compute();
 
+        # Error propagation: IntBot absorbs through arithmetic
+        if ($left_type isa Chalk::IR::Type::Integer && $left_type->is_bottom) {
+            return Chalk::IR::Type::Integer->BOTTOM();
+        }
+        if ($right_type isa Chalk::IR::Type::Integer && $right_type->is_bottom) {
+            return Chalk::IR::Type::Integer->BOTTOM();
+        }
+
         if ($left_type->is_constant && $right_type->is_constant) {
             return Chalk::IR::Type::Integer->constant(
                 $left_type->value * $right_type->value

--- a/lib/Chalk/IR/Node/Subtract.pm
+++ b/lib/Chalk/IR/Node/Subtract.pm
@@ -86,6 +86,14 @@ class Chalk::IR::Node::Subtract {
         my $left_type = $left->compute();
         my $right_type = $right->compute();
 
+        # Error propagation: IntBot absorbs through arithmetic
+        if ($left_type isa Chalk::IR::Type::Integer && $left_type->is_bottom) {
+            return Chalk::IR::Type::Integer->BOTTOM();
+        }
+        if ($right_type isa Chalk::IR::Type::Integer && $right_type->is_bottom) {
+            return Chalk::IR::Type::Integer->BOTTOM();
+        }
+
         if ($left_type->is_constant && $right_type->is_constant) {
             return Chalk::IR::Type::Integer->constant(
                 $left_type->value - $right_type->value

--- a/t/ir/intbot-propagation.t
+++ b/t/ir/intbot-propagation.t
@@ -1,0 +1,142 @@
+# ABOUTME: Test IntBot (error state) propagation through arithmetic operations
+# ABOUTME: Verify whether IntBot + x = IntBot (error propagation) or IntTop (unknown)
+
+use lib 'lib';
+use v5.42;
+use Test::More;
+use Chalk::IR::Type::Integer;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Node::Add;
+use Chalk::IR::Node::Subtract;
+use Chalk::IR::Node::Multiply;
+use Chalk::IR::Node::Divide;
+
+# Test division by zero creates IntBot
+subtest 'Division by zero returns IntBot' => sub {
+    my $numerator = Chalk::IR::Node::Constant->new(
+        value => 10,
+        type => Chalk::IR::Type::Integer->constant(10)
+    );
+    my $zero = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type => Chalk::IR::Type::Integer->constant(0)
+    );
+
+    my $div = Chalk::IR::Node::Divide->new(left => $numerator, right => $zero);
+    my $type = $div->compute();
+
+    ok($type isa Chalk::IR::Type::Integer, 'Division by zero returns TypeInteger');
+    ok($type->is_bottom, 'Division by zero returns IntBot (error state)');
+};
+
+# Test IntBot lattice behavior
+subtest 'IntBot meet() absorbs other integers' => sub {
+    my $bot = Chalk::IR::Type::Integer->BOTTOM();
+    my $const5 = Chalk::IR::Type::Integer->constant(5);
+    my $top = Chalk::IR::Type::Integer->TOP();
+
+    my $result1 = $bot->meet($const5);
+    ok($result1->is_bottom, 'IntBot meet constant = IntBot');
+
+    my $result2 = $bot->meet($top);
+    ok($result2->is_bottom, 'IntBot meet IntTop = IntBot');
+
+    my $result3 = $const5->meet($bot);
+    ok($result3->is_bottom, 'constant meet IntBot = IntBot');
+};
+
+# Test IntBot propagation through Add
+subtest 'Add propagates IntBot (error state)' => sub {
+    # Create a divide-by-zero to get IntBot
+    my $numerator = Chalk::IR::Node::Constant->new(
+        value => 10,
+        type => Chalk::IR::Type::Integer->constant(10)
+    );
+    my $zero = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type => Chalk::IR::Type::Integer->constant(0)
+    );
+    my $div_by_zero = Chalk::IR::Node::Divide->new(left => $numerator, right => $zero);
+
+    # Add IntBot + 5
+    my $const5 = Chalk::IR::Node::Constant->new(
+        value => 5,
+        type => Chalk::IR::Type::Integer->constant(5)
+    );
+    my $add = Chalk::IR::Node::Add->new(left => $div_by_zero, right => $const5);
+
+    my $result_type = $add->compute();
+
+    ok($result_type isa Chalk::IR::Type::Integer, 'Add returns TypeInteger');
+    ok($result_type->is_bottom, 'Add propagates IntBot (error state absorbs)');
+    ok(!$result_type->is_top, 'Result is not IntTop');
+    ok(!$result_type->is_constant, 'Result is not constant');
+};
+
+subtest 'Subtract propagates IntBot (error state)' => sub {
+    my $numerator = Chalk::IR::Node::Constant->new(
+        value => 10,
+        type => Chalk::IR::Type::Integer->constant(10)
+    );
+    my $zero = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type => Chalk::IR::Type::Integer->constant(0)
+    );
+    my $div_by_zero = Chalk::IR::Node::Divide->new(left => $numerator, right => $zero);
+
+    my $const5 = Chalk::IR::Node::Constant->new(
+        value => 5,
+        type => Chalk::IR::Type::Integer->constant(5)
+    );
+    my $sub = Chalk::IR::Node::Subtract->new(left => $const5, right => $div_by_zero);
+
+    my $result_type = $sub->compute();
+    ok($result_type isa Chalk::IR::Type::Integer, 'Subtract returns TypeInteger');
+    ok($result_type->is_bottom, 'Subtract propagates IntBot (error state absorbs)');
+};
+
+subtest 'Multiply propagates IntBot (error state)' => sub {
+    my $numerator = Chalk::IR::Node::Constant->new(
+        value => 10,
+        type => Chalk::IR::Type::Integer->constant(10)
+    );
+    my $zero = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type => Chalk::IR::Type::Integer->constant(0)
+    );
+    my $div_by_zero = Chalk::IR::Node::Divide->new(left => $numerator, right => $zero);
+
+    my $const5 = Chalk::IR::Node::Constant->new(
+        value => 5,
+        type => Chalk::IR::Type::Integer->constant(5)
+    );
+    my $mul = Chalk::IR::Node::Multiply->new(left => $div_by_zero, right => $const5);
+
+    my $result_type = $mul->compute();
+    ok($result_type isa Chalk::IR::Type::Integer, 'Multiply returns TypeInteger');
+    ok($result_type->is_bottom, 'Multiply propagates IntBot (error state absorbs)');
+};
+
+subtest 'Divide propagates IntBot from left operand' => sub {
+    my $numerator = Chalk::IR::Node::Constant->new(
+        value => 10,
+        type => Chalk::IR::Type::Integer->constant(10)
+    );
+    my $zero = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type => Chalk::IR::Type::Integer->constant(0)
+    );
+    my $div_by_zero = Chalk::IR::Node::Divide->new(left => $numerator, right => $zero);
+
+    my $const5 = Chalk::IR::Node::Constant->new(
+        value => 5,
+        type => Chalk::IR::Type::Integer->constant(5)
+    );
+    my $div = Chalk::IR::Node::Divide->new(left => $div_by_zero, right => $const5);
+
+    my $result_type = $div->compute();
+    ok($result_type isa Chalk::IR::Type::Integer, 'Divide returns TypeInteger');
+    ok($result_type->is_bottom, 'Divide propagates IntBot from left operand');
+};
+
+done_testing();

--- a/t/sea-of-nodes/compute.t
+++ b/t/sea-of-nodes/compute.t
@@ -389,9 +389,9 @@ subtest 'Negate node compute() with unknown integer returns IntTop' => sub {
     ok($type->is_top, 'Result is IntTop (unknown integer)');
 };
 
-# IntBot propagation tests - document current behavior
-# TODO(#220): Revisit IntBot arithmetic semantics with automatic coercion
-subtest 'Add node compute() with IntBot operand returns IntTop (current behavior)' => sub {
+# IntBot propagation tests - error state propagates through arithmetic
+# Fixed in #220: IntBot now correctly propagates (absorbs) through arithmetic operations
+subtest 'Add node compute() with IntBot operand propagates error' => sub {
     # Create a node that returns IntBot (division by zero)
     my $const20 = Chalk::IR::Node::Constant->new(value => 20, type => Chalk::IR::Type::Integer->constant(20));
     my $const0 = Chalk::IR::Node::Constant->new(value => 0, type => Chalk::IR::Type::Integer->constant(0));
@@ -407,9 +407,8 @@ subtest 'Add node compute() with IntBot operand returns IntTop (current behavior
 
     my $result = $add->compute();
     ok($result isa Chalk::IR::Type::Integer, 'IntBot + constant returns TypeInteger');
-    # Current behavior: IntBot isa TypeInteger, so returns IntTop
-    # Future consideration: should IntBot propagate (IntBot + x = IntBot)?
-    ok($result->is_top, 'Current behavior: IntBot + constant = IntTop');
+    # Correct behavior: IntBot propagates through arithmetic (error absorption)
+    ok($result->is_bottom, 'IntBot + constant = IntBot (error propagation)');
 };
 
 done_testing();


### PR DESCRIPTION
## Summary
- Implements correct lattice absorption semantics for IntBot (bottom type)
- IntBot represents error states (e.g., division by zero) and should propagate through operations
- `IntBot OP x = IntBot` (errors absorb through arithmetic)

## Changes
- 6 files changed, 179 insertions(+), 6 deletions(-)
- Add.pm, Subtract.pm, Multiply.pm, Divide.pm: Add IntBot propagation in compute()
- New test file: t/ir/intbot-propagation.t with comprehensive IntBot tests
- t/sea-of-nodes/compute.t: Updated to expect correct IntBot propagation behavior

## Related Issues
Closes #220

## Test Plan
- [x] New comprehensive test suite for IntBot propagation
- [x] All existing tests pass
- [x] Division by zero correctly produces IntBot
- [x] IntBot propagates through Add, Subtract, Multiply, Divide