### PR TITLE
ci: Reduce NYTProf disk usage to prevent out-of-space failures

### DIFF
--- a/.github/workflows/nytprof.yml
+++ b/.github/workflows/nytprof.yml
@@ -47,18 +47,13 @@ jobs:
 
           echo "HTML report generated" >> $GITHUB_STEP_SUMMARY
 
-      - name: Generate text summary
+      - name: Cleanup raw profiling data
         run: |
-          nytprofcsv
-
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          head -50 nytprof/calls.csv >> $GITHUB_STEP_SUMMARY || true
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          rm -f nytprof.out
+          echo "Cleaned up raw profiling data to save disk space" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload NYTProf report
         uses: actions/upload-artifact@v4
         with:
           name: nytprof-report-${{ matrix.name }}
-          path: |
-            nytprof-report/
-            nytprof.out
+          path: nytprof-report/


### PR DESCRIPTION
## Summary
Fix the NYTProf GitHub Action running out of disk space by reducing what we generate and upload.

## Changes
- Remove `nytprof.out` from artifact upload (raw profiling data can be massive)
- Delete raw profiling data after HTML report generation to free space
- Remove CSV generation step (not needed for our purposes)

The HTML report contains all the useful profiling visualization - we don't need the raw data or CSV files.

## Stats
- 1 file changed, 4 insertions(+), 9 deletions(-)

## Test plan
- [ ] Re-run NYTProf workflow manually after merge to verify it completes