### PR TITLE
feat(types): Add type flow audit with Grammar->IR->C conversion

### DIFF
--- a/lib/Chalk/IR/Type/Array.pm
+++ b/lib/Chalk/IR/Type/Array.pm
@@ -1,0 +1,51 @@
+# ABOUTME: Array represents array values in IR type lattice
+# ABOUTME: Maps to AV* in XS code generation
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+
+class Chalk::IR::Type::Array :isa(Chalk::IR::Type) {
+    field $element_type :param :reader = undef;
+    field $is_bottom :param :reader = 0;
+
+    method is_constant() { 0 }  # Arrays are not constants
+    method is_top()      { (!defined($element_type) && !$is_bottom) ? 1 : 0 }
+
+    sub TOP ($class) {
+        state $singleton = $class->new();
+        return $singleton;
+    }
+
+    sub BOTTOM ($class) {
+        state $singleton = $class->new(is_bottom => 1);
+        return $singleton;
+    }
+
+    sub of ($class, $elem_type) {
+        return $class->new(element_type => $elem_type);
+    }
+
+    method meet($other) {
+        return $other if $other isa Chalk::IR::Type::Bottom;
+        return $self if $other isa Chalk::IR::Type::Top;
+
+        return blessed($self)->BOTTOM() if $self->is_bottom;
+        return blessed($self)->BOTTOM() if $other isa blessed($self) && $other->is_bottom;
+
+        return $other if $self->is_top && $other isa blessed($self);
+        return $self if $other isa blessed($self) && $other->is_top;
+
+        # Same array type with element types - meet element types
+        if ($other isa blessed($self) && defined($element_type) && defined($other->element_type)) {
+            my $meet_elem = $element_type->meet($other->element_type);
+            return blessed($self)->of($meet_elem);
+        }
+
+        return Chalk::IR::Type::Top->top();
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/Code.pm
+++ b/lib/Chalk/IR/Type/Code.pm
@@ -1,0 +1,46 @@
+# ABOUTME: Code represents subroutine/code reference values in IR type lattice
+# ABOUTME: Maps to CV* in XS code generation
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+
+class Chalk::IR::Type::Code :isa(Chalk::IR::Type) {
+    field $param_types :param :reader = undef;
+    field $return_type :param :reader = undef;
+    field $is_bottom :param :reader = 0;
+
+    method is_constant() { 0 }  # Code refs are not constants
+    method is_top()      { (!defined($param_types) && !defined($return_type) && !$is_bottom) ? 1 : 0 }
+
+    sub TOP ($class) {
+        state $singleton = $class->new();
+        return $singleton;
+    }
+
+    sub BOTTOM ($class) {
+        state $singleton = $class->new(is_bottom => 1);
+        return $singleton;
+    }
+
+    sub of ($class, $params, $ret) {
+        return $class->new(param_types => $params, return_type => $ret);
+    }
+
+    method meet($other) {
+        return $other if $other isa Chalk::IR::Type::Bottom;
+        return $self if $other isa Chalk::IR::Type::Top;
+
+        return blessed($self)->BOTTOM() if $self->is_bottom;
+        return blessed($self)->BOTTOM() if $other isa blessed($self) && $other->is_bottom;
+
+        return $other if $self->is_top && $other isa blessed($self);
+        return $self if $other isa blessed($self) && $other->is_top;
+
+        return Chalk::IR::Type::Top->top();
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/Convert.pm
+++ b/lib/Chalk/IR/Type/Convert.pm
@@ -1,0 +1,105 @@
+# ABOUTME: Type conversion utilities for Grammar→IR type mapping
+# ABOUTME: Ensures clean type boundaries between parsing and optimization phases
+
+use 5.42.0;
+use experimental qw(class);
+
+# Load all IR types
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+use Chalk::IR::Type::Integer;
+use Chalk::IR::Type::Float;
+use Chalk::IR::Type::Bool;
+use Chalk::IR::Type::String;
+use Chalk::IR::Type::Array;
+use Chalk::IR::Type::Hash;
+use Chalk::IR::Type::Code;
+use Chalk::IR::Type::Ref;
+use Chalk::IR::Type::Object;
+use Chalk::IR::Type::Undef;
+use Chalk::IR::Type::Scalar;
+
+class Chalk::IR::Type::Convert {
+    # Grammar type class -> IR type class mapping
+    my %GRAMMAR_TO_IR = (
+        # Numeric
+        'Chalk::Grammar::Chalk::Type::Int'     => 'Chalk::IR::Type::Integer',
+        'Chalk::Grammar::Chalk::Type::Num'     => 'Chalk::IR::Type::Float',
+        'Chalk::Grammar::Chalk::Type::Boolean' => 'Chalk::IR::Type::Bool',
+
+        # Strings
+        'Chalk::Grammar::Chalk::Type::Str'     => 'Chalk::IR::Type::String',
+
+        # Collections
+        'Chalk::Grammar::Chalk::Type::Array'   => 'Chalk::IR::Type::Array',
+        'Chalk::Grammar::Chalk::Type::Hash'    => 'Chalk::IR::Type::Hash',
+
+        # References
+        'Chalk::Grammar::Chalk::Type::Ref'       => 'Chalk::IR::Type::Ref',
+        'Chalk::Grammar::Chalk::Type::ArrayRef'  => 'Chalk::IR::Type::Ref',
+        'Chalk::Grammar::Chalk::Type::HashRef'   => 'Chalk::IR::Type::Ref',
+        'Chalk::Grammar::Chalk::Type::CodeRef'   => 'Chalk::IR::Type::Ref',
+        'Chalk::Grammar::Chalk::Type::ScalarRef' => 'Chalk::IR::Type::Ref',
+
+        # Code
+        'Chalk::Grammar::Chalk::Type::Code'    => 'Chalk::IR::Type::Code',
+
+        # Objects
+        'Chalk::Grammar::Chalk::Type::Object'  => 'Chalk::IR::Type::Object',
+        'Chalk::Grammar::Chalk::Type::Class'   => 'Chalk::IR::Type::Object',
+
+        # Special
+        'Chalk::Grammar::Chalk::Type::Undef'   => 'Chalk::IR::Type::Undef',
+        'Chalk::Grammar::Chalk::Type::Scalar'  => 'Chalk::IR::Type::Scalar',
+        'Chalk::Grammar::Chalk::Type::Any'     => 'Chalk::IR::Type::Top',
+        'Chalk::Grammar::Chalk::Type::None'    => 'Chalk::IR::Type::Bottom',
+    );
+
+    # Convert a Grammar type to the corresponding IR type
+    # Returns IR::Type::Top if the grammar type is unknown
+    sub grammar_to_ir ($class, $grammar_type) {
+        return Chalk::IR::Type::Top->TOP() unless defined $grammar_type;
+
+        # If it's already an IR type, return it unchanged
+        return $grammar_type if $grammar_type isa Chalk::IR::Type;
+
+        my $grammar_class = blessed($grammar_type) // ref($grammar_type) // '';
+        my $ir_class = $GRAMMAR_TO_IR{$grammar_class};
+
+        unless ($ir_class) {
+            # Unknown grammar type - return Top
+            return Chalk::IR::Type::Top->top();
+        }
+
+        # Create the IR type instance
+        # Most IR types use TOP() factory method, but Top uses top()
+        if ($ir_class eq 'Chalk::IR::Type::Top') {
+            return Chalk::IR::Type::Top->top();
+        } elsif ($ir_class eq 'Chalk::IR::Type::Bottom') {
+            return Chalk::IR::Type::Bottom->BOTTOM();
+        } else {
+            return $ir_class->TOP();
+        }
+    }
+
+    # Check if a type is a Grammar type (should be converted)
+    sub is_grammar_type ($class, $type) {
+        return 0 unless defined $type && blessed($type);
+        return $type isa Chalk::Grammar::Chalk::Type;
+    }
+
+    # Check if a type is an IR type (ready for optimization/codegen)
+    sub is_ir_type ($class, $type) {
+        return 0 unless defined $type && blessed($type);
+        return $type isa Chalk::IR::Type;
+    }
+
+    # Ensure a type is an IR type - converts if necessary
+    sub ensure_ir_type ($class, $type) {
+        return Chalk::IR::Type::Top->top() unless defined $type;
+        return $type if $class->is_ir_type($type);
+        return $class->grammar_to_ir($type);
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/Hash.pm
+++ b/lib/Chalk/IR/Type/Hash.pm
@@ -1,0 +1,51 @@
+# ABOUTME: Hash represents hash values in IR type lattice
+# ABOUTME: Maps to HV* in XS code generation
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+
+class Chalk::IR::Type::Hash :isa(Chalk::IR::Type) {
+    field $value_type :param :reader = undef;
+    field $is_bottom :param :reader = 0;
+
+    method is_constant() { 0 }  # Hashes are not constants
+    method is_top()      { (!defined($value_type) && !$is_bottom) ? 1 : 0 }
+
+    sub TOP ($class) {
+        state $singleton = $class->new();
+        return $singleton;
+    }
+
+    sub BOTTOM ($class) {
+        state $singleton = $class->new(is_bottom => 1);
+        return $singleton;
+    }
+
+    sub of ($class, $val_type) {
+        return $class->new(value_type => $val_type);
+    }
+
+    method meet($other) {
+        return $other if $other isa Chalk::IR::Type::Bottom;
+        return $self if $other isa Chalk::IR::Type::Top;
+
+        return blessed($self)->BOTTOM() if $self->is_bottom;
+        return blessed($self)->BOTTOM() if $other isa blessed($self) && $other->is_bottom;
+
+        return $other if $self->is_top && $other isa blessed($self);
+        return $self if $other isa blessed($self) && $other->is_top;
+
+        # Same hash type with value types - meet value types
+        if ($other isa blessed($self) && defined($value_type) && defined($other->value_type)) {
+            my $meet_val = $value_type->meet($other->value_type);
+            return blessed($self)->of($meet_val);
+        }
+
+        return Chalk::IR::Type::Top->top();
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/Object.pm
+++ b/lib/Chalk/IR/Type/Object.pm
@@ -1,0 +1,51 @@
+# ABOUTME: Object represents blessed reference values in IR type lattice
+# ABOUTME: Parameterized by class name - maps to SV* in XS code generation
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+
+class Chalk::IR::Type::Object :isa(Chalk::IR::Type) {
+    field $class_name :param :reader = undef;
+    field $is_bottom :param :reader = 0;
+
+    method is_constant() { 0 }  # Objects are not constants
+    method is_top()      { (!defined($class_name) && !$is_bottom) ? 1 : 0 }
+
+    sub TOP ($class) {
+        state $singleton = $class->new();
+        return $singleton;
+    }
+
+    sub BOTTOM ($class) {
+        state $singleton = $class->new(is_bottom => 1);
+        return $singleton;
+    }
+
+    sub of ($class, $cls_name) {
+        return $class->new(class_name => $cls_name);
+    }
+
+    method meet($other) {
+        return $other if $other isa Chalk::IR::Type::Bottom;
+        return $self if $other isa Chalk::IR::Type::Top;
+
+        return blessed($self)->BOTTOM() if $self->is_bottom;
+        return blessed($self)->BOTTOM() if $other isa blessed($self) && $other->is_bottom;
+
+        return $other if $self->is_top && $other isa blessed($self);
+        return $self if $other isa blessed($self) && $other->is_top;
+
+        # Same class name = same type, different = Object TOP
+        if ($other isa blessed($self) && defined($class_name) && defined($other->class_name)) {
+            return $self if $class_name eq $other->class_name;
+            return blessed($self)->TOP();
+        }
+
+        return Chalk::IR::Type::Top->top();
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/Ref.pm
+++ b/lib/Chalk/IR/Type/Ref.pm
@@ -1,0 +1,51 @@
+# ABOUTME: Ref represents reference values in IR type lattice
+# ABOUTME: Parameterized by referent type - maps to SV* in XS code generation
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+
+class Chalk::IR::Type::Ref :isa(Chalk::IR::Type) {
+    field $referent_type :param :reader = undef;
+    field $is_bottom :param :reader = 0;
+
+    method is_constant() { 0 }  # Refs are not constants
+    method is_top()      { (!defined($referent_type) && !$is_bottom) ? 1 : 0 }
+
+    sub TOP ($class) {
+        state $singleton = $class->new();
+        return $singleton;
+    }
+
+    sub BOTTOM ($class) {
+        state $singleton = $class->new(is_bottom => 1);
+        return $singleton;
+    }
+
+    sub of ($class, $ref_type) {
+        return $class->new(referent_type => $ref_type);
+    }
+
+    method meet($other) {
+        return $other if $other isa Chalk::IR::Type::Bottom;
+        return $self if $other isa Chalk::IR::Type::Top;
+
+        return blessed($self)->BOTTOM() if $self->is_bottom;
+        return blessed($self)->BOTTOM() if $other isa blessed($self) && $other->is_bottom;
+
+        return $other if $self->is_top && $other isa blessed($self);
+        return $self if $other isa blessed($self) && $other->is_top;
+
+        # Same ref type with referent types - meet referent types
+        if ($other isa blessed($self) && defined($referent_type) && defined($other->referent_type)) {
+            my $meet_ref = $referent_type->meet($other->referent_type);
+            return blessed($self)->of($meet_ref);
+        }
+
+        return Chalk::IR::Type::Top->top();
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/Scalar.pm
+++ b/lib/Chalk/IR/Type/Scalar.pm
@@ -1,0 +1,46 @@
+# ABOUTME: Scalar represents any scalar value in IR type lattice
+# ABOUTME: Union of String|Integer|Float|Bool|Undef|Ref - maps to SV* in XS
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+
+class Chalk::IR::Type::Scalar :isa(Chalk::IR::Type) {
+    field $is_bottom :param :reader = 0;
+
+    method is_constant() { 0 }  # Scalar is a type category, not a constant
+    method is_top()      { !$is_bottom ? 1 : 0 }
+
+    sub TOP ($class) {
+        state $singleton = $class->new();
+        return $singleton;
+    }
+
+    sub BOTTOM ($class) {
+        state $singleton = $class->new(is_bottom => 1);
+        return $singleton;
+    }
+
+    method meet($other) {
+        return $other if $other isa Chalk::IR::Type::Bottom;
+        return $self if $other isa Chalk::IR::Type::Top;
+
+        return blessed($self)->BOTTOM() if $self->is_bottom;
+
+        # Scalar meets Scalar = Scalar
+        return $self if $other isa blessed($self);
+
+        # Scalar meets specific scalar type = that type (narrowing)
+        # Integer, Float, String, Bool, Undef, Ref are all scalars
+        for my $scalar_type (qw(Integer Float String Bool Undef Ref)) {
+            my $type_class = "Chalk::IR::Type::$scalar_type";
+            return $other if $other isa $type_class;
+        }
+
+        return Chalk::IR::Type::Top->top();
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/String.pm
+++ b/lib/Chalk/IR/Type/String.pm
@@ -1,0 +1,50 @@
+# ABOUTME: String represents string values in IR type lattice
+# ABOUTME: Maps to SV* in XS code generation
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+
+class Chalk::IR::Type::String :isa(Chalk::IR::Type) {
+    field $value :param :reader = undef;
+    field $is_bottom :param :reader = 0;
+
+    method is_constant() { (defined($value) && !$is_bottom) ? 1 : 0 }
+    method is_top()      { (!defined($value) && !$is_bottom) ? 1 : 0 }
+
+    sub TOP ($class) {
+        state $singleton = $class->new();
+        return $singleton;
+    }
+
+    sub BOTTOM ($class) {
+        state $singleton = $class->new(is_bottom => 1);
+        return $singleton;
+    }
+
+    sub constant ($class, $val) {
+        return $class->new(value => $val);
+    }
+
+    method meet($other) {
+        return $other if $other isa Chalk::IR::Type::Bottom;
+        return $self if $other isa Chalk::IR::Type::Top;
+
+        return blessed($self)->BOTTOM() if $self->is_bottom;
+        return blessed($self)->BOTTOM() if $other isa blessed($self) && $other->is_bottom;
+
+        return $other if $self->is_top && $other isa blessed($self);
+        return $self if $other isa blessed($self) && $other->is_top;
+
+        if ($self->is_constant && $other isa blessed($self) && $other->is_constant) {
+            return $self if $value eq $other->value;
+            return blessed($self)->TOP();
+        }
+
+        return Chalk::IR::Type::Top->top();
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Type/Undef.pm
+++ b/lib/Chalk/IR/Type/Undef.pm
@@ -1,0 +1,33 @@
+# ABOUTME: Undef represents the undefined value in IR type lattice
+# ABOUTME: Maps to SV* (&PL_sv_undef) in XS code generation
+
+use 5.42.0;
+use experimental qw(class);
+use Chalk::IR::Type;
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+
+class Chalk::IR::Type::Undef :isa(Chalk::IR::Type) {
+    method is_constant() { 1 }  # Undef is a constant (the undefined value)
+    method is_top()      { 0 }
+
+    method value() { return undef; }
+
+    sub TOP ($class) {
+        state $singleton = $class->new();
+        return $singleton;
+    }
+
+    method meet($other) {
+        return $other if $other isa Chalk::IR::Type::Bottom;
+        return $self if $other isa Chalk::IR::Type::Top;
+
+        # Undef meets Undef = Undef
+        return $self if $other isa blessed($self);
+
+        # Undef meets other type = global Top (different types)
+        return Chalk::IR::Type::Top->top();
+    }
+}
+
+1;

--- a/lib/Chalk/Target/XS.pm
+++ b/lib/Chalk/Target/XS.pm
@@ -6,6 +6,7 @@ use utf8;
 
 class Chalk::Target::XS {
     use Chalk::IR::Context;
+    use Chalk::IR::Type::Convert;
     use Chalk::Target::XS::AST::Module;
     use Chalk::Target::XS::AST::CompositeNode;
 
@@ -49,29 +50,42 @@ class Chalk::Target::XS {
         return $var;
     }
 
+    # IR type → C type mapping for Perl API
+    my %IR_TO_C = (
+        # Numeric
+        'Chalk::IR::Type::Integer' => 'IV',
+        'Chalk::IR::Type::Float'   => 'NV',
+        'Chalk::IR::Type::Bool'    => 'bool',
+
+        # Perl values
+        'Chalk::IR::Type::String'  => 'SV*',
+        'Chalk::IR::Type::Array'   => 'AV*',
+        'Chalk::IR::Type::Hash'    => 'HV*',
+        'Chalk::IR::Type::Code'    => 'CV*',
+        'Chalk::IR::Type::Ref'     => 'SV*',
+        'Chalk::IR::Type::Object'  => 'SV*',
+        'Chalk::IR::Type::Scalar'  => 'SV*',
+
+        # Special
+        'Chalk::IR::Type::Undef'   => 'SV*',
+        'Chalk::IR::Type::Top'     => 'SV*',
+        'Chalk::IR::Type::Bottom'  => 'void',
+    );
+
     # Map IR types to C types for Perl API
     # Prefer compute() (peephole type lattice) over compute_type() (semantic types)
     # because peephole inference propagates types through operations correctly
     method get_c_type($node) {
-        my $ir_type = $node->can('compute') ? $node->compute()
-                    : ($node->can('compute_type') ? $node->compute_type()
-                    : ($node->can('type') ? $node->type : undef));
-        return 'SV*' unless defined $ir_type;  # Fallback for nodes without type info
-        my $type_class = ref($ir_type);
+        my $type = $node->can('compute') ? $node->compute()
+                 : ($node->can('compute_type') ? $node->compute_type()
+                 : ($node->can('type') ? $node->type : undef));
+        return 'SV*' unless defined $type;  # Fallback for nodes without type info
 
-        # Handle IR types
-        return 'IV' if $type_class eq 'Chalk::IR::Type::Integer';
-        return 'NV' if $type_class eq 'Chalk::IR::Type::Float';
+        # Ensure we're working with an IR type (convert Grammar types if needed)
+        my $ir_type = Chalk::IR::Type::Convert->ensure_ir_type($type);
+        my $type_class = blessed($ir_type);
 
-        # Handle Grammar types
-        return 'IV' if $type_class eq 'Chalk::Grammar::Chalk::Type::Int';
-        return 'NV' if $type_class eq 'Chalk::Grammar::Chalk::Type::Num';
-        return 'SV*' if $type_class eq 'Chalk::Grammar::Chalk::Type::Str';
-        return 'AV*' if $type_class eq 'Chalk::Grammar::Chalk::Type::Array';
-        return 'AV*' if $type_class eq 'Chalk::Grammar::Chalk::Type::ArrayRef';
-        return 'HV*' if $type_class eq 'Chalk::Grammar::Chalk::Type::Hash';
-
-        return 'SV*';  # Conservative fallback
+        return $IR_TO_C{$type_class} // 'SV*';
     }
 
     # Compute return type from function body by finding Return node

--- a/t/ir-type-convert.t
+++ b/t/ir-type-convert.t
@@ -1,0 +1,167 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests for Grammar→IR type conversion
+# ABOUTME: Issue #478 - Ensure Grammar types don't leak into IR/codegen phases
+
+use 5.42.0;
+use FindBin qw($RealBin);
+use lib "$RealBin/../lib";
+use Test2::V0;
+use experimental qw(defer);
+defer { done_testing() }
+
+use Chalk::IR::Type::Convert;
+use Chalk::IR::Type::Top;
+use Chalk::IR::Type::Bottom;
+use Chalk::IR::Type::Integer;
+use Chalk::IR::Type::Float;
+use Chalk::IR::Type::Bool;
+use Chalk::IR::Type::String;
+use Chalk::IR::Type::Array;
+use Chalk::IR::Type::Hash;
+use Chalk::IR::Type::Code;
+use Chalk::IR::Type::Ref;
+use Chalk::IR::Type::Object;
+use Chalk::IR::Type::Undef;
+use Chalk::IR::Type::Scalar;
+
+use Chalk::Grammar::Chalk::Type::Int;
+use Chalk::Grammar::Chalk::Type::Num;
+use Chalk::Grammar::Chalk::Type::Str;
+use Chalk::Grammar::Chalk::Type::Boolean;
+use Chalk::Grammar::Chalk::Type::Array;
+use Chalk::Grammar::Chalk::Type::Hash;
+use Chalk::Grammar::Chalk::Type::Any;
+use Chalk::Grammar::Chalk::Type::None;
+
+subtest 'grammar_to_ir converts numeric types' => sub {
+    my $int_grammar = Chalk::Grammar::Chalk::Type::Int->new();
+    my $int_ir = Chalk::IR::Type::Convert->grammar_to_ir($int_grammar);
+    isa_ok $int_ir, ['Chalk::IR::Type::Integer'], 'Int → Integer';
+
+    my $num_grammar = Chalk::Grammar::Chalk::Type::Num->new();
+    my $num_ir = Chalk::IR::Type::Convert->grammar_to_ir($num_grammar);
+    isa_ok $num_ir, ['Chalk::IR::Type::Float'], 'Num → Float';
+
+    my $bool_grammar = Chalk::Grammar::Chalk::Type::Boolean->new();
+    my $bool_ir = Chalk::IR::Type::Convert->grammar_to_ir($bool_grammar);
+    isa_ok $bool_ir, ['Chalk::IR::Type::Bool'], 'Boolean → Bool';
+};
+
+subtest 'grammar_to_ir converts string type' => sub {
+    my $str_grammar = Chalk::Grammar::Chalk::Type::Str->new();
+    my $str_ir = Chalk::IR::Type::Convert->grammar_to_ir($str_grammar);
+    isa_ok $str_ir, ['Chalk::IR::Type::String'], 'Str → String';
+};
+
+subtest 'grammar_to_ir converts collection types' => sub {
+    # Grammar Array requires element_type param
+    my $int_grammar = Chalk::Grammar::Chalk::Type::Int->new();
+    my $array_grammar = Chalk::Grammar::Chalk::Type::Array->new(element_type => $int_grammar);
+    my $array_ir = Chalk::IR::Type::Convert->grammar_to_ir($array_grammar);
+    isa_ok $array_ir, ['Chalk::IR::Type::Array'], 'Array -> Array';
+
+    # Grammar Hash requires value_type param
+    my $hash_grammar = Chalk::Grammar::Chalk::Type::Hash->new(value_type => $int_grammar);
+    my $hash_ir = Chalk::IR::Type::Convert->grammar_to_ir($hash_grammar);
+    isa_ok $hash_ir, ['Chalk::IR::Type::Hash'], 'Hash -> Hash';
+};
+
+subtest 'grammar_to_ir converts special types' => sub {
+    my $any_grammar = Chalk::Grammar::Chalk::Type::Any->new();
+    my $any_ir = Chalk::IR::Type::Convert->grammar_to_ir($any_grammar);
+    isa_ok $any_ir, ['Chalk::IR::Type::Top'], 'Any → Top';
+
+    my $none_grammar = Chalk::Grammar::Chalk::Type::None->new();
+    my $none_ir = Chalk::IR::Type::Convert->grammar_to_ir($none_grammar);
+    isa_ok $none_ir, ['Chalk::IR::Type::Bottom'], 'None → Bottom';
+};
+
+subtest 'is_grammar_type correctly identifies Grammar types' => sub {
+    my $grammar_type = Chalk::Grammar::Chalk::Type::Int->new();
+    my $ir_type = Chalk::IR::Type::Integer->TOP();
+
+    ok Chalk::IR::Type::Convert->is_grammar_type($grammar_type),
+        'Grammar type is identified';
+    ok !Chalk::IR::Type::Convert->is_grammar_type($ir_type),
+        'IR type is not a Grammar type';
+    ok !Chalk::IR::Type::Convert->is_grammar_type(undef),
+        'undef is not a Grammar type';
+};
+
+subtest 'is_ir_type correctly identifies IR types' => sub {
+    my $grammar_type = Chalk::Grammar::Chalk::Type::Int->new();
+    my $ir_type = Chalk::IR::Type::Integer->TOP();
+
+    ok Chalk::IR::Type::Convert->is_ir_type($ir_type),
+        'IR type is identified';
+    ok !Chalk::IR::Type::Convert->is_ir_type($grammar_type),
+        'Grammar type is not an IR type';
+    ok !Chalk::IR::Type::Convert->is_ir_type(undef),
+        'undef is not an IR type';
+};
+
+subtest 'ensure_ir_type passes through IR types unchanged' => sub {
+    my $ir_int = Chalk::IR::Type::Integer->constant(42);
+    my $result = Chalk::IR::Type::Convert->ensure_ir_type($ir_int);
+
+    is refaddr($result), refaddr($ir_int),
+        'IR type passes through unchanged';
+};
+
+subtest 'ensure_ir_type converts Grammar types' => sub {
+    my $grammar_int = Chalk::Grammar::Chalk::Type::Int->new();
+    my $result = Chalk::IR::Type::Convert->ensure_ir_type($grammar_int);
+
+    isa_ok $result, ['Chalk::IR::Type::Integer'],
+        'Grammar type is converted to IR type';
+    ok !Chalk::IR::Type::Convert->is_grammar_type($result),
+        'Result is not a Grammar type';
+};
+
+subtest 'ensure_ir_type handles undef' => sub {
+    my $result = Chalk::IR::Type::Convert->ensure_ir_type(undef);
+
+    isa_ok $result, ['Chalk::IR::Type::Top'],
+        'undef converts to Top';
+};
+
+subtest 'new IR types exist and work' => sub {
+    # Test String
+    my $str = Chalk::IR::Type::String->TOP();
+    ok $str->is_top, 'String TOP is top';
+
+    my $str_const = Chalk::IR::Type::String->constant("hello");
+    ok $str_const->is_constant, 'String constant is constant';
+    is $str_const->value, "hello", 'String constant has correct value';
+
+    # Test Array
+    my $arr = Chalk::IR::Type::Array->TOP();
+    ok $arr->is_top, 'Array TOP is top';
+
+    # Test Hash
+    my $hash = Chalk::IR::Type::Hash->TOP();
+    ok $hash->is_top, 'Hash TOP is top';
+
+    # Test Code
+    my $code = Chalk::IR::Type::Code->TOP();
+    ok $code->is_top, 'Code TOP is top';
+
+    # Test Ref
+    my $ref = Chalk::IR::Type::Ref->TOP();
+    ok $ref->is_top, 'Ref TOP is top';
+
+    # Test Object
+    my $obj = Chalk::IR::Type::Object->TOP();
+    ok $obj->is_top, 'Object TOP is top';
+
+    my $point = Chalk::IR::Type::Object->of('Point');
+    is $point->class_name, 'Point', 'Object::of sets class name';
+
+    # Test Undef
+    my $undef = Chalk::IR::Type::Undef->TOP();
+    ok $undef->is_constant, 'Undef is constant (the undef value)';
+
+    # Test Scalar
+    my $scalar = Chalk::IR::Type::Scalar->TOP();
+    ok $scalar->is_top, 'Scalar TOP is top';
+};


### PR DESCRIPTION
## Summary

Establishes clean type boundaries in the compilation pipeline:

```
Grammar Types  →  IR Types  →  C Types
     ↓               ↓              ↓
  %GRAMMAR_TO_IR   (core)      %IR_TO_C
```

Each layer now owns its outbound conversion, preventing Grammar types from leaking into IR/codegen phases.

## Changes

### New IR Types (8 total)
- `Chalk::IR::Type::String` - String values (SV*)
- `Chalk::IR::Type::Array` - Array values (AV*)
- `Chalk::IR::Type::Hash` - Hash values (HV*)
- `Chalk::IR::Type::Code` - Subroutine values (CV*)
- `Chalk::IR::Type::Ref` - Reference values (SV*)
- `Chalk::IR::Type::Object` - Blessed references (SV*)
- `Chalk::IR::Type::Undef` - Undefined value (SV*)
- `Chalk::IR::Type::Scalar` - Any scalar value (SV*)

### Type Conversion Module
`Chalk::IR::Type::Convert` provides:
- `grammar_to_ir()` - Converts Grammar types to IR types
- `ensure_ir_type()` - Ensures a type is IR (converts if needed)
- `is_grammar_type()` / `is_ir_type()` - Type checking utilities

### Updated XS Target
- `get_c_type()` now uses `%IR_TO_C` mapping exclusively
- Grammar types converted via `ensure_ir_type()` at the boundary
- No more Grammar type handling in codegen layer

## Test Plan

- [x] New test `t/ir-type-convert.t` passes (10 tests)
- [x] XS arithmetic tests pass
- [x] XS constant return tests pass
- [ ] Full CI test suite (let CI handle)

## Related Issues

Fixes #478
Unblocks #476 (Typed literals)

## Statistics

- 11 files changed
- ~700 lines added
- 19 lines removed (Grammar type handling in XS.pm)