### PR TITLE
ci: Only run tests when code files change

### DIFF
--- a/.github/workflows/self-hosting.yml
+++ b/.github/workflows/self-hosting.yml
@@ -18,16 +18,35 @@ jobs:
       with:
         fetch-depth: 0  # Fetch full history for git merge-base to work
 
+    - name: Check for code changes
+      uses: dorny/paths-filter@v3
+      id: changes
+      with:
+        filters: |
+          code:
+            - 'lib/**'
+            - 't/**'
+            - 'app.pl'
+            - 'grammar/**'
+            - 'expected-ir/**'
+            - 'perl-tests/**'
+
+    - name: Skip message
+      if: steps.changes.outputs.code != 'true'
+      run: echo "No code changes detected, skipping tests"
+
     - name: Set up Perl
+      if: steps.changes.outputs.code == 'true'
       uses: shogo82148/actions-setup-perl@v1
       with:
         perl-version: '5.42'
 
     - name: Install Perl dependencies
+      if: steps.changes.outputs.code == 'true'
       run: |
         cpanm --notest Test2::V0 Test::Deep
 
     - name: Run test suite
+      if: steps.changes.outputs.code == 'true'
       run: |
         prove -lr t/
-


### PR DESCRIPTION
## Summary
Use `dorny/paths-filter` to skip expensive test steps when no code files change.

## How it works
- Workflow **always runs** (so the check passes for branch protection)
- Uses `dorny/paths-filter@v3` to detect if code files changed
- **Skips** Perl setup, dependency install, and tests if no code changed
- **Runs** full test suite if any monitored path changed

## Monitored paths
- `lib/**` - Perl modules
- `t/**` - Test files
- `app.pl` - Main application
- `grammar/**` - Grammar files
- `expected-ir/**` - Expected IR output
- `perl-tests/**` - Additional Perl tests

## What this fixes
Previously, using `paths:` filters meant the check wouldn't run at all for non-code PRs, leaving checks "pending" and blocking merge. Now the check always passes quickly for non-code changes.