### PR TITLE
fix(type-system): Complete TypeInference/Semantic integration for ClassDeclaration (#372)

### DIFF
--- a/lib/Chalk/Grammar/Chalk/Rule/ClassDeclaration.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/ClassDeclaration.pm
@@ -230,6 +230,14 @@ class Chalk::Grammar::Chalk::Rule::ClassDeclaration :isa(Chalk::GrammarRule) {
                 (ref($class_name_token) || (defined $class_name_token ? "'$class_name_token'" : 'undef'));
         }
 
+        # Check if TypeInference already registered this class (Composite mode)
+        # In Composite mode, TypeInference runs first and registers with proper field types
+        # We skip re-registration to avoid conflict and preserve the inferred types
+        my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
+        if ($registry->is_complete($class_name)) {
+            return undef;
+        }
+
         # Find the Block context (last child)
         my $block_ctx = $child_contexts[$#child_contexts];
 
@@ -237,14 +245,19 @@ class Chalk::Grammar::Chalk::Rule::ClassDeclaration :isa(Chalk::GrammarRule) {
         # Returns array of hashrefs: { name => $field_name, type => $type_obj, attributes => \@attrs, has_default => bool }
         my @field_info = _extract_fields_from_context($block_ctx);
 
-        # Build field hash: field_name => Type (use inferred type or default to Any)
+        # Get type_env from context (set by TypeInference via Composite integration)
+        # This allows us to use inferred field types instead of defaulting to Any
+        my $type_env = $context->env->{type_env} // {};
+
+        # Build field hash: field_name => Type (use type_env or default to Any)
         # Also build param_fields array for :param fields
         my %fields;
         my @param_fields;
         my $any_type = Chalk::Grammar::Chalk::Type::Any->new();
         for my $info (@field_info) {
             my $field_name = $info->{name};
-            my $field_type = $info->{type} // $any_type;
+            # First try type_env (from TypeInference), then field info, then Any
+            my $field_type = $type_env->{$field_name} // $info->{type} // $any_type;
             # Field names come as scalars like '$x', '$y', etc.
             $fields{$field_name} = $field_type;
 
@@ -270,7 +283,6 @@ class Chalk::Grammar::Chalk::Rule::ClassDeclaration :isa(Chalk::GrammarRule) {
         );
 
         # Register in TypeRegistry
-        my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
         $registry->register($class_name, $class_type);
 
         # Return undef for now (we don't need IR generation for type registration)

--- a/t/semiring/type-semantic-integration.t
+++ b/t/semiring/type-semantic-integration.t
@@ -150,3 +150,45 @@ subtest 'Multiple variable type bindings flow to Semantic' => sub {
         fail('Semantic sees $y as Num');
     }
 };
+
+# Test 3: ClassDeclaration field type integration
+# When using Composite with ClassDeclaration:
+# - TypeInference should register class with proper field types first
+# - Semantic should skip re-registration (avoid conflict)
+# - The TypeRegistry should have the TypeInference-inferred types
+subtest 'ClassDeclaration field types via Composite integration' => sub {
+    use Chalk::Grammar::Chalk::TypeRegistry;
+
+    # Reset registry for this test
+    my $registry = Chalk::Grammar::Chalk::TypeRegistry->instance();
+    $registry->reset();
+
+    my $code = q{class Counter { field $count = 0; }};
+
+    my $type_sr = Chalk::Semiring::TypeInference->new();
+    my $sem_sr = Chalk::Semiring::Semantic->new(grammar => $chalk_grammar);
+    my $composite = Chalk::Semiring::Composite->new(
+        semirings => [$type_sr, $sem_sr]
+    );
+
+    my $parser = Chalk::Parser->new(
+        grammar => $chalk_grammar,
+        semiring => $composite
+    );
+
+    my $element = $parser->parse_string($code);
+    ok(defined($element), 'Parsing with Composite succeeded');
+
+    # Verify class was registered
+    ok($registry->has_class('Counter'), 'Counter class is registered');
+    ok($registry->is_complete('Counter'), 'Counter class is complete');
+
+    # Get the class type and check field type
+    my $counter_type = $registry->lookup('Counter');
+    my $count_type = $counter_type->field_type('$count');
+
+    # The key assertion: field type should be Int (from TypeInference), not Any
+    ok(defined $count_type, 'Field $count has a type');
+    is($count_type->name, 'Int',
+        'Field $count has Int type (from TypeInference, not default Any)');
+};


### PR DESCRIPTION
## Summary

Completes the TypeInference/Semantic integration for ClassDeclaration (#372).

**Changes:**
- ClassDeclaration.evaluate() now checks if TypeInference already registered the class
- Uses type_env from context to get field types (instead of defaulting to Any)
- Fallback chain: type_env → field_info → Any

## Test plan

- [x] t/types/field-type-narrowing.t - 8/8 ✅
- [x] t/semiring/type-semantic-integration.t - 3/3 ✅ (new ClassDeclaration test added)
- [x] t/grammar/class-registration.t - 5/5 ✅
- [x] t/types/class-types.t - 56/56 ✅

## Stats

- 2 files changed
- 57 insertions(+), 3 deletions(-)

## Related Issues

- Closes #372