### PR TITLE
feat: Add XS visitors for FieldLoad and FieldStore (#516)

### DIFF
--- a/lib/Chalk/Target/XS.pm
+++ b/lib/Chalk/Target/XS.pm
@@ -165,6 +165,8 @@ class Chalk::Target::XS {
         # Class-related nodes
         return $self->visit_ClassDef($node) if $type eq 'ClassDef';
         return $self->visit_Field($node) if $type eq 'Field';
+        return $self->visit_FieldLoad($node) if $type eq 'FieldLoad';
+        return $self->visit_FieldStore($node) if $type eq 'FieldStore';
 
         # Variable operation nodes
         return $self->visit_Store($node) if $type eq 'Store';
@@ -1043,6 +1045,39 @@ class Chalk::Target::XS {
             type => 'SV*',
             name => $result_var,
             init => $init,
+        );
+    }
+
+    # FieldLoad: read a field from ObjectFIELDS array
+    method visit_FieldLoad($node) {
+        use Chalk::Target::XS::AST::VarDecl;
+
+        my $field_index = $node->field_index;
+        return undef unless defined $field_index;
+
+        my $result_var = $self->alloc_temp($node->id);
+
+        return Chalk::Target::XS::AST::VarDecl->new(
+            type => 'SV*',
+            name => $result_var,
+            init => "ObjectFIELDS(self)[$field_index]",
+        );
+    }
+
+    # FieldStore: write a field to ObjectFIELDS array
+    method visit_FieldStore($node) {
+        use Chalk::Target::XS::AST::Statement;
+
+        my $field_index = $node->field_index;
+        return undef unless defined $field_index;
+
+        my $value_id = $node->value_id;
+        my $value_var = $self->get_var($value_id);
+
+        # Decref old value first to prevent memory leak on reassignment
+        # (safe even if slot contains &PL_sv_undef which is immortal)
+        return Chalk::Target::XS::AST::Statement->new(
+            code => "SvREFCNT_dec(ObjectFIELDS(self)[$field_index]); ObjectFIELDS(self)[$field_index] = newSVsv($value_var)",
         );
     }
 }

