### PR TITLE
feat(ir): Add clone_with_inputs to Node::Base for uniform cloning

### DIFF
--- a/lib/Chalk/IR/Node/Base.pm
+++ b/lib/Chalk/IR/Node/Base.pm
@@ -131,6 +131,33 @@ class Chalk::IR::Node::Base {
 
         return join("\n", @lines);
     }
+
+    # Clone node with new inputs, preserving polymorphic class type
+    # Used by GVN optimizer to reconstruct nodes while maintaining Phi, Region, etc. types
+    # $node_map is old_id -> new_node mapping for looking up input nodes
+    # $new_attributes allows passing subclass-specific attributes for reconstruction
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $class = blessed($self);
+
+        # Translate old input IDs to new node IDs using node_map
+        my @translated_inputs;
+        for my $input_id (@$new_inputs) {
+            if (defined($input_id) && exists($node_map->{$input_id})) {
+                push @translated_inputs, $node_map->{$input_id}->id;
+            } else {
+                push @translated_inputs, $input_id;
+            }
+        }
+
+        # Build constructor args: inputs is required, merge in new_attributes
+        my %args = (
+            inputs      => \@translated_inputs,
+            source_info => $source_info,
+            %$new_attributes,
+        );
+
+        return $class->new(%args);
+    }
 }
 
 1;

--- a/lib/Chalk/IR/Node/Die.pm
+++ b/lib/Chalk/IR/Node/Die.pm
@@ -82,6 +82,28 @@ class Chalk::IR::Node::Die :isa(Chalk::IR::Node::CFGNode) {
         return;
     }
 
