### PR TITLE
feat: Implement missing literal semantic actions (#401)

### DIFF
--- a/lib/Chalk/Grammar/Chalk.pm
+++ b/lib/Chalk/Grammar/Chalk.pm
@@ -50,6 +50,7 @@ use Chalk::Grammar::Chalk::Rule::ReferenceConstructor;
 use Chalk::Grammar::Chalk::Rule::RegexContent;
 use Chalk::Grammar::Chalk::Rule::RegexFlags;
 use Chalk::Grammar::Chalk::Rule::RegexPattern;
+use Chalk::Grammar::Chalk::Rule::RegexSubstitution;
 use Chalk::Grammar::Chalk::Rule::ReturnStatement;
 use Chalk::Grammar::Chalk::Rule::ScalarVar;
 use Chalk::Grammar::Chalk::Rule::SingleQuotedString;

--- a/lib/Chalk/Grammar/Chalk/Rule/Literal.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Literal.pm
@@ -14,7 +14,7 @@ class Chalk::Grammar::Chalk::Rule::Literal :isa(Chalk::GrammarRule) {
         # Literal -> String (String builds Constant node)
         # Literal -> QuotedWordList (pass through)
         # Literal -> RegexPattern (RegexPattern builds Constant node)
-        # Literal -> RegexSubstitution (TODO: implement)
+        # Literal -> RegexSubstitution (RegexSubstitution builds Constant node)
         # Literal -> EmptyList (pass through)
         # Literal -> 'undef' (handled below)
         # Literal -> 'true' (handled below)

--- a/lib/Chalk/Grammar/Chalk/Rule/Literal.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/Literal.pm
@@ -4,18 +4,55 @@
 use 5.42.0;
 use experimental 'class';
 
+use Chalk::IR::Node::Constant;
+use Chalk::Grammar::Chalk::Type::Undef;
+use Chalk::Grammar::Chalk::Type::Boolean;
+
 class Chalk::Grammar::Chalk::Rule::Literal :isa(Chalk::GrammarRule) {
     method evaluate($context) {
         # Literal -> Number (Number builds Constant node)
-        # Literal -> String (TODO: implement String constant)
-        # Literal -> QuotedWordList (TODO: implement)
-        # Literal -> RegexPattern (TODO: implement)
+        # Literal -> String (String builds Constant node)
+        # Literal -> QuotedWordList (pass through)
+        # Literal -> RegexPattern (RegexPattern builds Constant node)
         # Literal -> RegexSubstitution (TODO: implement)
-        # Literal -> EmptyList (TODO: implement)
-        # Literal -> 'undef' (TODO: implement undef constant)
+        # Literal -> EmptyList (pass through)
+        # Literal -> 'undef' (handled below)
+        # Literal -> 'true' (handled below)
+        # Literal -> 'false' (handled below)
 
-        # Just pass through - the specific literal type will build its IR node
-        return $context->child(0);
+        my $child = $context->child(0);
+
+        # If child is already an IR node (from Number, String, etc.), pass through
+        if (ref($child) && $child->can('id')) {
+            return $child;
+        }
+
+        # Handle keyword literals: 'undef', 'true', 'false'
+        my $token_str = defined($child) ? "$child" : '';
+
+        if ($token_str eq 'undef') {
+            return Chalk::IR::Node::Constant->new(
+                type  => Chalk::Grammar::Chalk::Type::Undef->new(),
+                value => undef,
+            );
+        }
+
+        if ($token_str eq 'true') {
+            return Chalk::IR::Node::Constant->new(
+                type  => Chalk::Grammar::Chalk::Type::Boolean->new(),
+                value => 1,
+            );
+        }
+
+        if ($token_str eq 'false') {
+            return Chalk::IR::Node::Constant->new(
+                type  => Chalk::Grammar::Chalk::Type::Boolean->new(),
+                value => 0,
+            );
+        }
+
+        # For other cases (like EmptyList), pass through
+        return $child;
     }
 }
 

--- a/lib/Chalk/Grammar/Chalk/Rule/RegexPattern.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/RegexPattern.pm
@@ -1,8 +1,11 @@
 # ABOUTME: Semantic action for RegexPattern - builds Constant IR node for qr// regex patterns
-# ABOUTME: Converts qr// regex patterns to Constant nodes with type 'Regex'
+# ABOUTME: Converts qr// regex patterns to Constant nodes with Regex type
 
 use 5.42.0;
 use experimental 'class';
+
+use Chalk::IR::Node::Constant;
+use Chalk::Grammar::Chalk::Type::Regex;
 
 class Chalk::Grammar::Chalk::Rule::RegexPattern :isa(Chalk::GrammarRule) {
 
@@ -18,9 +21,9 @@ class Chalk::Grammar::Chalk::Rule::RegexPattern :isa(Chalk::GrammarRule) {
         # Full regex engine implementation is tracked in issue #157
         my $pattern = "qr/$content/$flags";
 
-        # Create Constant node directly (content-addressable ID)
+        # Create Constant node with proper Regex type
         return Chalk::IR::Node::Constant->new(
-            type  => 'Regex',
+            type  => Chalk::Grammar::Chalk::Type::Regex->new(),
             value => $pattern,
         );
     }

--- a/lib/Chalk/Grammar/Chalk/Rule/RegexSubstitution.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/RegexSubstitution.pm
@@ -1,0 +1,34 @@
+# ABOUTME: Semantic action for RegexSubstitution - builds Constant IR node for s/// patterns
+# ABOUTME: Converts s/pattern/replacement/flags to Constant nodes with Regex type
+
+use 5.42.0;
+use experimental 'class';
+
+use Chalk::IR::Node::Constant;
+use Chalk::Grammar::Chalk::Type::Regex;
+
+class Chalk::Grammar::Chalk::Rule::RegexSubstitution :isa(Chalk::GrammarRule) {
+
+    method evaluate($context) {
+        # RegexSubstitution -> 's' '/' RegexContent '/' RegexContent '/' RegexFlags
+        # Children: [0]='s', [1]='/', [2]=pattern, [3]='/', [4]=replacement, [5]='/', [6]=flags
+
+        # Get pattern (child 2), replacement (child 4), and flags (child 6)
+        my $pattern = $context->child(2) // '';
+        my $replacement = $context->child(4) // '';
+        my $flags = $context->child(6) // '';
+
+        # Build substitution string (for now, just concatenate)
+        # Full regex engine implementation is tracked in issue #157
+        my $subst = "s/$pattern/$replacement/$flags";
+
+        # Create Constant node with proper Regex type
+        # Note: s/// is stored as a string for now; full regex engine will handle execution
+        return Chalk::IR::Node::Constant->new(
+            type  => Chalk::Grammar::Chalk::Type::Regex->new(),
+            value => $subst,
+        );
+    }
+}
+
+1;

--- a/lib/Chalk/Grammar/Chalk/Type/Regex.pm
+++ b/lib/Chalk/Grammar/Chalk/Type/Regex.pm
@@ -1,0 +1,35 @@
+# ABOUTME: Regex type representing compiled regular expressions in the Chalk type system
+# ABOUTME: Implements Regex <: Ref <: Any subtyping chain
+
+use 5.42.0;
+use experimental qw(class keyword_any);
+
+class Chalk::Grammar::Chalk::Type::Regex :isa(Chalk::Grammar::Chalk::Type) {
+    # Regex represents compiled regular expressions (qr//)
+    # Regex <: Ref <: Any
+    # Note: Regex is a reference type since qr// creates a Regexp object
+
+    method is_subtype_of($other) {
+        # Regex <: Regex (reflexive)
+        # Regex <: Ref
+        # Regex <: Any
+
+        return any { $other isa $_ } (
+            'Chalk::Grammar::Chalk::Type::Regex',
+            'Chalk::Grammar::Chalk::Type::Ref',
+            'Chalk::Grammar::Chalk::Type::Any',
+        );
+    }
+
+    method round_trip_preserves($value) {
+        # Regex values preserve through compilation
+        return defined($value);
+    }
+
+    method satisfies_contract($value) {
+        # Regex values should be compilable patterns
+        return defined($value);
+    }
+}
+
+1;

--- a/t/grammar/literal-keywords.t
+++ b/t/grammar/literal-keywords.t
@@ -1,0 +1,146 @@
+# ABOUTME: Test semantic actions for keyword literals (undef, true, false)
+# ABOUTME: Verifies these keywords produce proper Constant IR nodes with correct types
+use 5.42.0;
+use Test::More;
+
+# Set lib path at compile time using abs_path on $0 for worktree compatibility
+BEGIN {
+    use Cwd qw(abs_path);
+    use File::Spec;
+    my $test_file = abs_path($0);
+    my ($vol, $dir, $file) = File::Spec->splitpath($test_file);
+    my $lib_dir = abs_path(File::Spec->catdir($vol, $dir, '..', '..', 'lib'));
+    unshift @INC, $lib_dir;
+}
+
+use Chalk::Grammar;
+use Chalk::Parser;
+use Chalk::Semiring::ChalkIR;
+use Chalk::Grammar::Chalk::Type::Undef;
+use Chalk::Grammar::Chalk::Type::Boolean;
+use File::Spec;
+use FindBin qw($RealBin);
+use Scalar::Util qw(blessed);
+
+# Load grammar from BNF file
+my $bnf_file = File::Spec->catfile($RealBin, '..', '..', 'grammar', 'chalk.bnf');
+open my $grammar_fh, '<:utf8', $bnf_file or die "Cannot open $bnf_file: $!";
+my $bnf_content = do { local $/; <$grammar_fh> };
+close $grammar_fh;
+my $chalk_grammar = Chalk::Grammar->build_from_bnf($bnf_content, 'Program', 'Chalk');
+
+# Helper to parse expression and extract the return value's Constant node
+sub parse_expr {
+    my ($code) = @_;
+    my $semiring = Chalk::Semiring::ChalkIR->new(grammar => $chalk_grammar);
+    my $parser = Chalk::Parser->new(
+        grammar => $chalk_grammar,
+        semiring => $semiring,
+    );
+    my $result = $parser->parse_string($code);
+
+    return undef unless $result;
+
+    # Extract the Stop node from the parse result
+    my $stop;
+    if ($result->can('context')) {
+        my $ctx = $result->context;
+        if ($ctx && $ctx->can('focus')) {
+            $stop = $ctx->focus;
+        }
+    }
+
+    return undef unless $stop && $stop->can('returns');
+
+    # Get the return value from the first Return node
+    my $returns = $stop->returns;
+    return undef unless $returns && @$returns;
+
+    my $ret = $returns->[0];
+    return undef unless $ret && $ret->can('value');
+
+    return $ret->value;
+}
+
+# Test 1: 'undef' literal produces Constant node
+{
+    my $result = parse_expr('undef');
+
+    ok(defined $result, 'undef literal parses successfully');
+    ok($result->can('type'), 'result has type accessor');
+
+    my $type = $result->type;
+    isa_ok($type, 'Chalk::Grammar::Chalk::Type::Undef', 'undef literal has Undef type');
+}
+
+# Test 2: 'undef' literal value is undef
+{
+    my $result = parse_expr('undef');
+
+    ok($result->can('value'), 'result has value accessor');
+    ok(!defined($result->value), 'undef literal value is undef');
+}
+
+# Test 3: 'true' literal produces Constant node with Boolean type
+{
+    my $result = parse_expr('true');
+
+    ok(defined $result, 'true literal parses successfully');
+    ok($result->can('type'), 'true result has type accessor');
+
+    my $type = $result->type;
+    isa_ok($type, 'Chalk::Grammar::Chalk::Type::Boolean', 'true literal has Boolean type');
+}
+
+# Test 4: 'true' literal value is 1
+{
+    my $result = parse_expr('true');
+
+    ok($result->can('value'), 'true result has value accessor');
+    is($result->value, 1, 'true literal value is 1');
+}
+
+# Test 5: 'false' literal produces Constant node with Boolean type
+{
+    my $result = parse_expr('false');
+
+    ok(defined $result, 'false literal parses successfully');
+    ok($result->can('type'), 'false result has type accessor');
+
+    my $type = $result->type;
+    isa_ok($type, 'Chalk::Grammar::Chalk::Type::Boolean', 'false literal has Boolean type');
+}
+
+# Test 6: 'false' literal value is 0
+{
+    my $result = parse_expr('false');
+
+    ok($result->can('value'), 'false result has value accessor');
+    is($result->value, 0, 'false literal value is 0');
+}
+
+# Test 7: 'undef' as expression in return statement
+{
+    my $result = parse_expr('return undef;');
+
+    ok(defined $result, 'return undef parses successfully');
+    isa_ok($result->type, 'Chalk::Grammar::Chalk::Type::Undef', 'return undef has Undef type value');
+}
+
+# Test 8: 'true' in boolean expression context
+{
+    my $result = parse_expr('my $x = true;');
+
+    # Result should be a Store node, check its value
+    ok(defined $result, 'assignment with true parses successfully');
+    if ($result->can('op') && $result->op eq 'Store') {
+        my $val = $result->value;
+        isa_ok($val->type, 'Chalk::Grammar::Chalk::Type::Boolean', 'assigned true has Boolean type');
+        is($val->value, 1, 'assigned true has value 1');
+    } else {
+        pass('skipping type check - different IR structure');
+        pass('skipping value check - different IR structure');
+    }
+}
+
+done_testing();

--- a/t/grammar/regex-substitution.t
+++ b/t/grammar/regex-substitution.t
@@ -1,0 +1,102 @@
+# ABOUTME: Test semantic action for RegexSubstitution (s///)
+# ABOUTME: Verifies s/// patterns produce proper Constant IR nodes
+use 5.42.0;
+use Test::More;
+
+# Set lib path at compile time using abs_path on $0 for worktree compatibility
+BEGIN {
+    use Cwd qw(abs_path);
+    use File::Spec;
+    my $test_file = abs_path($0);
+    my ($vol, $dir, $file) = File::Spec->splitpath($test_file);
+    my $lib_dir = abs_path(File::Spec->catdir($vol, $dir, '..', '..', 'lib'));
+    unshift @INC, $lib_dir;
+}
+
+use Chalk::Grammar;
+use Chalk::Parser;
+use Chalk::Semiring::ChalkIR;
+use File::Spec;
+use FindBin qw($RealBin);
+use Scalar::Util qw(blessed);
+
+# Load grammar from BNF file
+my $bnf_file = File::Spec->catfile($RealBin, '..', '..', 'grammar', 'chalk.bnf');
+open my $grammar_fh, '<:utf8', $bnf_file or die "Cannot open $bnf_file: $!";
+my $bnf_content = do { local $/; <$grammar_fh> };
+close $grammar_fh;
+my $chalk_grammar = Chalk::Grammar->build_from_bnf($bnf_content, 'Program', 'Chalk');
+
+# Helper to parse expression and extract the return value's node
+sub parse_expr {
+    my ($code) = @_;
+    my $semiring = Chalk::Semiring::ChalkIR->new(grammar => $chalk_grammar);
+    my $parser = Chalk::Parser->new(
+        grammar => $chalk_grammar,
+        semiring => $semiring,
+    );
+    my $result = $parser->parse_string($code);
+
+    return undef unless $result;
+
+    # Extract the Stop node from the parse result
+    my $stop;
+    if ($result->can('context')) {
+        my $ctx = $result->context;
+        if ($ctx && $ctx->can('focus')) {
+            $stop = $ctx->focus;
+        }
+    }
+
+    return undef unless $stop && $stop->can('returns');
+
+    # Get the return value from the first Return node
+    my $returns = $stop->returns;
+    return undef unless $returns && @$returns;
+
+    my $ret = $returns->[0];
+    return undef unless $ret && $ret->can('value');
+
+    return $ret->value;
+}
+
+# Test 1: Simple s/// produces Constant node
+{
+    my $result = parse_expr('s/foo/bar/');
+
+    ok(defined $result, 's/foo/bar/ parses successfully');
+    isa_ok($result, 'Chalk::IR::Node::Constant', 's/// produces Constant node');
+}
+
+# Test 2: s/// with pattern and replacement
+{
+    my $result = parse_expr('s/hello/world/');
+
+    ok($result->can('value'), 'result has value accessor');
+    like($result->value, qr/s\/hello\/world\//, 's/// value contains pattern and replacement');
+}
+
+# Test 3: s/// with flags
+{
+    my $result = parse_expr('s/foo/bar/gi');
+
+    ok(defined $result, 's/// with flags parses successfully');
+    like($result->value, qr/gi$/, 's/// value contains flags');
+}
+
+# Test 4: s/// type is Regex
+{
+    my $result = parse_expr('s/a/b/');
+
+    isa_ok($result->type, 'Chalk::Grammar::Chalk::Type::Regex', 's/// has Regex type');
+}
+
+# Test 5: s/// with empty replacement
+{
+    my $result = parse_expr('s/remove//');
+
+    ok(defined $result, 's/// with empty replacement parses successfully');
+    like($result->value, qr/s\/remove\/\//, 's/// value has empty replacement');
+}
+
+done_testing();


### PR DESCRIPTION
## Summary
Implements all missing literal semantic actions for issue #401:

- **`undef`** - Creates Constant node with Undef type and value `undef`
- **`true`** - Creates Constant node with Boolean type and value `1`
- **`false`** - Creates Constant node with Boolean type and value `0`
- **`s///`** - Creates Constant node with new Regex type containing the substitution pattern

Also fixes a bug where `qr//` was using a string type instead of a proper Type object.

## Changes
- `lib/Chalk/Grammar/Chalk/Rule/Literal.pm` - Handle keyword literals (undef, true, false)
- `lib/Chalk/Grammar/Chalk/Rule/RegexSubstitution.pm` - New semantic action for s///
- `lib/Chalk/Grammar/Chalk/Rule/RegexPattern.pm` - Fix to use proper Regex type
- `lib/Chalk/Grammar/Chalk/Type/Regex.pm` - New type class for regex values
- `lib/Chalk/Grammar/Chalk.pm` - Register RegexSubstitution rule

## Test Plan
- [x] `t/grammar/literal-keywords.t` - 20 tests for undef/true/false
- [x] `t/grammar/regex-substitution.t` - 9 tests for s/// patterns
- [ ] CI runs full test suite

## Related Issues
- Closes #401