### PR TITLE
feat(types): Require c_type parameter for typed literal handling

### DIFF
--- a/lib/Chalk/Target/XS/AST/Literal.pm
+++ b/lib/Chalk/Target/XS/AST/Literal.pm
@@ -5,23 +5,16 @@ use experimental qw(class);
 
 class Chalk::Target::XS::AST::Literal :isa(Chalk::Target::XS::AST::Node) {
     field $value :param :reader;
-    field $c_type :param = undef;  # C type from IR (IV, NV, SV*, etc.)
+    field $c_type :param :reader;  # C type from IR (IV, NV, SV*, etc.) - required
 
     method emit() {
         # Handle undef as empty string
         return '""' unless defined $value;
 
-        # Use c_type to determine formatting when available
-        # Numeric types: IV (integer), NV (floating point)
-        # String types: SV*, or any non-numeric type
-        my $is_numeric = 0;
-        if (defined $c_type) {
-            $is_numeric = ($c_type eq 'IV' || $c_type eq 'NV');
-        } else {
-            # Fallback: check if value looks numeric (for backward compatibility)
-            # This handles cases where Literal is created without IR type info
-            $is_numeric = ($value =~ /\A-?(?:\d+\.?\d*|\d*\.?\d+)\z/);
-        }
+        # Determine formatting based on c_type from IR type system
+        # Numeric types: IV (integer), NV (floating point), bool
+        # String/SV types: SV*, AV*, HV*, CV*, etc.
+        my $is_numeric = ($c_type eq 'IV' || $c_type eq 'NV' || $c_type eq 'bool');
 
         if ($is_numeric) {
             return "$value";

--- a/t/target/xs-ast-nodes.t
+++ b/t/target/xs-ast-nodes.t
@@ -29,47 +29,55 @@ BEGIN {
 {
     use_ok('Chalk::Target::XS::AST::Literal') or BAIL_OUT("Cannot load Literal");
 
-    # Integer literal
-    my $int_lit = Chalk::Target::XS::AST::Literal->new(value => 42);
+    # Integer literal (c_type from IR::Type::Integer -> IV)
+    my $int_lit = Chalk::Target::XS::AST::Literal->new(value => 42, c_type => 'IV');
     is($int_lit->emit(), '42', 'Integer literal emits correctly');
+    is($int_lit->c_type(), 'IV', 'Integer literal has correct c_type');
 
-    # String literal (should emit with quotes)
-    my $str_lit = Chalk::Target::XS::AST::Literal->new(value => 'hello');
+    # String literal (c_type from IR::Type::String -> SV*)
+    my $str_lit = Chalk::Target::XS::AST::Literal->new(value => 'hello', c_type => 'SV*');
     is($str_lit->emit(), '"hello"', 'String literal emits with quotes');
+    is($str_lit->c_type(), 'SV*', 'String literal has correct c_type');
 
-    # Floating point literal
-    my $float_lit = Chalk::Target::XS::AST::Literal->new(value => 3.14);
+    # Floating point literal (c_type from IR::Type::Float -> NV)
+    my $float_lit = Chalk::Target::XS::AST::Literal->new(value => 3.14, c_type => 'NV');
     is($float_lit->emit(), '3.14', 'Float literal emits correctly');
+    is($float_lit->c_type(), 'NV', 'Float literal has correct c_type');
+
+    # Boolean literal (c_type from IR::Type::Bool -> bool)
+    my $bool_lit = Chalk::Target::XS::AST::Literal->new(value => 1, c_type => 'bool');
+    is($bool_lit->emit(), '1', 'Boolean literal emits correctly');
+    is($bool_lit->c_type(), 'bool', 'Boolean literal has correct c_type');
 
     # Edge case: String literal with quotes (verify escaping works)
-    my $quoted_str = Chalk::Target::XS::AST::Literal->new(value => 'say "hello"');
+    my $quoted_str = Chalk::Target::XS::AST::Literal->new(value => 'say "hello"', c_type => 'SV*');
     is($quoted_str->emit(), '"say \"hello\""', 'String literal with quotes escapes correctly');
 
     # Edge case: String with backslashes
-    my $backslash_str = Chalk::Target::XS::AST::Literal->new(value => 'path\\to\\file');
+    my $backslash_str = Chalk::Target::XS::AST::Literal->new(value => 'path\\to\\file', c_type => 'SV*');
     is($backslash_str->emit(), '"path\\\\to\\\\file"', 'String literal with backslashes escapes correctly');
 
     # Edge case: String with newlines
-    my $newline_str = Chalk::Target::XS::AST::Literal->new(value => "line1\nline2");
+    my $newline_str = Chalk::Target::XS::AST::Literal->new(value => "line1\nline2", c_type => 'SV*');
     is($newline_str->emit(), '"line1\\nline2"', 'String literal with newlines escapes correctly');
 
     # Edge case: String with tabs
-    my $tab_str = Chalk::Target::XS::AST::Literal->new(value => "col1\tcol2");
+    my $tab_str = Chalk::Target::XS::AST::Literal->new(value => "col1\tcol2", c_type => 'SV*');
     is($tab_str->emit(), '"col1\\tcol2"', 'String literal with tabs escapes correctly');
 
     # Edge case: String with multiple special characters
-    my $complex_str = Chalk::Target::XS::AST::Literal->new(value => "say \"hello\"\npath\\here");
+    my $complex_str = Chalk::Target::XS::AST::Literal->new(value => "say \"hello\"\npath\\here", c_type => 'SV*');
     is($complex_str->emit(), '"say \\"hello\\"\\npath\\\\here"', 'String with mixed special chars escapes correctly');
 
     # Edge case: Empty string literal
-    my $empty_str = Chalk::Target::XS::AST::Literal->new(value => '');
+    my $empty_str = Chalk::Target::XS::AST::Literal->new(value => '', c_type => 'SV*');
     is($empty_str->emit(), '""', 'Empty string literal emits correctly');
 
     # Edge case: Negative numbers
-    my $neg_int = Chalk::Target::XS::AST::Literal->new(value => -42);
+    my $neg_int = Chalk::Target::XS::AST::Literal->new(value => -42, c_type => 'IV');
     is($neg_int->emit(), '-42', 'Negative integer emits correctly');
 
-    my $neg_float = Chalk::Target::XS::AST::Literal->new(value => -3.14);
+    my $neg_float = Chalk::Target::XS::AST::Literal->new(value => -3.14, c_type => 'NV');
     is($neg_float->emit(), '-3.14', 'Negative float emits correctly');
 }
 
@@ -88,7 +96,7 @@ BEGIN {
     my $var_init = Chalk::Target::XS::AST::VarDecl->new(
         type => 'IV',
         name => 'count',
-        init => Chalk::Target::XS::AST::Literal->new(value => 0)
+        init => Chalk::Target::XS::AST::Literal->new(value => 0, c_type => 'IV')
     );
     is($var_init->emit(), 'IV count = 0;', 'Variable with initializer emits correctly');
 }
@@ -105,7 +113,7 @@ BEGIN {
 
     # Return with literal
     my $ret_lit = Chalk::Target::XS::AST::Return->new(
-        expr => Chalk::Target::XS::AST::Literal->new(value => 42)
+        expr => Chalk::Target::XS::AST::Literal->new(value => 42, c_type => 'IV')
     );
     is($ret_lit->emit(), 'RETVAL = 42;', 'Return with literal emits correctly');
 }


### PR DESCRIPTION
## Summary
- Removes regex fallback pattern matching from Literal.pm's emit() method
- c_type field is now required, not optional, ensuring type info from IR
- Builds on #478's type flow infrastructure (Grammar→IR→C)

## Related Issues
Closes #476

## Changes
- **lib/Chalk/Target/XS/AST/Literal.pm**: Remove regex fallback, require c_type
- **t/target/xs-ast-nodes.t**: Update all tests to pass c_type explicitly

## Statistics
- 2 files changed
- +29 lines, -28 lines

## Test plan
- [x] `plenv exec perl t/target/xs-ast-nodes.t` - All 39 tests pass
- [x] `plenv exec perl t/target/xs-core.t` - All 17 tests pass  
- [x] `plenv exec perl t/target/xs-constant-return.t` - All 12 tests pass
- [x] `plenv exec perl t/target/xs-compiles.t` - XS compilation succeeds
- [x] `plenv exec perl t/ir-type-convert.t` - Type conversion works