### PR TITLE
feat(xs): Add built-in function mapping to Perl C API

### DIFF
--- a/lib/Chalk/Target/XS.pm
+++ b/lib/Chalk/Target/XS.pm
@@ -72,6 +72,33 @@ class Chalk::Target::XS {
         'Chalk::IR::Type::Bottom'  => 'void',
     );
 
+    # Perl built-in function -> C API mapping
+    my %BUILTIN_TO_C_API = (
+        # Array operations
+        'push'    => 'av_push',
+        'pop'     => 'av_pop',
+        'shift'   => 'av_shift',
+        'unshift' => 'av_unshift',
+
+        # Hash operations
+        'exists' => 'hv_exists_ent',
+        'delete' => 'hv_delete_ent',
+
+        # Scalar operations
+        'defined' => 'SvOK',
+        'length'  => 'sv_len',
+    );
+
+    # Check if a function name is a Perl built-in with C API mapping
+    method is_builtin($func_name) {
+        return exists $BUILTIN_TO_C_API{$func_name};
+    }
+
+    # Get the C API function for a Perl built-in
+    method get_builtin_c_api($func_name) {
+        return $BUILTIN_TO_C_API{$func_name};
+    }
+
     # Map IR types to C types for Perl API
     # Prefer compute() (peephole type lattice) over compute_type() (semantic types)
     # because peephole inference propagates types through operations correctly
@@ -703,14 +730,33 @@ class Chalk::Target::XS {
             }
         }
 
+        # Check if this is a Perl built-in with a C API mapping
+        my $c_func_name = $func_name;
+        my $return_type = 'IV';  # Default return type
+        if ($self->is_builtin($func_name)) {
+            $c_func_name = $self->get_builtin_c_api($func_name);
+
+            # Set appropriate return type based on the builtin
+            if ($func_name eq 'defined') {
+                $return_type = 'bool';
+            } elsif ($func_name eq 'pop' || $func_name eq 'shift' || $func_name eq 'delete') {
+                $return_type = 'SV*';
+            } elsif ($func_name eq 'exists') {
+                $return_type = 'bool';
+            } elsif ($func_name eq 'length') {
+                $return_type = 'STRLEN';
+            }
+            # push/unshift don't return meaningful values (return count)
+        }
+
         # Allocate result variable and create VarDecl with FunctionCall init
         my $result_var = $self->alloc_temp($node->id);
 
         return Chalk::Target::XS::AST::VarDecl->new(
-            type => 'IV',  # TODO: infer return type
+            type => $return_type,
             name => $result_var,
             init => Chalk::Target::XS::AST::FunctionCall->new(
-                name => $func_name,
+                name => $c_func_name,
                 args => \@arg_vars,
             ),
         );

