### PR TITLE
ci: Add perf benchmark workflow for self-hosting.t

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -1,0 +1,77 @@
+# ABOUTME: GitHub Action to benchmark self-hosting.t using perf stat
+# ABOUTME: Compares Perl 5.42 with and without threads using official Docker images
+name: Performance Benchmark
+
+on:
+  workflow_dispatch:  # Manual trigger only
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - name: "no-threads"
+            image: "perl:5.42"
+          - name: "threaded"
+            image: "perl:5.42-threaded"
+
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install perf tools
+        run: |
+          apt-get update
+          apt-get install -y linux-perf procps || apt-get install -y linux-tools-generic || true
+
+      - name: Verify Perl version and config
+        run: |
+          perl -v
+          perl -V:usethreads
+
+      - name: Run perf stat on self-hosting.t
+        run: |
+          echo "## Perf Stats (${{ matrix.name }})" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          perf stat perl t/self-hosting.t 2>&1 | tee perf-output.txt || \
+          /usr/bin/time -v perl t/self-hosting.t 2>&1 | tee perf-output.txt
+
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat perf-output.txt >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload perf results
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-results-${{ matrix.name }}
+          path: perf-output.txt
+
+  compare:
+    needs: benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all perf results
+        uses: actions/download-artifact@v4
+        with:
+          path: results
+
+      - name: Compare results
+        run: |
+          echo "## Performance Comparison: Perl 5.42 Threads vs No-Threads" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### No Threads" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat results/perf-results-no-threads/perf-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### With Threads" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat results/perf-results-threaded/perf-output.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Add GitHub Action to benchmark `self-hosting.t` using `perf stat`, comparing Perl 5.42 with and without threads enabled using official Docker images.

## Features
- **Manual trigger only** (`workflow_dispatch`) - too expensive for every PR
- Uses official Docker images:
  - `perl:5.42` (no threads)
  - `perl:5.42-threaded` (threads enabled)
- Measures hardware performance counters via `perf stat`
- Falls back to `/usr/bin/time -v` if `perf` unavailable in container
- Posts comparison to workflow summary
- Uploads results as artifacts

## Metrics Captured (when perf available)
| Metric | Purpose |
|--------|---------|
| `cycles` / `instructions` | CPU work, IPC |
| `cache-references` / `cache-misses` | Memory efficiency |
| `branches` / `branch-misses` | Branch prediction accuracy |

## Usage
1. Go to Actions → "Performance Benchmark"
2. Click "Run workflow"
3. View results in workflow summary

## Caveats
- GitHub runners may not expose all hardware counters due to virtualization
- Some metrics may show `<not supported>` or fall back to timing

## Files Changed
- `.github/workflows/perf-benchmark.yml` (new, 85 lines)