--- a/t/target/xs-field-access.t
+++ b/t/target/xs-field-access.t
@@ -1,0 +1,178 @@
+# ABOUTME: Tests for XS field access via FieldLoad and FieldStore visitors
+# ABOUTME: Verifies generation of ObjectFIELDS array access in XS code
+
+use 5.42.0;
+use Test::More;
+use FindBin qw($RealBin);
+
+use lib "$RealBin/../../lib";
+use Chalk::IR::Graph;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Node::FieldLoad;
+use Chalk::IR::Node::FieldStore;
+use Chalk::IR::Type::Integer;
+use Chalk::IR::Type::String;
+use Chalk::Target::XS;
+
+subtest 'FieldLoad generates ObjectFIELDS read' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Create a simple graph: load field at index 0
+    my $const_obj = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => Chalk::IR::Type::Integer->constant(1),
+    );
+    my $const_field = Chalk::IR::Node::Constant->new(
+        value => 'x',
+        type  => Chalk::IR::Type::String->constant('x'),
+    );
+
+    my $load = Chalk::IR::Node::FieldLoad->new(
+        inputs      => [$const_obj->id, $const_field->id],
+        object_id   => $const_obj->id,
+        field_id    => $const_field->id,
+        field_index => 0,
+    );
+
+    $graph->add_node($const_obj);
+    $graph->add_node($const_field);
+    $graph->add_node($load);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    my $xs_node = $xs->visit($load);
+    ok(defined $xs_node, 'FieldLoad visitor returns XS node');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'FieldLoad emits code');
+    like($code, qr/SV\*/, 'FieldLoad declares SV* variable');
+    like($code, qr/ObjectFIELDS\s*\(\s*self\s*\)\s*\[\s*0\s*\]/, 'FieldLoad uses ObjectFIELDS[0]');
+};
+
+subtest 'FieldLoad with different index' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $const_obj = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => Chalk::IR::Type::Integer->constant(1),
+    );
+    my $const_field = Chalk::IR::Node::Constant->new(
+        value => 'y',
+        type  => Chalk::IR::Type::String->constant('y'),
+    );
+
+    my $load = Chalk::IR::Node::FieldLoad->new(
+        inputs      => [$const_obj->id, $const_field->id],
+        object_id   => $const_obj->id,
+        field_id    => $const_field->id,
+        field_index => 2,
+    );
+
+    $graph->add_node($const_obj);
+    $graph->add_node($const_field);
+    $graph->add_node($load);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    my $xs_node = $xs->visit($load);
+    my $code = $xs_node->emit();
+    like($code, qr/ObjectFIELDS\s*\(\s*self\s*\)\s*\[\s*2\s*\]/, 'FieldLoad uses ObjectFIELDS[2]');
+};
+
+subtest 'FieldStore generates ObjectFIELDS write' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Create a simple graph: store value to field at index 0
+    my $const_obj = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => Chalk::IR::Type::Integer->constant(1),
+    );
+    my $const_field = Chalk::IR::Node::Constant->new(
+        value => 'x',
+        type  => Chalk::IR::Type::String->constant('x'),
+    );
+    my $const_value = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => Chalk::IR::Type::Integer->constant(42),
+    );
+
+    my $store = Chalk::IR::Node::FieldStore->new(
+        inputs      => [$const_obj->id, $const_field->id, $const_value->id],
+        object_id   => $const_obj->id,
+        field_id    => $const_field->id,
+        value_id    => $const_value->id,
+        field_index => 0,
+    );
+
+    $graph->add_node($const_obj);
+    $graph->add_node($const_field);
+    $graph->add_node($const_value);
+    $graph->add_node($store);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    # First visit the value to allocate its temp
+    $xs->visit($const_value);
+
+    my $xs_node = $xs->visit($store);
+    ok(defined $xs_node, 'FieldStore visitor returns XS node');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'FieldStore emits code');
+    like($code, qr/ObjectFIELDS\s*\(\s*self\s*\)\s*\[\s*0\s*\]/, 'FieldStore uses ObjectFIELDS[0]');
+    like($code, qr/SvREFCNT_dec/, 'FieldStore decrefs old value to prevent memory leak');
+    like($code, qr/newSVsv/, 'FieldStore uses newSVsv to copy value');
+};
+
+subtest 'FieldStore with different index' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $const_obj = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => Chalk::IR::Type::Integer->constant(1),
+    );
+    my $const_field = Chalk::IR::Node::Constant->new(
+        value => 'count',
+        type  => Chalk::IR::Type::String->constant('count'),
+    );
+    my $const_value = Chalk::IR::Node::Constant->new(
+        value => 99,
+        type  => Chalk::IR::Type::Integer->constant(99),
+    );
+
+    my $store = Chalk::IR::Node::FieldStore->new(
+        inputs      => [$const_obj->id, $const_field->id, $const_value->id],
+        object_id   => $const_obj->id,
+        field_id    => $const_field->id,
+        value_id    => $const_value->id,
+        field_index => 3,
+    );
+
+    $graph->add_node($const_obj);
+    $graph->add_node($const_field);
+    $graph->add_node($const_value);
+    $graph->add_node($store);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    # Visit the value first
+    $xs->visit($const_value);
+
+    my $xs_node = $xs->visit($store);
+    my $code = $xs_node->emit();
+    like($code, qr/ObjectFIELDS\s*\(\s*self\s*\)\s*\[\s*3\s*\]/, 'FieldStore uses ObjectFIELDS[3]');
+};
+
+done_testing();


### PR DESCRIPTION
## Summary
Implements XS visitors for object field access operations, enabling methods to read and write object state.

## Changes
- Added `visit_FieldLoad` - generates `ObjectFIELDS(self)[index]` for field reads
- Added `visit_FieldStore` - generates field writes with proper memory management
- Created comprehensive test suite `t/target/xs-field-access.t`

## Memory Safety
FieldStore uses `SvREFCNT_dec` before assignment to prevent memory leaks on field reassignment. This is safe even when the slot contains `&PL_sv_undef` (immortal).

## XS Pattern
```c
// FieldLoad
SV* tmp = ObjectFIELDS(self)[field_index];

// FieldStore  
SvREFCNT_dec(ObjectFIELDS(self)[field_index]);
ObjectFIELDS(self)[field_index] = newSVsv(value);
```

## Stats
- 2 files changed, 213 insertions(+)

## Test plan
- [x] `t/target/xs-field-access.t` passes (4 tests)
- [ ] CI passes

Closes #516