### PR TITLE
feat: Implement Stage 0 blockers - Steps 1-5 (#397, #396, #398, #402, #7)

### DIFF
--- a/lib/Chalk/Grammar/Chalk/Rule/ArrayVar.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/ArrayVar.pm
@@ -1,5 +1,5 @@
-# ABOUTME: Semantic action for ArrayVar rule in Chalk grammar
-# ABOUTME: Passes through array variable tokens (@var or @_)
+# ABOUTME: Semantic action for ArrayVar - extracts variable name from array syntax
+# ABOUTME: ArrayVar handles @identifier and returns the variable name as metadata
 use 5.42.0;
 use experimental 'class';
 
@@ -7,8 +7,26 @@ class Chalk::Grammar::Chalk::Rule::ArrayVar :isa(Chalk::GrammarRule) {
     method evaluate($context) {
         # ArrayVar -> '@' Identifier
         # ArrayVar -> '@' %SPECIAL_IDENTIFIER%
-        # Pass through first child (the @ sigil)
-        return $context->child(0);
+
+        # Child 0 is '@', child 1 is the identifier
+        my $identifier_node = $context->child(1);
+
+        # Extract the actual string - Identifier returns an array of characters
+        my $identifier;
+        if (ref($identifier_node) eq 'ARRAY') {
+            # Join array elements to get the identifier string
+            $identifier = join('', $identifier_node->@*);
+        } else {
+            $identifier = $identifier_node;
+        }
+
+        # Return a hashref with metadata about this variable
+        # This will be used by Variable and VariableDeclaration
+        return {
+            type => 'array_var',
+            name => $identifier,
+            sigil => '@'
+        };
     }
 }
 

--- a/lib/Chalk/Grammar/Chalk/Rule/ExpressionList.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/ExpressionList.pm
@@ -1,9 +1,11 @@
 # ABOUTME: Semantic action for ExpressionList - handles comma-separated expressions
-# ABOUTME: Returns undef for empty list, passes through single expression, or builds list structure
+# ABOUTME: Returns undef for empty list, passes through single expression, or List node for multiple
 
 use 5.42.0;
 use experimental 'class';
 use Chalk::Grammar;  # Provides Chalk::GrammarRule base class
+use Chalk::IR::Node::List;
+use Scalar::Util 'blessed';
 
 class Chalk::Grammar::Chalk::Rule::ExpressionList :isa(Chalk::GrammarRule) {
     method evaluate($context) {
@@ -14,15 +16,30 @@ class Chalk::Grammar::Chalk::Rule::ExpressionList :isa(Chalk::GrammarRule) {
             return undef;
         }
 
-        # ExpressionList -> Expression  (single expression)
-        if (@children == 1) {
-            return $context->child(0);
+        # Filter to only IR nodes (skip comma tokens and other non-IR children)
+        my @ir_nodes;
+        for my $child_ctx (@children) {
+            my $focus = $child_ctx->focus;
+            if (blessed($focus) && $focus->can('id')) {
+                push @ir_nodes, $focus;
+            }
         }
 
-        # For multiple expressions or fat-comma pairs, we'd need to build
-        # an array/list IR structure. For now, just pass through the first.
-        # TODO: Implement proper list/array IR nodes
-        return $context->child(0);
+        # No IR nodes found
+        if (@ir_nodes == 0) {
+            return undef;
+        }
+
+        # Single expression - pass through directly
+        if (@ir_nodes == 1) {
+            return $ir_nodes[0];
+        }
+
+        # Multiple expressions - create List node
+        return Chalk::IR::Node::List->new(
+            inputs   => [],
+            elements => \@ir_nodes,
+        );
     }
 }
 

--- a/lib/Chalk/Grammar/Chalk/Rule/HashVar.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/HashVar.pm
@@ -1,12 +1,32 @@
-# ABOUTME: Semantic action for HashVar rule in Chalk grammar
-# ABOUTME: Passes through for HashVar constructs
+# ABOUTME: Semantic action for HashVar - extracts variable name from hash syntax
+# ABOUTME: HashVar handles %identifier and returns the variable name as metadata
 use 5.42.0;
 use experimental 'class';
 
 class Chalk::Grammar::Chalk::Rule::HashVar :isa(Chalk::GrammarRule) {
     method evaluate($context) {
-        # Pass through first child
-        return $context->child(0);
+        # HashVar -> '%' Identifier
+        # HashVar -> '%' %SPECIAL_IDENTIFIER%
+
+        # Child 0 is '%', child 1 is the identifier
+        my $identifier_node = $context->child(1);
+
+        # Extract the actual string - Identifier returns an array of characters
+        my $identifier;
+        if (ref($identifier_node) eq 'ARRAY') {
+            # Join array elements to get the identifier string
+            $identifier = join('', $identifier_node->@*);
+        } else {
+            $identifier = $identifier_node;
+        }
+
+        # Return a hashref with metadata about this variable
+        # This will be used by Variable and VariableDeclaration
+        return {
+            type => 'hash_var',
+            name => $identifier,
+            sigil => '%'
+        };
     }
 }
 

--- a/lib/Chalk/Grammar/Chalk/Rule/Variable.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Variable.pm
@@ -7,34 +7,40 @@ use experimental 'class';
 class Chalk::Grammar::Chalk::Rule::Variable :isa(Chalk::GrammarRule) {
     method evaluate($context) {
         # Variable -> ScalarVar (lookup variable in context)
-        # Variable -> ArrayVar (TODO)
-        # Variable -> HashVar (TODO)
+        # Variable -> ArrayVar (lookup array in context)
+        # Variable -> HashVar (lookup hash in context)
         # Variable -> ArraySize (TODO)
 
-        # Get the variable metadata from child (ScalarVar)
+        # Get the variable metadata from child (ScalarVar, ArrayVar, or HashVar)
         my $var_metadata = $context->child(0);
 
-        # For now, only handle scalar variables
-        # ScalarVar returns a hashref with { type => 'scalar_var', name => $identifier, sigil => '$' }
-        if (ref($var_metadata) eq 'HASH' && $var_metadata->{type} eq 'scalar_var') {
+        # Handle all variable types that return metadata hashes
+        if (ref($var_metadata) eq 'HASH') {
+            my $var_type = $var_metadata->{type} // '';
             my $var_name = $var_metadata->{name};
+            my $sigil = $var_metadata->{sigil};
             my $scope = $context->env->{scope};
 
-            # Look up the variable's IR node from Scope
-            # Scope stores actual node objects, not just IDs
-            if ($scope) {
-                my $node = $scope->lookup($var_name);
-                if (defined($node) && ref($node) && $node->can('id')) {
-                    # Return the node object directly
-                    return $node;
-                }
-            }
+            # Construct the full variable name with sigil for scope lookup
+            my $full_name = $sigil . $var_name;
 
-            # Not yet defined - return metadata (for VariableDeclaration to extract name)
-            return $var_metadata;
+            if ($var_type eq 'scalar_var' || $var_type eq 'array_var' || $var_type eq 'hash_var') {
+                # Look up the variable's IR node from Scope
+                # Scope stores actual node objects, not just IDs
+                if ($scope) {
+                    my $node = $scope->lookup($full_name);
+                    if (defined($node) && ref($node) && $node->can('id')) {
+                        # Return the node object directly
+                        return $node;
+                    }
+                }
+
+                # Not yet defined - return metadata (for VariableDeclaration to extract name)
+                return $var_metadata;
+            }
         }
 
-        # For other variable types, pass through the metadata for now
+        # For other variable types, pass through the metadata
         return $var_metadata;
     }
 }

--- a/lib/Chalk/Grammar/Chalk/Rule/Variable.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Variable.pm
@@ -1,16 +1,87 @@
-# ABOUTME: Semantic action for Variable - looks up variable in scope or passes through metadata
-# ABOUTME: Variable delegates to ScalarVar, ArrayVar, HashVar for variable type handling
+# ABOUTME: Semantic action for Variable - looks up variable in scope or generates access nodes
+# ABOUTME: Variable handles ScalarVar, ArrayVar, HashVar and subscripting ($arr[0], $hash{key})
 
 use 5.42.0;
 use experimental 'class';
+use Chalk::IR::Node::ArrayGet;
+use Chalk::IR::Node::HashGet;
+use Scalar::Util 'blessed';
 
 class Chalk::Grammar::Chalk::Rule::Variable :isa(Chalk::GrammarRule) {
     method evaluate($context) {
         # Variable -> ScalarVar (lookup variable in context)
         # Variable -> ArrayVar (lookup array in context)
         # Variable -> HashVar (lookup hash in context)
+        # Variable -> ScalarVar '[' Expression ']' (array element access)
+        # Variable -> ScalarVar '{' Expression '}' (hash element access)
         # Variable -> ArraySize (TODO)
 
+        my @children = $context->children->@*;
+
+        # Check for subscripting: ScalarVar '[' Expression ']' or ScalarVar '{' Expression '}'
+        if (@children == 4) {
+            my $child1 = $context->child(1);
+            my $bracket = ref($child1) ? undef : $child1;
+
+            if (defined($bracket) && ($bracket eq '[' || $bracket eq '{')) {
+                return $self->_handle_subscript($context, $bracket);
+            }
+        }
+
+        # Simple variable access (single child)
+        return $self->_handle_simple_variable($context);
+    }
+
+    method _handle_subscript($context, $bracket) {
+        my $var_metadata = $context->child(0);
+        my $index_or_key = $context->child(2);  # The expression between brackets
+        my $scope = $context->env->{scope};
+
+        # Extract variable name from metadata
+        my $var_name;
+        if (ref($var_metadata) eq 'HASH' && $var_metadata->{type}) {
+            $var_name = $var_metadata->{name};
+        } else {
+            die "Variable: expected variable metadata for subscript, got: " . (ref($var_metadata) || $var_metadata);
+        }
+
+        # Validate the index/key is an IR node
+        unless (blessed($index_or_key) && $index_or_key->can('id')) {
+            die "Variable: expected IR node for subscript index/key, got: " . (ref($index_or_key) || $index_or_key);
+        }
+
+        if ($bracket eq '[') {
+            # Array element access: $arr[0]
+            # Look up the array using @name
+            my $array_node = $scope ? $scope->lookup('@' . $var_name) : undef;
+
+            unless ($array_node && blessed($array_node) && $array_node->can('id')) {
+                die "Variable: array '\@$var_name' not found in scope";
+            }
+
+            return Chalk::IR::Node::ArrayGet->new(
+                inputs   => [],
+                array_id => $array_node->id,
+                index_id => $index_or_key->id,
+            );
+        } else {
+            # Hash element access: $hash{key}
+            # Look up the hash using %name
+            my $hash_node = $scope ? $scope->lookup('%' . $var_name) : undef;
+
+            unless ($hash_node && blessed($hash_node) && $hash_node->can('id')) {
+                die "Variable: hash '\%$var_name' not found in scope";
+            }
+
+            return Chalk::IR::Node::HashGet->new(
+                inputs  => [],
+                hash_id => $hash_node->id,
+                key_id  => $index_or_key->id,
+            );
+        }
+    }
+
+    method _handle_simple_variable($context) {
         # Get the variable metadata from child (ScalarVar, ArrayVar, or HashVar)
         my $var_metadata = $context->child(0);
 

--- a/lib/Chalk/Grammar/Chalk/Rule/VariableDeclaration.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/VariableDeclaration.pm
@@ -38,11 +38,27 @@ class Chalk::Grammar::Chalk::Rule::VariableDeclaration :isa(Chalk::GrammarRule) 
 
         # Extract variable name from metadata hashref
         my $var_name;
-        if (ref($var) eq 'HASH' && $var->{type} && $var->{type} eq 'scalar_var') {
-            $var_name = $var->{name};
+        my $var_type;
+        if (ref($var) eq 'HASH' && $var->{type}) {
+            $var_type = $var->{type};
+            my $name = $var->{name};
+            my $sigil = $var->{sigil};
+
+            if ($var_type eq 'scalar_var') {
+                # Scalars are stored without sigil for backward compatibility
+                $var_name = $name;
+            } elsif ($var_type eq 'array_var') {
+                # Arrays are stored with @ sigil
+                $var_name = '@' . $name;
+            } elsif ($var_type eq 'hash_var') {
+                # Hashes are stored with % sigil
+                $var_name = '%' . $name;
+            } else {
+                die "VariableDeclaration: unknown variable type: $var_type";
+            }
         } else {
             my $desc = ref($var) || (defined $var ? "'$var'" : 'undef');
-            die "VariableDeclaration: expected scalar_var hashref, got: $desc";
+            die "VariableDeclaration: expected variable hashref, got: $desc";
         }
 
         # Get the expression value (child after '=' + WS_OPT)

--- a/lib/Chalk/IR/Node/Call.pm
+++ b/lib/Chalk/IR/Node/Call.pm
@@ -79,9 +79,20 @@ class Chalk::IR::Node::Call {
             $recv_value = $context->("node:" . $receiver->id);
         }
 
-        # Actual function dispatch would happen here
-        # For now, return undef - CallEnd handles return value
-        return undef;
+        # Return call descriptor for CallEnd to process
+        # This contains all information needed for function dispatch
+        my $descriptor = {
+            func_name => $func_name,
+            args      => \@evaluated_args,
+            rpc       => $rpc,
+        };
+
+        # Include receiver for method calls
+        if (defined $recv_value) {
+            $descriptor->{receiver} = $recv_value;
+        }
+
+        return $descriptor;
     }
 
     method attributes() {

--- a/lib/Chalk/IR/Node/CallEnd.pm
+++ b/lib/Chalk/IR/Node/CallEnd.pm
@@ -3,6 +3,7 @@
 use 5.42.0;
 use experimental qw(class);
 use utf8;
+use Chalk::IR::Node::Proj;
 
 class Chalk::IR::Node::CallEnd {
     field $call :param :reader;         # The Call node this completes
@@ -11,6 +12,11 @@ class Chalk::IR::Node::CallEnd {
 
     # Dependency tracking for peephole re-optimization
     field $_deps = [];
+
+    # Cached projection nodes
+    field $_ctrl_proj = undef;
+    field $_mem_proj = undef;
+    field $_ret_proj = undef;
 
     method add_dep($dependent_node_id) {
         push $_deps->@*, $dependent_node_id;
@@ -68,21 +74,39 @@ class Chalk::IR::Node::CallEnd {
         return;
     }
 
-    # Projection accessors (for future use)
-    # These would create Proj nodes for control, memory, and return value
+    # Projection accessors for control, memory, and return value
+    # Returns cached Proj nodes (created on first access)
     method ctrl_proj() {
-        # Returns a Proj node for control flow continuation
-        return undef;  # Placeholder
+        return $_ctrl_proj if defined $_ctrl_proj;
+        $_ctrl_proj = Chalk::IR::Node::Proj->new(
+            inputs => [ $self->id ],
+            index  => 0,
+            label  => 'ctrl',
+            source => $self,
+        );
+        return $_ctrl_proj;
     }
 
     method mem_proj() {
-        # Returns a Proj node for memory state
-        return undef;  # Placeholder
+        return $_mem_proj if defined $_mem_proj;
+        $_mem_proj = Chalk::IR::Node::Proj->new(
+            inputs => [ $self->id ],
+            index  => 1,
+            label  => 'mem',
+            source => $self,
+        );
+        return $_mem_proj;
     }
 
     method ret_proj() {
-        # Returns a Proj node for return value
-        return undef;  # Placeholder
+        return $_ret_proj if defined $_ret_proj;
+        $_ret_proj = Chalk::IR::Node::Proj->new(
+            inputs => [ $self->id ],
+            index  => 2,
+            label  => 'ret',
+            source => $self,
+        );
+        return $_ret_proj;
     }
 }
 

--- a/lib/Chalk/IR/Node/List.pm
+++ b/lib/Chalk/IR/Node/List.pm
@@ -1,0 +1,50 @@
+# ABOUTME: List node for holding multiple expression values
+# ABOUTME: Used for expression lists, function arguments, and list assignment
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+
+class Chalk::IR::Node::List :isa(Chalk::IR::Node::Base) {
+    field $elements :param :reader = [];  # Array of IR nodes
+
+    method op() { 'List' }
+
+    method to_hash() {
+        my @element_ids = map { $_->id } $elements->@*;
+        return {
+            id     => $self->id,
+            op     => 'List',
+            inputs => $self->inputs,
+            attributes => {
+                element_count => scalar($elements->@*),
+                element_ids   => \@element_ids,
+            },
+        };
+    }
+
+    method execute($context) {
+        # Evaluate all elements and return as array ref
+        my @values;
+        for my $elem ($elements->@*) {
+            my $value = $context->("node:" . $elem->id);
+            push @values, $value;
+        }
+        return \@values;
+    }
+
+    # Return the number of elements
+    method length() {
+        return scalar($elements->@*);
+    }
+
+    # Get element at index
+    method element_at($index) {
+        return $elements->[$index];
+    }
+
+    method peephole($graph = undef) {
+        return $self;
+    }
+}
+
+1;

--- a/t/grammar/expressionlist.t
+++ b/t/grammar/expressionlist.t
@@ -1,0 +1,199 @@
+# ABOUTME: Tests for ExpressionList semantic action
+# ABOUTME: Verifies ExpressionList generates proper List IR nodes
+
+use v5.42;
+use Test::More;
+use FindBin qw($RealBin);
+
+use lib "$RealBin/../../lib";
+use Chalk::Grammar;  # Must be loaded first to define Chalk::GrammarRule
+use Chalk::Grammar::Chalk::Rule::ExpressionList;
+use Chalk::IR::Node::List;
+use Chalk::IR::Node::Constant;
+use Chalk::Grammar::Chalk::Type::Int;
+use Chalk::Grammar::Chalk::Type::Str;
+use Chalk::EvalContext;
+use Scalar::Util 'blessed';
+
+# Helper to create a context with IR node children
+sub make_context {
+    my (@elements) = @_;
+
+    my @child_contexts;
+    my $pos = 0;
+    for my $elem (@elements) {
+        push @child_contexts, Chalk::EvalContext->new(
+            focus => $elem,
+            children => [],
+            start_pos => $pos,
+            end_pos => $pos + 1,
+            env => {},
+            grammar => undef,
+            rule => undef
+        );
+        $pos += 2;  # Account for comma
+    }
+
+    return Chalk::EvalContext->new(
+        children => \@child_contexts,
+        focus => undef,
+        start_pos => 0,
+        end_pos => $pos,
+        env => {},
+        grammar => undef,
+        rule => undef
+    );
+}
+
+subtest 'ExpressionList empty returns undef' => sub {
+    my $context = make_context();
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ExpressionList->new(
+        lhs => 'ExpressionList',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(!defined($result), 'Empty ExpressionList returns undef');
+};
+
+subtest 'ExpressionList single element passes through' => sub {
+    my $elem = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+
+    my $context = make_context($elem);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ExpressionList->new(
+        lhs => 'ExpressionList',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Single element returns IR node');
+    is($result->id, $elem->id, 'Returns the same element');
+};
+
+subtest 'ExpressionList multiple elements returns List node' => sub {
+    my $elem1 = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+    my $elem2 = Chalk::IR::Node::Constant->new(
+        value => 2,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+    my $elem3 = Chalk::IR::Node::Constant->new(
+        value => 3,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+
+    my $context = make_context($elem1, $elem2, $elem3);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ExpressionList->new(
+        lhs => 'ExpressionList',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Multiple elements returns blessed object');
+    is($result->op, 'List', 'Returns a List node');
+    is($result->length, 3, 'List has 3 elements');
+    is($result->element_at(0)->id, $elem1->id, 'First element is correct');
+    is($result->element_at(1)->id, $elem2->id, 'Second element is correct');
+    is($result->element_at(2)->id, $elem3->id, 'Third element is correct');
+};
+
+subtest 'ExpressionList with two elements' => sub {
+    my $elem1 = Chalk::IR::Node::Constant->new(
+        value => 'hello',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+    my $elem2 = Chalk::IR::Node::Constant->new(
+        value => 'world',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+
+    my $context = make_context($elem1, $elem2);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ExpressionList->new(
+        lhs => 'ExpressionList',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Two elements returns blessed object');
+    is($result->op, 'List', 'Returns a List node');
+    is($result->length, 2, 'List has 2 elements');
+};
+
+subtest 'ExpressionList filters non-IR children (like commas)' => sub {
+    # This tests that ExpressionList properly filters out non-IR nodes
+    # like comma tokens that might appear in the children
+
+    my $elem1 = Chalk::IR::Node::Constant->new(
+        value => 10,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+    my $comma = ',';  # Non-IR token
+    my $elem2 = Chalk::IR::Node::Constant->new(
+        value => 20,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+
+    # Create context with mixed children (IR nodes and tokens)
+    my @child_contexts = (
+        Chalk::EvalContext->new(
+            focus => $elem1,
+            children => [],
+            start_pos => 0,
+            end_pos => 2,
+            env => {},
+            grammar => undef,
+            rule => undef
+        ),
+        Chalk::EvalContext->new(
+            focus => $comma,
+            children => [],
+            start_pos => 2,
+            end_pos => 3,
+            env => {},
+            grammar => undef,
+            rule => undef
+        ),
+        Chalk::EvalContext->new(
+            focus => $elem2,
+            children => [],
+            start_pos => 4,
+            end_pos => 6,
+            env => {},
+            grammar => undef,
+            rule => undef
+        ),
+    );
+
+    my $context = Chalk::EvalContext->new(
+        children => \@child_contexts,
+        focus => undef,
+        start_pos => 0,
+        end_pos => 6,
+        env => {},
+        grammar => undef,
+        rule => undef
+    );
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ExpressionList->new(
+        lhs => 'ExpressionList',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Result is blessed');
+    is($result->op, 'List', 'Returns a List node');
+    is($result->length, 2, 'List has 2 elements (comma filtered out)');
+    is($result->element_at(0)->id, $elem1->id, 'First element is correct');
+    is($result->element_at(1)->id, $elem2->id, 'Second element is correct');
+};
+
+done_testing();

--- a/t/grammar/variable-indexing.t
+++ b/t/grammar/variable-indexing.t
@@ -1,0 +1,266 @@
+# ABOUTME: Tests for Variable semantic action with array/hash indexing
+# ABOUTME: Verifies Variable generates ArrayGet/HashGet nodes for $arr[0], $hash{key}
+
+use v5.42;
+use Test::More;
+use FindBin qw($RealBin);
+
+use lib "$RealBin/../../lib";
+use Chalk::Grammar;  # Must be loaded first to define Chalk::GrammarRule
+use Chalk::Grammar::Chalk::Rule::Variable;
+use Chalk::IR::Node::ArrayGet;
+use Chalk::IR::Node::HashGet;
+use Chalk::IR::Node::NewArray;
+use Chalk::IR::Node::NewHash;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Node::Scope;
+use Chalk::IR::Node::Start;
+use Chalk::Grammar::Chalk::Type::Int;
+use Chalk::Grammar::Chalk::Type::Str;
+use Chalk::EvalContext;
+use Scalar::Util 'blessed';
+
+# Helper to create a scope with an array variable
+sub make_scope_with_array {
+    my ($var_name, $array_node) = @_;
+    my $start = Chalk::IR::Node::Start->new();
+    my $scope = Chalk::IR::Node::Scope->new();
+    $scope = $scope->with_control($start);
+    $scope = $scope->with_binding('@' . $var_name, $array_node);
+    return $scope;
+}
+
+# Helper to create a scope with a hash variable
+sub make_scope_with_hash {
+    my ($var_name, $hash_node) = @_;
+    my $start = Chalk::IR::Node::Start->new();
+    my $scope = Chalk::IR::Node::Scope->new();
+    $scope = $scope->with_control($start);
+    $scope = $scope->with_binding('%' . $var_name, $hash_node);
+    return $scope;
+}
+
+# Helper to create a context for Variable -> ScalarVar '[' Expression ']'
+# This represents $arr[0] where the scalar access uses the array sigil lookup
+sub make_array_subscript_context {
+    my ($var_name, $index_node, $scope) = @_;
+
+    # For $arr[0], the ScalarVar metadata points to scalar sigil
+    # but we need to look up the array @arr
+    my $scalar_var_metadata = {
+        type => 'scalar_var',
+        name => $var_name,
+        sigil => '$'
+    };
+
+    # Children: ScalarVar, '[', Expression, ']'
+    my @child_contexts = (
+        # Child 0: ScalarVar (returns metadata)
+        Chalk::EvalContext->new(
+            focus => $scalar_var_metadata,
+            children => [],
+            start_pos => 0,
+            end_pos => 4,
+            env => { scope => $scope },
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 1: '['
+        Chalk::EvalContext->new(
+            focus => '[',
+            children => [],
+            start_pos => 4,
+            end_pos => 5,
+            env => { scope => $scope },
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 2: Expression (index node)
+        Chalk::EvalContext->new(
+            focus => $index_node,
+            children => [],
+            start_pos => 5,
+            end_pos => 6,
+            env => { scope => $scope },
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 3: ']'
+        Chalk::EvalContext->new(
+            focus => ']',
+            children => [],
+            start_pos => 6,
+            end_pos => 7,
+            env => { scope => $scope },
+            grammar => undef,
+            rule => undef
+        ),
+    );
+
+    return Chalk::EvalContext->new(
+        children => \@child_contexts,
+        focus => undef,
+        start_pos => 0,
+        end_pos => 7,
+        env => { scope => $scope },
+        grammar => undef,
+        rule => undef
+    );
+}
+
+# Helper to create a context for Variable -> ScalarVar '{' Expression '}'
+# This represents $hash{key}
+sub make_hash_subscript_context {
+    my ($var_name, $key_node, $scope) = @_;
+
+    my $scalar_var_metadata = {
+        type => 'scalar_var',
+        name => $var_name,
+        sigil => '$'
+    };
+
+    # Children: ScalarVar, '{', Expression, '}'
+    my @child_contexts = (
+        # Child 0: ScalarVar (returns metadata)
+        Chalk::EvalContext->new(
+            focus => $scalar_var_metadata,
+            children => [],
+            start_pos => 0,
+            end_pos => 5,
+            env => { scope => $scope },
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 1: '{'
+        Chalk::EvalContext->new(
+            focus => '{',
+            children => [],
+            start_pos => 5,
+            end_pos => 6,
+            env => { scope => $scope },
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 2: Expression (key node)
+        Chalk::EvalContext->new(
+            focus => $key_node,
+            children => [],
+            start_pos => 6,
+            end_pos => 9,
+            env => { scope => $scope },
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 3: '}'
+        Chalk::EvalContext->new(
+            focus => '}',
+            children => [],
+            start_pos => 9,
+            end_pos => 10,
+            env => { scope => $scope },
+            grammar => undef,
+            rule => undef
+        ),
+    );
+
+    return Chalk::EvalContext->new(
+        children => \@child_contexts,
+        focus => undef,
+        start_pos => 0,
+        end_pos => 10,
+        env => { scope => $scope },
+        grammar => undef,
+        rule => undef
+    );
+}
+
+subtest 'Variable array subscript generates ArrayGet' => sub {
+    my $array_node = Chalk::IR::Node::NewArray->new(inputs => []);
+    my $scope = make_scope_with_array('arr', $array_node);
+
+    my $index_node = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+
+    my $context = make_array_subscript_context('arr', $index_node, $scope);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::Variable->new(
+        lhs => 'Variable',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Result is blessed');
+    is($result->op, 'ArrayGet', 'Returns an ArrayGet node');
+    is($result->array_id, $array_node->id, 'Array ID is correct');
+    is($result->index_id, $index_node->id, 'Index ID is correct');
+};
+
+subtest 'Variable hash subscript generates HashGet' => sub {
+    my $hash_node = Chalk::IR::Node::NewHash->new(inputs => []);
+    my $scope = make_scope_with_hash('config', $hash_node);
+
+    my $key_node = Chalk::IR::Node::Constant->new(
+        value => 'name',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+
+    my $context = make_hash_subscript_context('config', $key_node, $scope);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::Variable->new(
+        lhs => 'Variable',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Result is blessed');
+    is($result->op, 'HashGet', 'Returns a HashGet node');
+    is($result->hash_id, $hash_node->id, 'Hash ID is correct');
+    is($result->key_id, $key_node->id, 'Key ID is correct');
+};
+
+subtest 'Variable still works for simple variable lookup' => sub {
+    my $array_node = Chalk::IR::Node::NewArray->new(inputs => []);
+    my $scope = make_scope_with_array('data', $array_node);
+
+    # Simple ArrayVar context (just @data, no subscript)
+    my $var_metadata = {
+        type => 'array_var',
+        name => 'data',
+        sigil => '@'
+    };
+
+    my @child_contexts = (
+        Chalk::EvalContext->new(
+            focus => $var_metadata,
+            children => [],
+            start_pos => 0,
+            end_pos => 5,
+            env => { scope => $scope },
+            grammar => undef,
+            rule => undef
+        ),
+    );
+
+    my $context = Chalk::EvalContext->new(
+        children => \@child_contexts,
+        focus => undef,
+        start_pos => 0,
+        end_pos => 5,
+        env => { scope => $scope },
+        grammar => undef,
+        rule => undef
+    );
+
+    my $rule = Chalk::Grammar::Chalk::Rule::Variable->new(
+        lhs => 'Variable',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Result is blessed');
+    is($result->id, $array_node->id, 'Returns the array node from scope');
+};
+
+done_testing();

--- a/t/grammar/variable.t
+++ b/t/grammar/variable.t
@@ -1,0 +1,299 @@
+# ABOUTME: Tests for Variable semantic action
+# ABOUTME: Verifies Variable handles ScalarVar, ArrayVar, HashVar correctly
+
+use v5.42;
+use Test::More;
+use FindBin qw($RealBin);
+
+use lib "$RealBin/../../lib";
+use Chalk::Grammar;  # Must be loaded first to define Chalk::GrammarRule
+use Chalk::Grammar::Chalk::Rule::Variable;
+use Chalk::Grammar::Chalk::Rule::ScalarVar;
+use Chalk::Grammar::Chalk::Rule::ArrayVar;
+use Chalk::Grammar::Chalk::Rule::HashVar;
+use Chalk::IR::Node::Scope;
+use Chalk::IR::Node::Constant;
+use Chalk::Grammar::Chalk::Type::Int;
+use Chalk::EvalContext;
+use Scalar::Util 'blessed';
+
+# ===== ScalarVar metadata tests =====
+
+subtest 'ScalarVar returns metadata hash' => sub {
+    # Mock context for '$foo'
+    my $context = Chalk::EvalContext->new(
+        children => [
+            # Child 0: '$' sigil
+            Chalk::EvalContext->new(
+                focus => '$',
+                children => [],
+                start_pos => 0,
+                end_pos => 1,
+                env => {},
+                grammar => undef,
+                rule => undef
+            ),
+            # Child 1: identifier 'foo'
+            Chalk::EvalContext->new(
+                focus => 'foo',
+                children => [],
+                start_pos => 1,
+                end_pos => 4,
+                env => {},
+                grammar => undef,
+                rule => undef
+            ),
+        ],
+        focus => undef,
+        start_pos => 0,
+        end_pos => 4,
+        env => {},
+        grammar => undef,
+        rule => undef
+    );
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ScalarVar->new(
+        lhs => 'ScalarVar',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    is(ref($result), 'HASH', 'ScalarVar returns hashref');
+    is($result->{type}, 'scalar_var', 'type is scalar_var');
+    is($result->{name}, 'foo', 'name is correct');
+    is($result->{sigil}, '$', 'sigil is $');
+};
+
+# ===== ArrayVar metadata tests =====
+
+subtest 'ArrayVar returns metadata hash' => sub {
+    # Mock context for '@arr'
+    my $context = Chalk::EvalContext->new(
+        children => [
+            # Child 0: '@' sigil
+            Chalk::EvalContext->new(
+                focus => '@',
+                children => [],
+                start_pos => 0,
+                end_pos => 1,
+                env => {},
+                grammar => undef,
+                rule => undef
+            ),
+            # Child 1: identifier 'arr'
+            Chalk::EvalContext->new(
+                focus => 'arr',
+                children => [],
+                start_pos => 1,
+                end_pos => 4,
+                env => {},
+                grammar => undef,
+                rule => undef
+            ),
+        ],
+        focus => undef,
+        start_pos => 0,
+        end_pos => 4,
+        env => {},
+        grammar => undef,
+        rule => undef
+    );
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ArrayVar->new(
+        lhs => 'ArrayVar',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    is(ref($result), 'HASH', 'ArrayVar returns hashref');
+    is($result->{type}, 'array_var', 'type is array_var');
+    is($result->{name}, 'arr', 'name is correct');
+    is($result->{sigil}, '@', 'sigil is @');
+};
+
+# ===== HashVar metadata tests =====
+
+subtest 'HashVar returns metadata hash' => sub {
+    # Mock context for '%hash'
+    my $context = Chalk::EvalContext->new(
+        children => [
+            # Child 0: '%' sigil
+            Chalk::EvalContext->new(
+                focus => '%',
+                children => [],
+                start_pos => 0,
+                end_pos => 1,
+                env => {},
+                grammar => undef,
+                rule => undef
+            ),
+            # Child 1: identifier 'hash'
+            Chalk::EvalContext->new(
+                focus => 'hash',
+                children => [],
+                start_pos => 1,
+                end_pos => 5,
+                env => {},
+                grammar => undef,
+                rule => undef
+            ),
+        ],
+        focus => undef,
+        start_pos => 0,
+        end_pos => 5,
+        env => {},
+        grammar => undef,
+        rule => undef
+    );
+
+    my $rule = Chalk::Grammar::Chalk::Rule::HashVar->new(
+        lhs => 'HashVar',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    is(ref($result), 'HASH', 'HashVar returns hashref');
+    is($result->{type}, 'hash_var', 'type is hash_var');
+    is($result->{name}, 'hash', 'name is correct');
+    is($result->{sigil}, '%', 'sigil is %');
+};
+
+# ===== Variable rule tests =====
+
+subtest 'Variable handles array_var metadata' => sub {
+    # Create a scope with an array variable
+    my $scope = Chalk::IR::Node::Scope->new();
+    my $array_node = Chalk::IR::Node::Constant->new(
+        value => 'mock_array_ref',
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+    $scope = $scope->with_binding('@arr', $array_node);
+
+    # Create metadata that ArrayVar would return
+    my $array_metadata = {
+        type => 'array_var',
+        name => 'arr',
+        sigil => '@'
+    };
+
+    # Mock context with scope and array metadata
+    my $context = Chalk::EvalContext->new(
+        children => [
+            Chalk::EvalContext->new(
+                focus => $array_metadata,
+                children => [],
+                start_pos => 0,
+                end_pos => 4,
+                env => { scope => $scope },
+                grammar => undef,
+                rule => undef
+            ),
+        ],
+        focus => undef,
+        start_pos => 0,
+        end_pos => 4,
+        env => { scope => $scope },
+        grammar => undef,
+        rule => undef
+    );
+
+    my $rule = Chalk::Grammar::Chalk::Rule::Variable->new(
+        lhs => 'Variable',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Variable returns IR node for array');
+    is($result->id, $array_node->id, 'Returns the correct array node');
+};
+
+subtest 'Variable handles hash_var metadata' => sub {
+    # Create a scope with a hash variable
+    my $scope = Chalk::IR::Node::Scope->new();
+    my $hash_node = Chalk::IR::Node::Constant->new(
+        value => 'mock_hash_ref',
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+    $scope = $scope->with_binding('%myhash', $hash_node);
+
+    # Create metadata that HashVar would return
+    my $hash_metadata = {
+        type => 'hash_var',
+        name => 'myhash',
+        sigil => '%'
+    };
+
+    # Mock context with scope and hash metadata
+    my $context = Chalk::EvalContext->new(
+        children => [
+            Chalk::EvalContext->new(
+                focus => $hash_metadata,
+                children => [],
+                start_pos => 0,
+                end_pos => 7,
+                env => { scope => $scope },
+                grammar => undef,
+                rule => undef
+            ),
+        ],
+        focus => undef,
+        start_pos => 0,
+        end_pos => 7,
+        env => { scope => $scope },
+        grammar => undef,
+        rule => undef
+    );
+
+    my $rule = Chalk::Grammar::Chalk::Rule::Variable->new(
+        lhs => 'Variable',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Variable returns IR node for hash');
+    is($result->id, $hash_node->id, 'Returns the correct hash node');
+};
+
+subtest 'Variable passes through metadata for undeclared array' => sub {
+    # Create an empty scope (no @arr defined)
+    my $scope = Chalk::IR::Node::Scope->new();
+
+    # Create metadata that ArrayVar would return
+    my $array_metadata = {
+        type => 'array_var',
+        name => 'undefined_arr',
+        sigil => '@'
+    };
+
+    my $context = Chalk::EvalContext->new(
+        children => [
+            Chalk::EvalContext->new(
+                focus => $array_metadata,
+                children => [],
+                start_pos => 0,
+                end_pos => 14,
+                env => { scope => $scope },
+                grammar => undef,
+                rule => undef
+            ),
+        ],
+        focus => undef,
+        start_pos => 0,
+        end_pos => 14,
+        env => { scope => $scope },
+        grammar => undef,
+        rule => undef
+    );
+
+    my $rule = Chalk::Grammar::Chalk::Rule::Variable->new(
+        lhs => 'Variable',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    is(ref($result), 'HASH', 'Returns metadata for undeclared variable');
+    is($result->{type}, 'array_var', 'Preserves array_var type');
+    is($result->{name}, 'undefined_arr', 'Preserves name');
+};
+
+done_testing();

--- a/t/grammar/variabledeclaration-arrays.t
+++ b/t/grammar/variabledeclaration-arrays.t
@@ -1,0 +1,263 @@
+# ABOUTME: Tests for VariableDeclaration semantic action with arrays and hashes
+# ABOUTME: Verifies VariableDeclaration generates proper IR nodes for @arr and %hash
+
+use v5.42;
+use Test::More;
+use FindBin qw($RealBin);
+
+use lib "$RealBin/../../lib";
+use Chalk::Grammar;  # Must be loaded first to define Chalk::GrammarRule
+use Chalk::Grammar::Chalk::Rule::VariableDeclaration;
+use Chalk::IR::Node::NewArray;
+use Chalk::IR::Node::NewHash;
+use Chalk::IR::Node::Store;
+use Chalk::IR::Node::Scope;
+use Chalk::IR::Node::Start;
+use Chalk::IR::Node::List;
+use Chalk::IR::Node::Constant;
+use Chalk::Grammar::Chalk::Type::Int;
+use Chalk::EvalContext;
+use Scalar::Util 'blessed';
+
+# Helper to create a Start node for control flow
+sub make_start {
+    return Chalk::IR::Node::Start->new();
+}
+
+# Helper to create a scope with control flow
+sub make_scope {
+    my $start = make_start();
+    my $scope = Chalk::IR::Node::Scope->new();
+    return $scope->with_control($start);
+}
+
+# Helper to create a context for VariableDeclaration
+# VariableDeclaration -> LexicalDeclarator WS_OPT Variable WS_OPT '=' WS_OPT Expression
+sub make_decl_context {
+    my ($var_metadata, $value_node, $scope) = @_;
+
+    # Children: 'my', WS, Variable, WS, '=', WS, Expression
+    my @child_contexts = (
+        # Child 0: 'my' (LexicalDeclarator)
+        Chalk::EvalContext->new(
+            focus => 'my',
+            children => [],
+            start_pos => 0,
+            end_pos => 2,
+            env => {},
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 1: WS_OPT (whitespace)
+        Chalk::EvalContext->new(
+            focus => ' ',
+            children => [],
+            start_pos => 2,
+            end_pos => 3,
+            env => {},
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 2: Variable (returns metadata hash)
+        Chalk::EvalContext->new(
+            focus => $var_metadata,
+            children => [],
+            start_pos => 3,
+            end_pos => 7,
+            env => {},
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 3: WS_OPT
+        Chalk::EvalContext->new(
+            focus => ' ',
+            children => [],
+            start_pos => 7,
+            end_pos => 8,
+            env => {},
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 4: '='
+        Chalk::EvalContext->new(
+            focus => '=',
+            children => [],
+            start_pos => 8,
+            end_pos => 9,
+            env => {},
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 5: WS_OPT
+        Chalk::EvalContext->new(
+            focus => ' ',
+            children => [],
+            start_pos => 9,
+            end_pos => 10,
+            env => {},
+            grammar => undef,
+            rule => undef
+        ),
+        # Child 6: Expression (the value IR node)
+        Chalk::EvalContext->new(
+            focus => $value_node,
+            children => [],
+            start_pos => 10,
+            end_pos => 15,
+            env => {},
+            grammar => undef,
+            rule => undef
+        ),
+    );
+
+    my $env = { scope => $scope };
+
+    return Chalk::EvalContext->new(
+        children => \@child_contexts,
+        focus => undef,
+        start_pos => 0,
+        end_pos => 15,
+        env => $env,
+        grammar => undef,
+        rule => undef
+    );
+}
+
+subtest 'VariableDeclaration handles scalar_var' => sub {
+    my $scope = make_scope();
+
+    my $var_metadata = {
+        type => 'scalar_var',
+        name => 'x',
+        sigil => '$'
+    };
+
+    my $value = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+
+    my $context = make_decl_context($var_metadata, $value, $scope);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::VariableDeclaration->new(
+        lhs => 'VariableDeclaration',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Result is blessed');
+    is($result->op, 'Store', 'Returns a Store node');
+    is($result->var, 'x', 'Variable name is correct');
+};
+
+subtest 'VariableDeclaration handles array_var' => sub {
+    my $scope = make_scope();
+
+    my $var_metadata = {
+        type => 'array_var',
+        name => 'arr',
+        sigil => '@'
+    };
+
+    # For array declaration, the value is a NewArray node
+    my $value = Chalk::IR::Node::NewArray->new(
+        inputs => []
+    );
+
+    my $context = make_decl_context($var_metadata, $value, $scope);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::VariableDeclaration->new(
+        lhs => 'VariableDeclaration',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Result is blessed');
+    is($result->op, 'Store', 'Returns a Store node');
+    is($result->var, '@arr', 'Variable name includes sigil for arrays');
+};
+
+subtest 'VariableDeclaration handles hash_var' => sub {
+    my $scope = make_scope();
+
+    my $var_metadata = {
+        type => 'hash_var',
+        name => 'hash',
+        sigil => '%'
+    };
+
+    # For hash declaration, the value is a NewHash node
+    my $value = Chalk::IR::Node::NewHash->new(
+        inputs => []
+    );
+
+    my $context = make_decl_context($var_metadata, $value, $scope);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::VariableDeclaration->new(
+        lhs => 'VariableDeclaration',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(blessed($result), 'Result is blessed');
+    is($result->op, 'Store', 'Returns a Store node');
+    is($result->var, '%hash', 'Variable name includes sigil for hashes');
+};
+
+subtest 'VariableDeclaration updates scope with array binding' => sub {
+    my $scope = make_scope();
+
+    my $var_metadata = {
+        type => 'array_var',
+        name => 'data',
+        sigil => '@'
+    };
+
+    my $value = Chalk::IR::Node::NewArray->new(
+        inputs => []
+    );
+
+    my $context = make_decl_context($var_metadata, $value, $scope);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::VariableDeclaration->new(
+        lhs => 'VariableDeclaration',
+        rhs => []
+    );
+    $rule->evaluate($context);
+
+    # Check that scope was updated
+    my $new_scope = $context->env->{scope};
+    my $bound_value = $new_scope->lookup('@data');
+    ok(defined($bound_value), 'Array variable is bound in scope');
+    is($bound_value->id, $value->id, 'Bound value matches the NewArray node');
+};
+
+subtest 'VariableDeclaration updates scope with hash binding' => sub {
+    my $scope = make_scope();
+
+    my $var_metadata = {
+        type => 'hash_var',
+        name => 'config',
+        sigil => '%'
+    };
+
+    my $value = Chalk::IR::Node::NewHash->new(
+        inputs => []
+    );
+
+    my $context = make_decl_context($var_metadata, $value, $scope);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::VariableDeclaration->new(
+        lhs => 'VariableDeclaration',
+        rhs => []
+    );
+    $rule->evaluate($context);
+
+    # Check that scope was updated
+    my $new_scope = $context->env->{scope};
+    my $bound_value = $new_scope->lookup('%config');
+    ok(defined($bound_value), 'Hash variable is bound in scope');
+    is($bound_value->id, $value->id, 'Bound value matches the NewHash node');
+};
+
+done_testing();

--- a/t/ir/call-node.t
+++ b/t/ir/call-node.t
@@ -128,4 +128,112 @@ subtest 'Call node has rpc identifier' => sub {
     like($call->rpc, qr/^rpc_\d+$/, 'rpc has expected format');
 };
 
+# ===== Execute tests (#396) =====
+
+subtest 'Call execute returns call descriptor' => sub {
+    my $callee = Chalk::IR::Node::Constant->new(
+        value => 'my_func',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+    my $arg1 = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+    my $arg2 = Chalk::IR::Node::Constant->new(
+        value => 'hello',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+
+    my $call = Chalk::IR::Node::Call->new(
+        callee => $callee,
+        args => [$arg1, $arg2],
+    );
+
+    # Create mock context that returns node values
+    my %node_values = (
+        $callee->id => 'my_func',
+        $arg1->id => 42,
+        $arg2->id => 'hello',
+    );
+    my $context = sub ($key) {
+        if ($key =~ /^node:(.+)$/) {
+            return $node_values{$1};
+        }
+        return undef;
+    };
+
+    my $result = $call->execute($context);
+    ok(defined($result), 'execute returns defined value');
+    is(ref($result), 'HASH', 'execute returns hashref');
+    is($result->{func_name}, 'my_func', 'descriptor has func_name');
+    is_deeply($result->{args}, [42, 'hello'], 'descriptor has evaluated args');
+    is($result->{rpc}, $call->rpc, 'descriptor has rpc');
+};
+
+subtest 'Call execute with no arguments' => sub {
+    my $callee = Chalk::IR::Node::Constant->new(
+        value => 'no_args_func',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+
+    my $call = Chalk::IR::Node::Call->new(
+        callee => $callee,
+        args => [],
+    );
+
+    my %node_values = (
+        $callee->id => 'no_args_func',
+    );
+    my $context = sub ($key) {
+        if ($key =~ /^node:(.+)$/) {
+            return $node_values{$1};
+        }
+        return undef;
+    };
+
+    my $result = $call->execute($context);
+    ok(defined($result), 'execute returns defined value');
+    is($result->{func_name}, 'no_args_func', 'descriptor has func_name');
+    is_deeply($result->{args}, [], 'descriptor has empty args');
+};
+
+subtest 'Call execute with receiver for method calls' => sub {
+    my $receiver = Chalk::IR::Node::Constant->new(
+        value => 'MyObject',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+    my $callee = Chalk::IR::Node::Constant->new(
+        value => 'do_something',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+    my $arg = Chalk::IR::Node::Constant->new(
+        value => 10,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+
+    my $call = Chalk::IR::Node::Call->new(
+        callee => $callee,
+        args => [$arg],
+        receiver => $receiver,
+    );
+
+    my %node_values = (
+        $callee->id => 'do_something',
+        $arg->id => 10,
+        $receiver->id => 'MyObject',
+    );
+    my $context = sub ($key) {
+        if ($key =~ /^node:(.+)$/) {
+            return $node_values{$1};
+        }
+        return undef;
+    };
+
+    my $result = $call->execute($context);
+    ok(defined($result), 'execute returns defined value');
+    is($result->{func_name}, 'do_something', 'descriptor has method name');
+    is($result->{receiver}, 'MyObject', 'descriptor has receiver');
+    is_deeply($result->{args}, [10], 'descriptor has args');
+};
+
 done_testing();

--- a/t/ir/callend-node.t
+++ b/t/ir/callend-node.t
@@ -83,4 +83,71 @@ subtest 'CallEnd node inputs include call' => sub {
     is($inputs->[0], $call->id, 'First input is call id');
 };
 
+# ===== Projection tests (#397) =====
+
+subtest 'CallEnd ctrl_proj returns Proj node' => sub {
+    my $call = make_call();
+    my $call_end = Chalk::IR::Node::CallEnd->new(
+        call => $call,
+    );
+
+    my $ctrl = $call_end->ctrl_proj;
+    ok(defined($ctrl), 'ctrl_proj returns defined value');
+    ok(blessed($ctrl), 'ctrl_proj returns blessed object');
+    is($ctrl->op, 'Proj', 'ctrl_proj returns Proj node');
+    is($ctrl->label, 'ctrl', 'ctrl_proj has correct label');
+    is($ctrl->index, 0, 'ctrl_proj has index 0');
+    is($ctrl->source, $call_end, 'ctrl_proj source is CallEnd');
+};
+
+subtest 'CallEnd mem_proj returns Proj node' => sub {
+    my $call = make_call();
+    my $call_end = Chalk::IR::Node::CallEnd->new(
+        call => $call,
+    );
+
+    my $mem = $call_end->mem_proj;
+    ok(defined($mem), 'mem_proj returns defined value');
+    ok(blessed($mem), 'mem_proj returns blessed object');
+    is($mem->op, 'Proj', 'mem_proj returns Proj node');
+    is($mem->label, 'mem', 'mem_proj has correct label');
+    is($mem->index, 1, 'mem_proj has index 1');
+    is($mem->source, $call_end, 'mem_proj source is CallEnd');
+};
+
+subtest 'CallEnd ret_proj returns Proj node' => sub {
+    my $call = make_call();
+    my $call_end = Chalk::IR::Node::CallEnd->new(
+        call => $call,
+    );
+
+    my $ret = $call_end->ret_proj;
+    ok(defined($ret), 'ret_proj returns defined value');
+    ok(blessed($ret), 'ret_proj returns blessed object');
+    is($ret->op, 'Proj', 'ret_proj returns Proj node');
+    is($ret->label, 'ret', 'ret_proj has correct label');
+    is($ret->index, 2, 'ret_proj has index 2');
+    is($ret->source, $call_end, 'ret_proj source is CallEnd');
+};
+
+subtest 'CallEnd projections are cached' => sub {
+    my $call = make_call();
+    my $call_end = Chalk::IR::Node::CallEnd->new(
+        call => $call,
+    );
+
+    # Call each projection twice
+    my $ctrl1 = $call_end->ctrl_proj;
+    my $ctrl2 = $call_end->ctrl_proj;
+    is(refaddr($ctrl1), refaddr($ctrl2), 'ctrl_proj returns same object on repeated calls');
+
+    my $mem1 = $call_end->mem_proj;
+    my $mem2 = $call_end->mem_proj;
+    is(refaddr($mem1), refaddr($mem2), 'mem_proj returns same object on repeated calls');
+
+    my $ret1 = $call_end->ret_proj;
+    my $ret2 = $call_end->ret_proj;
+    is(refaddr($ret1), refaddr($ret2), 'ret_proj returns same object on repeated calls');
+};
+
 done_testing();

--- a/t/ir/list-node.t
+++ b/t/ir/list-node.t
@@ -1,0 +1,143 @@
+# ABOUTME: Tests for List IR node
+# ABOUTME: Verifies List node for holding multiple expression values
+
+use v5.42;
+use Test::More;
+use FindBin qw($RealBin);
+
+use lib "$RealBin/../../lib";
+use Chalk::IR::Node::List;
+use Chalk::IR::Node::Constant;
+use Chalk::Grammar::Chalk::Type::Int;
+use Chalk::Grammar::Chalk::Type::Str;
+use Scalar::Util 'blessed';
+
+subtest 'List node basic structure' => sub {
+    my $elem1 = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+    my $elem2 = Chalk::IR::Node::Constant->new(
+        value => 2,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+
+    my $list = Chalk::IR::Node::List->new(
+        inputs => [],
+        elements => [$elem1, $elem2],
+    );
+
+    ok(defined($list), 'List node is defined');
+    ok(blessed($list), 'List node is blessed');
+    ok($list->isa('Chalk::IR::Node::List'), 'List node has correct type');
+};
+
+subtest 'List node op method' => sub {
+    my $list = Chalk::IR::Node::List->new(
+        inputs => [],
+        elements => [],
+    );
+
+    is($list->op, 'List', 'op() returns List');
+};
+
+subtest 'List node elements accessor' => sub {
+    my $elem1 = Chalk::IR::Node::Constant->new(
+        value => 'a',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+    my $elem2 = Chalk::IR::Node::Constant->new(
+        value => 'b',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+    my $elem3 = Chalk::IR::Node::Constant->new(
+        value => 'c',
+        type => Chalk::Grammar::Chalk::Type::Str->new()
+    );
+
+    my $list = Chalk::IR::Node::List->new(
+        inputs => [],
+        elements => [$elem1, $elem2, $elem3],
+    );
+
+    is($list->length, 3, 'length returns correct count');
+    is($list->element_at(0), $elem1, 'element_at(0) returns first element');
+    is($list->element_at(1), $elem2, 'element_at(1) returns second element');
+    is($list->element_at(2), $elem3, 'element_at(2) returns third element');
+};
+
+subtest 'List node to_hash' => sub {
+    my $elem1 = Chalk::IR::Node::Constant->new(
+        value => 10,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+    my $elem2 = Chalk::IR::Node::Constant->new(
+        value => 20,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+
+    my $list = Chalk::IR::Node::List->new(
+        inputs => [],
+        elements => [$elem1, $elem2],
+    );
+
+    my $hash = $list->to_hash;
+    is($hash->{op}, 'List', 'to_hash op is List');
+    is($hash->{id}, $list->id, 'to_hash id matches');
+    ok(exists $hash->{attributes}, 'to_hash has attributes');
+    is($hash->{attributes}{element_count}, 2, 'attributes has element_count');
+    is_deeply($hash->{attributes}{element_ids}, [$elem1->id, $elem2->id],
+              'attributes has element_ids');
+};
+
+subtest 'List node execute evaluates elements' => sub {
+    my $elem1 = Chalk::IR::Node::Constant->new(
+        value => 100,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+    my $elem2 = Chalk::IR::Node::Constant->new(
+        value => 200,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+    my $elem3 = Chalk::IR::Node::Constant->new(
+        value => 300,
+        type => Chalk::Grammar::Chalk::Type::Int->new()
+    );
+
+    my $list = Chalk::IR::Node::List->new(
+        inputs => [],
+        elements => [$elem1, $elem2, $elem3],
+    );
+
+    # Create mock context
+    my %node_values = (
+        $elem1->id => 100,
+        $elem2->id => 200,
+        $elem3->id => 300,
+    );
+    my $context = sub ($key) {
+        if ($key =~ /^node:(.+)$/) {
+            return $node_values{$1};
+        }
+        return undef;
+    };
+
+    my $result = $list->execute($context);
+    is(ref($result), 'ARRAY', 'execute returns arrayref');
+    is_deeply($result, [100, 200, 300], 'execute returns evaluated elements');
+};
+
+subtest 'Empty list' => sub {
+    my $list = Chalk::IR::Node::List->new(
+        inputs => [],
+        elements => [],
+    );
+
+    is($list->length, 0, 'empty list has length 0');
+
+    my $context = sub { undef };
+    my $result = $list->execute($context);
+    is_deeply($result, [], 'execute returns empty array for empty list');
+};
+
+done_testing();


### PR DESCRIPTION
## Summary

Implements all 5 steps of the Stage 0 blockers work plan:

### Step 1: #397 CallEnd Projections
- Implement `ctrl_proj()`, `mem_proj()`, `ret_proj()` methods in CallEnd node
- Each method returns a cached Proj node for control flow, memory state, and return value

### Step 2: #396 Call execute()
- Implement `Call.execute()` returning call descriptor
- Returns hash with func_name, args, rpc, and optional receiver
- Provides all information needed for CallEnd to dispatch functions

### Step 3: #398 ArrayVar/HashVar
- Update ArrayVar.pm to return metadata hash (type, name, sigil)
- Update HashVar.pm to return metadata hash (type, name, sigil)
- Update Variable.pm to handle array_var and hash_var types
- Variables looked up in scope using full name with sigil (@arr, %hash)

### Step 4: #402 ExpressionList IR
- Create `Chalk::IR::Node::List` for holding multiple expression values
- Update ExpressionList semantic action to return List node for multiple expressions
- Properly filters out non-IR children (like comma tokens)
- Single expressions pass through directly, empty lists return undef

### Step 5: #7 Array/Hash Semantic Actions
- Extend VariableDeclaration to handle array_var and hash_var types
- Arrays stored with @ sigil prefix, hashes with % sigil prefix
- Extend Variable rule to generate ArrayGet/HashGet for subscripting
- $arr[0] generates ArrayGet node, $hash{key} generates HashGet node

## Test Plan
- [x] 4 subtests for CallEnd projection functionality
- [x] 3 subtests for Call.execute()
- [x] 6 subtests for Variable rule (ScalarVar, ArrayVar, HashVar)
- [x] 6 subtests for List IR node
- [x] 5 subtests for ExpressionList semantic action
- [x] 5 subtests for VariableDeclaration with arrays/hashes
- [x] 3 subtests for Variable subscripting (ArrayGet, HashGet)
- [x] All 41 IR tests pass (260 assertions)

## Related Issues
- Closes #397 (CallEnd IR node projections)
- Closes #396 (Call execute() method)
- Closes #398 (ArrayVar/HashVar in Variable rule)
- Closes #402 (ExpressionList proper list/array IR)
- Closes #7 (Array/Hash semantic actions)
- Completes Stage 0 blockers work plan (all 5 steps)