### PR TITLE
fix: Remove duplicate blessed imports causing prototype mismatch warnings

### DIFF
--- a/lib/Chalk/Grammar/Chalk/Rule/ExpressionList.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/ExpressionList.pm
@@ -5,7 +5,7 @@ use 5.42.0;
 use experimental 'class';
 use Chalk::Grammar;  # Provides Chalk::GrammarRule base class
 use Chalk::IR::Node::List;
-use Scalar::Util 'blessed';
+# Note: blessed is auto-imported by use 5.42.0
 
 class Chalk::Grammar::Chalk::Rule::ExpressionList :isa(Chalk::GrammarRule) {
     method evaluate($context) {

--- a/lib/Chalk/Grammar/Chalk/Rule/Ternary.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Ternary.pm
@@ -3,7 +3,7 @@
 
 use 5.42.0;
 use experimental 'class';
-use Scalar::Util 'blessed';
+# Note: blessed is auto-imported by use 5.42.0
 
 class Chalk::Grammar::Chalk::Rule::Ternary :isa(Chalk::GrammarRule) {
     method evaluate($context) {

--- a/lib/Chalk/Grammar/Chalk/Rule/Variable.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Variable.pm
@@ -5,7 +5,7 @@ use 5.42.0;
 use experimental 'class';
 use Chalk::IR::Node::ArrayGet;
 use Chalk::IR::Node::HashGet;
-use Scalar::Util 'blessed';
+# Note: blessed is auto-imported by use 5.42.0
 
 class Chalk::Grammar::Chalk::Rule::Variable :isa(Chalk::GrammarRule) {
     method evaluate($context) {


### PR DESCRIPTION
## Summary

Removes duplicate `blessed` imports from 3 files that were causing prototype mismatch warnings.

Perl 5.42.0 auto-imports `blessed` from `Scalar::Util` with prototype `($)`. When these files also explicitly imported `blessed`, it caused:
```
Prototype mismatch: sub main::blessed: none vs ($)
```

## Files Changed

- `lib/Chalk/Grammar/Chalk/Rule/ExpressionList.pm`
- `lib/Chalk/Grammar/Chalk/Rule/Ternary.pm`  
- `lib/Chalk/Grammar/Chalk/Rule/Variable.pm`

## Test Plan

- [x] All sea-of-nodes tests pass
- [x] No prototype mismatch warnings
- [ ] Self-hosting test passes (currently running, 118/248 complete with 0 failures)