### PR TITLE
feat: Add XS visitors for string operations (StrConcat, InterpolatedString)

### DIFF
--- a/lib/Chalk/Target/XS.pm
+++ b/lib/Chalk/Target/XS.pm
@@ -179,6 +179,10 @@ class Chalk::Target::XS {
         return $self->visit_Or($node) if $type eq 'Or';
         return $self->visit_DefinedOr($node) if $type eq 'DefinedOr';
 
+        # String operation nodes
+        return $self->visit_StrConcat($node) if $type eq 'StrConcat';
+        return $self->visit_InterpolatedString($node) if $type eq 'InterpolatedString';
+
         # Unknown node type - return undef
         return undef;
     }
@@ -959,6 +963,86 @@ class Chalk::Target::XS {
             type => 'SV*',
             name => $result_var,
             init => "SvOK($left_var) ? $left_var : $right_var",
+        );
+    }
+
+    # String concatenation: $a . $b
+    method visit_StrConcat($node) {
+        use Chalk::Target::XS::AST::VarDecl;
+
+        my $left = $node->left;
+        my $right = $node->right;
+        my $left_var = $self->get_var($left->id);
+        my $right_var = $self->get_var($right->id);
+
+        my $result_var = $self->alloc_temp($node->id);
+
+        # Create new SV, copy left, concatenate right
+        # sv_catsv concatenates right onto left (mutates left)
+        # So we need: result = newSVsv(left); sv_catsv(result, right);
+        # Using a compound expression in the init
+        return Chalk::Target::XS::AST::VarDecl->new(
+            type => 'SV*',
+            name => $result_var,
+            init => "(sv_catsv($result_var = newSVsv($left_var), $right_var), $result_var)",
+        );
+    }
+
+    # Interpolated string: "Hello $name" with multiple parts
+    method visit_InterpolatedString($node) {
+        use Chalk::Target::XS::AST::VarDecl;
+
+        my $parts = $node->parts // [];
+        my $result_var = $self->alloc_temp($node->id);
+
+        if ($parts->@* == 0) {
+            # Empty string
+            return Chalk::Target::XS::AST::VarDecl->new(
+                type => 'SV*',
+                name => $result_var,
+                init => 'newSVpvn("", 0)',
+            );
+        }
+
+        # Get variable names for all parts
+        my @part_vars;
+        for my $part ($parts->@*) {
+            if ($part && $part->can('id')) {
+                push @part_vars, $self->get_var($part->id);
+            }
+        }
+
+        if (@part_vars == 0) {
+            # No valid parts
+            return Chalk::Target::XS::AST::VarDecl->new(
+                type => 'SV*',
+                name => $result_var,
+                init => 'newSVpvn("", 0)',
+            );
+        }
+
+        if (@part_vars == 1) {
+            # Single part - just copy it
+            return Chalk::Target::XS::AST::VarDecl->new(
+                type => 'SV*',
+                name => $result_var,
+                init => "newSVsv($part_vars[0])",
+            );
+        }
+
+        # Multiple parts - concatenate all
+        # Start with copy of first, then catsv each remaining
+        my $first = shift @part_vars;
+        my $init = "$result_var = newSVsv($first)";
+        for my $pv (@part_vars) {
+            $init .= ", sv_catsv($result_var, $pv)";
+        }
+        $init = "($init, $result_var)";
+
+        return Chalk::Target::XS::AST::VarDecl->new(
+            type => 'SV*',
+            name => $result_var,
+            init => $init,
         );
     }
 }