--- a/t/target/xs-builtins.t
+++ b/t/target/xs-builtins.t
@@ -1,0 +1,193 @@
+#!/usr/bin/env perl
+# ABOUTME: Tests for XS built-in function mapping to Perl C API
+# ABOUTME: Verifies that Perl built-ins generate correct C API calls
+use 5.42.0;
+use Test::More;
+use experimental qw(class);
+
+# Set lib path at compile time using abs_path on $0 for worktree compatibility
+BEGIN {
+    use Cwd qw(abs_path);
+    use File::Spec;
+    my $test_file = abs_path($0);
+    my ($vol, $dir, $file) = File::Spec->splitpath($test_file);
+    my $lib_dir = abs_path(File::Spec->catdir($vol, $dir, '..', '..', 'lib'));
+    unshift @INC, $lib_dir;
+}
+
+use_ok('Chalk::Target::XS') or BAIL_OUT("Cannot load Chalk::Target::XS");
+use_ok('Chalk::IR::Node::Call') or BAIL_OUT("Cannot load Call node");
+use_ok('Chalk::IR::Node::Constant') or BAIL_OUT("Cannot load Constant node");
+
+# Helper to create an XS target with minimal graph
+sub make_xs_target {
+    my $graph = { nodes => {}, start => undef, end => undef };
+    return Chalk::Target::XS->new(
+        graph => $graph,
+        module_name => 'Test::Builtins'
+    );
+}
+
+# Test that built-in mapping exists
+{
+    my $xs = make_xs_target();
+    ok($xs->can('is_builtin'), 'XS target has is_builtin method');
+    ok($xs->can('get_builtin_c_api'), 'XS target has get_builtin_c_api method');
+}
+
+# Test array built-ins recognition
+{
+    my $xs = make_xs_target();
+
+    ok($xs->is_builtin('push'), 'push is recognized as builtin');
+    ok($xs->is_builtin('pop'), 'pop is recognized as builtin');
+    ok($xs->is_builtin('shift'), 'shift is recognized as builtin');
+    ok($xs->is_builtin('unshift'), 'unshift is recognized as builtin');
+}
+
+# Test hash built-ins recognition
+{
+    my $xs = make_xs_target();
+
+    ok($xs->is_builtin('exists'), 'exists is recognized as builtin');
+    ok($xs->is_builtin('delete'), 'delete is recognized as builtin');
+}
+
+# Test scalar built-ins recognition
+{
+    my $xs = make_xs_target();
+
+    ok($xs->is_builtin('defined'), 'defined is recognized as builtin');
+    ok($xs->is_builtin('length'), 'length is recognized as builtin');
+}
+
+# Test C API mapping for array operations
+{
+    my $xs = make_xs_target();
+
+    is($xs->get_builtin_c_api('push'), 'av_push', 'push maps to av_push');
+    is($xs->get_builtin_c_api('pop'), 'av_pop', 'pop maps to av_pop');
+    is($xs->get_builtin_c_api('shift'), 'av_shift', 'shift maps to av_shift');
+    is($xs->get_builtin_c_api('unshift'), 'av_unshift', 'unshift maps to av_unshift');
+}
+
+# Test C API mapping for hash operations
+{
+    my $xs = make_xs_target();
+
+    is($xs->get_builtin_c_api('exists'), 'hv_exists_ent', 'exists maps to hv_exists_ent');
+    is($xs->get_builtin_c_api('delete'), 'hv_delete_ent', 'delete maps to hv_delete_ent');
+}
+
+# Test C API mapping for scalar operations
+{
+    my $xs = make_xs_target();
+
+    is($xs->get_builtin_c_api('defined'), 'SvOK', 'defined maps to SvOK');
+    is($xs->get_builtin_c_api('length'), 'sv_len', 'length maps to sv_len');
+}
+
+# Test non-builtin returns undef
+{
+    my $xs = make_xs_target();
+
+    ok(!$xs->is_builtin('my_custom_function'), 'custom function not a builtin');
+    is($xs->get_builtin_c_api('my_custom_function'), undef, 'custom function has no C API mapping');
+}
+
+# Helper to create a builtin call and test its output
+sub test_builtin_call {
+    my ($func_name, $expected_c_api, $expected_type) = @_;
+
+    use Chalk::IR::Type::String;
+    use Chalk::IR::Type::Integer;
+
+    my $xs = make_xs_target();
+
+    my $callee = Chalk::IR::Node::Constant->new(
+        value => $func_name,
+        type  => Chalk::IR::Type::String->TOP(),
+    );
+    my $arg = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => Chalk::IR::Type::Integer->TOP(),
+    );
+    my $call = Chalk::IR::Node::Call->new(
+        callee => $callee,
+        args   => [$arg],
+    );
+
+    # First, visit the argument to bind it
+    $xs->visit($arg);
+
+    # Visit the call
+    my $result = $xs->visit($call);
+
+    isa_ok($result, 'Chalk::Target::XS::AST::VarDecl',
+        "visit_Call returns VarDecl for $func_name");
+
+    my $emitted = $result->emit();
+    like($emitted, qr/\Q$expected_c_api\E/,
+        "$func_name() call emits $expected_c_api");
+    like($emitted, qr/^\Q$expected_type\E\s/,
+        "$func_name() has return type $expected_type");
+}
+
+# Test visit_Call generates correct C API for defined
+test_builtin_call('defined', 'SvOK', 'bool');
+
+# Test visit_Call generates correct C API for length
+test_builtin_call('length', 'sv_len', 'STRLEN');
+
+# Test visit_Call generates correct C API for pop
+test_builtin_call('pop', 'av_pop', 'SV*');
+
+# Test visit_Call generates correct C API for shift
+test_builtin_call('shift', 'av_shift', 'SV*');
+
+# Test visit_Call generates correct C API for push
+test_builtin_call('push', 'av_push', 'IV');
+
+# Test visit_Call generates correct C API for unshift
+test_builtin_call('unshift', 'av_unshift', 'IV');
+
+# Test visit_Call generates correct C API for exists
+test_builtin_call('exists', 'hv_exists_ent', 'bool');
+
+# Test visit_Call generates correct C API for delete
+test_builtin_call('delete', 'hv_delete_ent', 'SV*');
+
+# Test non-builtin function call
+{
+    use Chalk::IR::Type::String;
+    use Chalk::IR::Type::Integer;
+
+    my $xs = make_xs_target();
+
+    my $callee = Chalk::IR::Node::Constant->new(
+        value => 'my_custom_func',
+        type  => Chalk::IR::Type::String->TOP(),
+    );
+    my $arg = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => Chalk::IR::Type::Integer->TOP(),
+    );
+    my $call = Chalk::IR::Node::Call->new(
+        callee => $callee,
+        args   => [$arg],
+    );
+
+    $xs->visit($arg);
+    my $result = $xs->visit($call);
+
+    isa_ok($result, 'Chalk::Target::XS::AST::VarDecl',
+        'visit_Call returns VarDecl for custom function');
+
+    my $emitted = $result->emit();
+    like($emitted, qr/my_custom_func/,
+        'Custom function call uses original function name');
+    like($emitted, qr/^IV\s/,
+        'Custom function has default return type IV');
+}
+
+done_testing();


### PR DESCRIPTION
## Summary
Implements mapping from Perl built-in functions to their C API equivalents for XS code generation.

## Built-in Mappings

### Array Operations
| Perl | C API | Return Type |
|------|-------|-------------|
| `push` | `av_push` | IV |
| `pop` | `av_pop` | SV* |
| `shift` | `av_shift` | SV* |
| `unshift` | `av_unshift` | IV |

### Hash Operations
| Perl | C API | Return Type |
|------|-------|-------------|
| `exists` | `hv_exists_ent` | bool |
| `delete` | `hv_delete_ent` | SV* |

### Scalar Operations
| Perl | C API | Return Type |
|------|-------|-------------|
| `defined` | `SvOK` | bool |
| `length` | `sv_len` | STRLEN |

## Related Issues
Closes #295

## Changes
- **lib/Chalk/Target/XS.pm**:
  - Add `%BUILTIN_TO_C_API` mapping hash
  - Add `is_builtin()` method
  - Add `get_builtin_c_api()` method
  - Update `visit_Call` to use C API names and return types
- **t/target/xs-builtins.t**: New test file with 50 tests

## Statistics
- 2 files changed
- +241 lines, -2 lines

## Test plan
- [x] `plenv exec perl t/target/xs-builtins.t` - 50 tests pass
- [x] `plenv exec perl t/target/xs-core.t` - 17 tests pass
- [x] `plenv exec perl t/target/xs-function-calls.t` - 6 tests pass
- [x] `plenv exec perl t/target/xs-compiles.t` - XS compilation succeeds