+    # Clone with new inputs from node_map, preserving polymorphic Die type
+    # Used by GVN optimizer to reconstruct nodes
+    # $node_map is old_id -> new_node mapping
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        my $new_control;
+        my $new_message;
+
+        # Input order: control, message
+        if (defined $new_inputs->[0] && exists $node_map->{$new_inputs->[0]}) {
+            $new_control = $node_map->{$new_inputs->[0]};
+        }
+        if (defined $new_inputs->[1] && exists $node_map->{$new_inputs->[1]}) {
+            $new_message = $node_map->{$new_inputs->[1]};
+        }
+
+        return Chalk::IR::Node::Die->new(
+            control     => $new_control,
+            message     => $new_message,
+            source_info => $source_info,
+        );
+    }
+
     # Immutable reconstruction with new control edge
     method with_control($new_control) {
         return Chalk::IR::Node::Die->new(

--- a/lib/Chalk/IR/Node/Start.pm
+++ b/lib/Chalk/IR/Node/Start.pm
@@ -102,6 +102,19 @@ class Chalk::IR::Node::Start :isa(Chalk::IR::Node::CFGNode) {
         return;
     }
 
+    # Clone with new inputs, preserving polymorphic Start type
+    # Start has no inputs (entry point), but method needed for uniform interface
+    # Used by GVN optimizer for polymorphic node reconstruction
+    method clone_with_inputs($new_inputs, $node_map, $new_attributes = {}) {
+        return Chalk::IR::Node::Start->new(
+            function_name => $new_attributes->{function_name} // $function_name,
+            params        => $new_attributes->{params} // $params,
+            label         => $new_attributes->{label} // $label,
+            arg_value     => $new_attributes->{arg_value} // $arg_value,
+            source_info   => $source_info,
+        );
+    }
+
 }
 
 1;

--- a/t/ir-node-clone-with-inputs.t
+++ b/t/ir-node-clone-with-inputs.t
@@ -1,0 +1,197 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests for clone_with_inputs across all IR node types
+# ABOUTME: Issue #477 - Normalize IR node class inheritance hierarchy
+
+use 5.42.0;
+use FindBin qw($RealBin);
+use lib "$RealBin/../lib";
+use Test2::V0;
+use experimental qw(defer);
+defer { done_testing() }
+
+use Chalk::IR::Node;
+use Chalk::IR::Node::Base;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Node::Add;
+use Chalk::IR::Node::Phi;
+use Chalk::IR::Node::Region;
+use Chalk::IR::Node::Start;
+use Chalk::IR::Type::Integer;
+use Chalk::IR::Type::Ctrl;
+
+subtest 'All polymorphic nodes should have clone_with_inputs' => sub {
+    # Test that all polymorphic node classes have clone_with_inputs method
+
+    my @polymorphic_classes = qw(
+        Chalk::IR::Node::Constant
+        Chalk::IR::Node::Add
+        Chalk::IR::Node::Phi
+        Chalk::IR::Node::Region
+        Chalk::IR::Node::Start
+    );
+
+    for my $class (@polymorphic_classes) {
+        ok $class->can('clone_with_inputs'),
+            "$class has clone_with_inputs method";
+    }
+};
+
+subtest 'clone_with_inputs preserves polymorphic type for Phi' => sub {
+    # Create a simple Phi node
+    my $const1 = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => Chalk::IR::Type::Integer->constant(1),
+    );
+    my $const2 = Chalk::IR::Node::Constant->new(
+        value => 2,
+        type  => Chalk::IR::Type::Integer->constant(2),
+    );
+
+    # Create a region control
+    my $ctrl = Chalk::IR::Node::Constant->new(
+        value => 'Ctrl',
+        type  => Chalk::IR::Type::Ctrl->new(),
+    );
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [$ctrl->id],
+    );
+
+    my $phi = Chalk::IR::Node::Phi->new(
+        region_id => $region->id,
+        inputs    => [$region->id, $const1->id, $const2->id],
+    );
+
+    # Build a node_map for cloning
+    my %node_map = (
+        $region->id => $region,
+        $const1->id => $const1,
+        $const2->id => $const2,
+    );
+
+    # Clone the Phi node
+    my $cloned = $phi->clone_with_inputs(
+        [$region->id, $const1->id, $const2->id],
+        \%node_map,
+        { region_id => $region->id },
+    );
+
+    isa_ok $cloned, ['Chalk::IR::Node::Phi'],
+        'Cloned node preserves Phi type';
+    is $cloned->op, 'Phi',
+        'Cloned node has correct op';
+    is $cloned->region_id, $region->id,
+        'Cloned node has correct region_id';
+};
+
+subtest 'clone_with_inputs preserves polymorphic type for Region' => sub {
+    # Create control inputs
+    my $ctrl1 = Chalk::IR::Node::Constant->new(
+        value => 'Ctrl',
+        type  => Chalk::IR::Type::Ctrl->new(),
+    );
+    my $ctrl2 = Chalk::IR::Node::Constant->new(
+        value => 'Ctrl',
+        type  => Chalk::IR::Type::Ctrl->new(),
+    );
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [$ctrl1->id, $ctrl2->id],
+    );
+
+    # Build a node_map for cloning
+    my %node_map = (
+        $ctrl1->id => $ctrl1,
+        $ctrl2->id => $ctrl2,
+    );
+
+    # Clone the Region node
+    my $cloned = $region->clone_with_inputs(
+        [$ctrl1->id, $ctrl2->id],
+        \%node_map,
+        {},
+    );
+
+    isa_ok $cloned, ['Chalk::IR::Node::Region'],
+        'Cloned node preserves Region type';
+    is $cloned->op, 'Region',
+        'Cloned node has correct op';
+};
+
+subtest 'clone_with_inputs works for Constant (leaf node)' => sub {
+    my $const = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => Chalk::IR::Type::Integer->constant(42),
+    );
+
+    my $cloned = $const->clone_with_inputs([], {}, {});
+
+    isa_ok $cloned, ['Chalk::IR::Node::Constant'],
+        'Cloned node preserves Constant type';
+    is $cloned->value, 42,
+        'Cloned node has correct value';
+};
+
+subtest 'clone_with_inputs works for Add (binary op)' => sub {
+    my $left = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => Chalk::IR::Type::Integer->constant(1),
+    );
+    my $right = Chalk::IR::Node::Constant->new(
+        value => 2,
+        type  => Chalk::IR::Type::Integer->constant(2),
+    );
+
+    my $add = Chalk::IR::Node::Add->new(
+        left  => $left,
+        right => $right,
+    );
+
+    my %node_map = (
+        $left->id  => $left,
+        $right->id => $right,
+    );
+
+    my $cloned = $add->clone_with_inputs(
+        [$left->id, $right->id],
+        \%node_map,
+        {},
+    );
+
+    isa_ok $cloned, ['Chalk::IR::Node::Add'],
+        'Cloned node preserves Add type';
+    is $cloned->op, 'Add',
+        'Cloned node has correct op';
+};
+
+subtest 'Node::Base subclasses can be cloned' => sub {
+    # This is the key test - Base didn't have clone_with_inputs
+    # which caused GVN to fall back to generic Node
+
+    my $ctrl = Chalk::IR::Node::Constant->new(
+        value => 'Ctrl',
+        type  => Chalk::IR::Type::Ctrl->new(),
+    );
+
+    my $region = Chalk::IR::Node::Region->new(
+        inputs => [$ctrl->id],
+    );
+
+    # Before fix: Base doesn't have clone_with_inputs
+    # After fix: Base should have clone_with_inputs
+    ok $region->can('clone_with_inputs'),
+        'Region (inherits from Base) has clone_with_inputs';
+
+    my %node_map = ($ctrl->id => $ctrl);
+    my $cloned = $region->clone_with_inputs(
+        [$ctrl->id],
+        \%node_map,
+        {},
+    );
+
+    # Critical: the cloned node should still be a Region, not generic Node
+    isa_ok $cloned, ['Chalk::IR::Node::Region'],
+        'Cloned Region is still a Region, not generic Node';
+    isnt ref($cloned), 'Chalk::IR::Node',
+        'Cloned Region is not a generic Chalk::IR::Node';
+};


### PR DESCRIPTION
## Summary

The GVN optimizer needs to clone IR nodes while preserving their polymorphic types. Previously, `Node::Base` subclasses (Phi, Region, and 29 other nodes) lacked `clone_with_inputs`, causing GVN to fall back to generic `Chalk::IR::Node` which loses polymorphic behavior.

This PR normalizes the IR node hierarchy by ensuring all polymorphic nodes can be cloned while maintaining their specific class types.

## Changes

- Add `clone_with_inputs` method to `Chalk::IR::Node::Base` - provides default implementation for all 29 subclasses
- Add `clone_with_inputs` to `Chalk::IR::Node::Start` (inherits from CFGNode, not Base)
- Add `clone_with_inputs` to `Chalk::IR::Node::Die` (inherits from CFGNode, not Base)
- Add comprehensive test suite for `clone_with_inputs` across node types

## Test plan

- [x] New test `t/ir-node-clone-with-inputs.t` passes
- [x] GVN input reference test passes
- [x] Sea of Nodes GVN test passes
- [ ] Full CI test suite (let CI handle the 3-hour run)

## Related Issues

Fixes #477

## Statistics

- 4 files changed
- ~260 lines added (mostly test code)