--- a/t/target/xs-string-ops.t
+++ b/t/target/xs-string-ops.t
@@ -1,0 +1,275 @@
+# ABOUTME: Test XS target visitor for string operations (StrConcat, InterpolatedString)
+# ABOUTME: Verifies XS code generation for string concatenation and interpolation
+use 5.42.0;
+use Test::More;
+
+# Set lib path at compile time using abs_path on $0 for worktree compatibility
+BEGIN {
+    use Cwd qw(abs_path);
+    use File::Spec;
+    my $test_file = abs_path($0);
+    my ($vol, $dir, $file) = File::Spec->splitpath($test_file);
+    my $lib_dir = abs_path(File::Spec->catdir($vol, $dir, '..', '..', 'lib'));
+    unshift @INC, $lib_dir;
+}
+
+use Chalk::Target::XS;
+use Chalk::IR::Node::StrConcat;
+use Chalk::IR::Node::InterpolatedString;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Type::String;
+
+# Test 1: visit_StrConcat creates VarDecl with concatenation
+{
+    my $left = Chalk::IR::Node::Constant->new(
+        value => "Hello",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $right = Chalk::IR::Node::Constant->new(
+        value => " World",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $concat = Chalk::IR::Node::StrConcat->new(
+        left => $left,
+        right => $right,
+    );
+
+    my $target = Chalk::Target::XS->new(
+        graph => undef,
+        module_name => 'TestModule',
+    );
+
+    # Pre-bind the operand temp variables
+    $target->bind_var($left->id, 'tmp_left');
+    $target->bind_var($right->id, 'tmp_right');
+
+    my $result = $target->visit_StrConcat($concat);
+
+    isa_ok($result, 'Chalk::Target::XS::AST::VarDecl', 'visit_StrConcat returns VarDecl');
+    like($result->name, qr/^tmp_\d+$/, 'visit_StrConcat allocates temp variable');
+}
+
+# Test 2: visit_StrConcat emits sv_catsv concatenation
+{
+    my $left = Chalk::IR::Node::Constant->new(
+        value => "foo",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $right = Chalk::IR::Node::Constant->new(
+        value => "bar",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $concat = Chalk::IR::Node::StrConcat->new(
+        left => $left,
+        right => $right,
+    );
+
+    my $target = Chalk::Target::XS->new(
+        graph => undef,
+        module_name => 'TestModule',
+    );
+
+    $target->bind_var($left->id, 'str_a');
+    $target->bind_var($right->id, 'str_b');
+    my $result = $target->visit_StrConcat($concat);
+
+    my $emitted = $result->emit();
+    like($emitted, qr/sv_catsv/, 'visit_StrConcat emits sv_catsv');
+    like($emitted, qr/str_a/, 'visit_StrConcat references left operand');
+    like($emitted, qr/str_b/, 'visit_StrConcat references right operand');
+}
+
+# Test 3: visit_StrConcat returns SV* type
+{
+    my $left = Chalk::IR::Node::Constant->new(
+        value => "a",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $right = Chalk::IR::Node::Constant->new(
+        value => "b",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $concat = Chalk::IR::Node::StrConcat->new(
+        left => $left,
+        right => $right,
+    );
+
+    my $target = Chalk::Target::XS->new(
+        graph => undef,
+        module_name => 'TestModule',
+    );
+
+    $target->bind_var($left->id, 'x');
+    $target->bind_var($right->id, 'y');
+    my $result = $target->visit_StrConcat($concat);
+
+    is($result->type, 'SV*', 'visit_StrConcat uses SV* type');
+}
+
+# Test 4: visit dispatch includes StrConcat
+{
+    my $left = Chalk::IR::Node::Constant->new(
+        value => "test",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $right = Chalk::IR::Node::Constant->new(
+        value => "ing",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $concat = Chalk::IR::Node::StrConcat->new(
+        left => $left,
+        right => $right,
+    );
+
+    my $target = Chalk::Target::XS->new(
+        graph => undef,
+        module_name => 'TestModule',
+    );
+
+    $target->bind_var($left->id, 'tmp_0');
+    $target->bind_var($right->id, 'tmp_1');
+
+    my $result = $target->visit($concat);
+    isa_ok($result, 'Chalk::Target::XS::AST::VarDecl', 'visit() dispatches StrConcat');
+}
+
+# Test 5: visit_InterpolatedString creates VarDecl
+{
+    my $part1 = Chalk::IR::Node::Constant->new(
+        value => "Hello ",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $part2 = Chalk::IR::Node::Constant->new(
+        value => "World",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $interp = Chalk::IR::Node::InterpolatedString->new(
+        parts => [$part1, $part2],
+    );
+
+    my $target = Chalk::Target::XS->new(
+        graph => undef,
+        module_name => 'TestModule',
+    );
+
+    $target->bind_var($part1->id, 'part_0');
+    $target->bind_var($part2->id, 'part_1');
+
+    my $result = $target->visit_InterpolatedString($interp);
+
+    isa_ok($result, 'Chalk::Target::XS::AST::VarDecl', 'visit_InterpolatedString returns VarDecl');
+    like($result->name, qr/^tmp_\d+$/, 'visit_InterpolatedString allocates temp variable');
+}
+
+# Test 6: visit_InterpolatedString emits concatenation for all parts
+{
+    my $part1 = Chalk::IR::Node::Constant->new(
+        value => "Hi ",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $part2 = Chalk::IR::Node::Constant->new(
+        value => "there",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $part3 = Chalk::IR::Node::Constant->new(
+        value => "!",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $interp = Chalk::IR::Node::InterpolatedString->new(
+        parts => [$part1, $part2, $part3],
+    );
+
+    my $target = Chalk::Target::XS->new(
+        graph => undef,
+        module_name => 'TestModule',
+    );
+
+    $target->bind_var($part1->id, 'p0');
+    $target->bind_var($part2->id, 'p1');
+    $target->bind_var($part3->id, 'p2');
+
+    my $result = $target->visit_InterpolatedString($interp);
+    my $emitted = $result->emit();
+
+    # Should reference all parts in the concatenation
+    like($emitted, qr/p0/, 'visit_InterpolatedString references part 0');
+    like($emitted, qr/p1/, 'visit_InterpolatedString references part 1');
+    like($emitted, qr/p2/, 'visit_InterpolatedString references part 2');
+}
+
+# Test 7: visit_InterpolatedString returns SV* type
+{
+    my $part = Chalk::IR::Node::Constant->new(
+        value => "text",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $interp = Chalk::IR::Node::InterpolatedString->new(
+        parts => [$part],
+    );
+
+    my $target = Chalk::Target::XS->new(
+        graph => undef,
+        module_name => 'TestModule',
+    );
+
+    $target->bind_var($part->id, 'str');
+    my $result = $target->visit_InterpolatedString($interp);
+
+    is($result->type, 'SV*', 'visit_InterpolatedString uses SV* type');
+}
+
+# Test 8: visit dispatch includes InterpolatedString
+{
+    my $part = Chalk::IR::Node::Constant->new(
+        value => "test",
+        type => Chalk::IR::Type::String->new(),
+    );
+
+    my $interp = Chalk::IR::Node::InterpolatedString->new(
+        parts => [$part],
+    );
+
+    my $target = Chalk::Target::XS->new(
+        graph => undef,
+        module_name => 'TestModule',
+    );
+
+    $target->bind_var($part->id, 'tmp_0');
+
+    my $result = $target->visit($interp);
+    isa_ok($result, 'Chalk::Target::XS::AST::VarDecl', 'visit() dispatches InterpolatedString');
+}
+
+# Test 9: visit_InterpolatedString with empty parts
+{
+    my $interp = Chalk::IR::Node::InterpolatedString->new(
+        parts => [],
+    );
+
+    my $target = Chalk::Target::XS->new(
+        graph => undef,
+        module_name => 'TestModule',
+    );
+
+    my $result = $target->visit_InterpolatedString($interp);
+
+    isa_ok($result, 'Chalk::Target::XS::AST::VarDecl', 'visit_InterpolatedString handles empty parts');
+    my $emitted = $result->emit();
+    like($emitted, qr/newSVpvn\("", 0\)|newSVpvs\(""\)/, 'Empty InterpolatedString creates empty string');
+}
+
+done_testing();


### PR DESCRIPTION
## Summary
Add XS visitors for string concatenation and interpolation operations.

## Changes
- `visit_StrConcat` - String concatenation (`$a . $b`) using `sv_catsv`
- `visit_InterpolatedString` - Multi-part string interpolation
- Dispatch entries in `visit()` method
- Test file with 16 tests

## XS Generation
```c
// StrConcat: $a . $b
SV* tmp_0 = (sv_catsv(tmp_0 = newSVsv(str_a), str_b), tmp_0);

// InterpolatedString: "Hello " . $name . "!"
SV* tmp_0 = (tmp_0 = newSVsv(p0), sv_catsv(tmp_0, p1), sv_catsv(tmp_0, p2), tmp_0);
```

## Test Results
```
t/target/xs-string-ops.t .. ok
All tests successful.
Files=1, Tests=16
```

Fixes #512

## Related
Part of Stage 0: Perl→XS Compiler milestone