### PR TITLE
feat: Add XS visitors for array operations (#513)

### DIFF
--- a/.github/workflows/nytprof.yml
+++ b/.github/workflows/nytprof.yml
@@ -1,5 +1,5 @@
 # ABOUTME: GitHub Action to profile self-hosting.t using Devel::NYTProf
-# ABOUTME: Generates HTML reports comparing Perl 5.42 with and without threads
+# ABOUTME: Generates HTML report for Perl 5.42 (unthreaded)
 name: NYTProf Profiling
 
 on:
@@ -9,16 +9,8 @@ jobs:
   profile:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        include:
-          - name: "no-threads"
-            image: "perl:5.42"
-          - name: "threaded"
-            image: "perl:5.42-threaded"
-
     container:
-      image: ${{ matrix.image }}
+      image: perl:5.42
 
     steps:
       - name: Checkout code
@@ -28,14 +20,13 @@ jobs:
         run: |
           cpan -T Devel::NYTProf
 
-      - name: Verify Perl version and config
+      - name: Verify Perl version
         run: |
           perl -v
-          perl -V:usethreads
 
       - name: Run self-hosting.t under NYTProf
         run: |
-          echo "## NYTProf (${{ matrix.name }})" >> $GITHUB_STEP_SUMMARY
+          echo "## NYTProf Profiling" >> $GITHUB_STEP_SUMMARY
 
           perl -d:NYTProf t/self-hosting.t
 
@@ -55,5 +46,5 @@ jobs:
       - name: Upload NYTProf report
         uses: actions/upload-artifact@v4
         with:
-          name: nytprof-report-${{ matrix.name }}
+          name: nytprof-report
           path: nytprof-report/

--- a/lib/Chalk/Target/XS.pm
+++ b/lib/Chalk/Target/XS.pm
@@ -185,6 +185,12 @@ class Chalk::Target::XS {
         return $self->visit_StrConcat($node) if $type eq 'StrConcat';
         return $self->visit_InterpolatedString($node) if $type eq 'InterpolatedString';
 
+        # Array operation nodes
+        return $self->visit_NewArray($node) if $type eq 'NewArray';
+        return $self->visit_ArrayLoad($node) if $type eq 'ArrayLoad';
+        return $self->visit_ArrayStore($node) if $type eq 'ArrayStore';
+        return $self->visit_ArrayLength($node) if $type eq 'ArrayLength';
+
         # Unknown node type - return undef
         return undef;
     }
@@ -1078,6 +1084,85 @@ class Chalk::Target::XS {
         # (safe even if slot contains &PL_sv_undef which is immortal)
         return Chalk::Target::XS::AST::Statement->new(
             code => "SvREFCNT_dec(ObjectFIELDS(self)[$field_index]); ObjectFIELDS(self)[$field_index] = newSVsv($value_var)",
+        );
+    }
+
+    # NewArray: create a new empty Perl array (AV*)
+    method visit_NewArray($node) {
+        use Chalk::Target::XS::AST::VarDecl;
+
+        my $result_var = $self->alloc_temp($node->id);
+
+        return Chalk::Target::XS::AST::VarDecl->new(
+            type => 'AV*',
+            name => $result_var,
+            init => 'newAV()',
+        );
+    }
+
+    # ArrayLoad: read an element from an array using av_fetch
+    method visit_ArrayLoad($node) {
+        use Chalk::Target::XS::AST::VarDecl;
+
+        # Support both legacy (array_id) and new (array) patterns
+        my $array_id = $node->array_id // ($node->array ? $node->array->id : undef);
+        my $index_id = $node->index_id // ($node->index ? $node->index->id : undef);
+
+        my $array_var = $self->get_var($array_id);
+        my $index_var = $self->get_var($index_id);
+
+        return undef unless defined $array_var && defined $index_var;
+
+        my $result_var = $self->alloc_temp($node->id);
+
+        # av_fetch returns SV** (pointer to SV*), returns NULL if not found
+        # We dereference if found, otherwise use &PL_sv_undef
+        # Note: av_fetch returns borrowed reference; caller must SvREFCNT_inc if storing
+        return Chalk::Target::XS::AST::VarDecl->new(
+            type => 'SV*',
+            name => $result_var,
+            init => "({ SV** elem = av_fetch($array_var, SvIV($index_var), 0); elem ? *elem : &PL_sv_undef; })",
+        );
+    }
+
+    # ArrayStore: write an element to an array using av_store
+    method visit_ArrayStore($node) {
+        use Chalk::Target::XS::AST::Statement;
+
+        # Support both legacy (array_id) and new (array) patterns
+        my $array_id = $node->array_id // ($node->array ? $node->array->id : undef);
+        my $index_id = $node->index_id // ($node->index ? $node->index->id : undef);
+        my $value_id = $node->value_id // ($node->value ? $node->value->id : undef);
+
+        my $array_var = $self->get_var($array_id);
+        my $index_var = $self->get_var($index_id);
+        my $value_var = $self->get_var($value_id);
+
+        return undef unless defined $array_var && defined $index_var && defined $value_var;
+
+        # av_store takes ownership of the SV, so we copy with newSVsv
+        return Chalk::Target::XS::AST::Statement->new(
+            code => "av_store($array_var, SvIV($index_var), newSVsv($value_var))",
+        );
+    }
+
+    # ArrayLength: get the length of an array using av_len
+    method visit_ArrayLength($node) {
+        use Chalk::Target::XS::AST::VarDecl;
+
+        # ArrayLength only has $array (node reference), not array_id
+        my $array_id = $node->array ? $node->array->id : undef;
+        my $array_var = $self->get_var($array_id);
+
+        return undef unless defined $array_var;
+
+        my $result_var = $self->alloc_temp($node->id);
+
+        # av_len returns highest index (-1 for empty), so add 1 for length
+        return Chalk::Target::XS::AST::VarDecl->new(
+            type => 'SV*',
+            name => $result_var,
+            init => "newSViv(av_len($array_var) + 1)",
         );
     }
 }

--- a/lib/Chalk/Target/XS.pm
+++ b/lib/Chalk/Target/XS.pm
@@ -196,6 +196,9 @@ class Chalk::Target::XS {
         return $self->visit_HashLoad($node) if $type eq 'HashLoad';
         return $self->visit_HashStore($node) if $type eq 'HashStore';
 
+        # Function definition nodes
+        return $self->visit_FunctionDef($node) if $type eq 'FunctionDef';
+
         # Unknown node type - return undef
         return undef;
     }
@@ -373,29 +376,11 @@ class Chalk::Target::XS {
         my $stop = $self->find_stop_node();
 
         if ($stop && $stop->can('function_defs')) {
-            # Generate one XSUB per function definition
+            # Generate one XSUB per function definition using visitor
             my $funcs = $stop->function_defs // [];
             for my $func_def ($funcs->@*) {
-                # Reset temp counter for each function
-                $temp_counter = 0;
-                $ctx = Chalk::IR::Context->empty_context();
-
-                my $func_name = $func_def->name // 'anonymous';
-                my $params = $func_def->parameters // [];
-
-                # Compute return type from function body
-                my $return_type = $self->compute_return_type($func_def);
-
-                # Generate body statements for this function
-                my @body_statements = $self->generate_function_body($func_def);
-
-                my $xsub = Chalk::Target::XS::AST::XSUB->new(
-                    name => $func_name,
-                    params => $params,
-                    body => \@body_statements,
-                    return_type => $return_type,
-                );
-                push @xsubs, $xsub;
+                my $xsub = $self->visit_FunctionDef($func_def);
+                push @xsubs, $xsub if defined $xsub;
             }
         }
 
@@ -1226,6 +1211,32 @@ class Chalk::Target::XS {
         # Use SvPV to get key string and length; negate klen for UTF-8 keys
         return Chalk::Target::XS::AST::Statement->new(
             code => "{ STRLEN klen; const char* key = SvPV($key_var, klen); if (SvUTF8($key_var)) klen = -klen; hv_store($hash_var, key, klen, newSVsv($value_var), 0); }",
+        );
+    }
+
+    # FunctionDef: generate XSUB for standalone function
+    # Unlike methods, functions have no implicit $self parameter
+    method visit_FunctionDef($node) {
+        use Chalk::Target::XS::AST::XSUB;
+
+        # Reset temp counter for this function
+        $temp_counter = 0;
+        $ctx = Chalk::IR::Context->empty_context();
+
+        my $func_name = $node->name // 'anonymous';
+        my $params = $node->parameters // [];
+
+        # Compute return type from function body
+        my $return_type = $self->compute_return_type($node);
+
+        # Generate body statements for this function
+        my @body_statements = $self->generate_function_body($node);
+
+        return Chalk::Target::XS::AST::XSUB->new(
+            name        => $func_name,
+            params      => $params,
+            body        => \@body_statements,
+            return_type => $return_type,
         );
     }
 }

--- a/lib/Chalk/Target/XS.pm
+++ b/lib/Chalk/Target/XS.pm
@@ -191,6 +191,11 @@ class Chalk::Target::XS {
         return $self->visit_ArrayStore($node) if $type eq 'ArrayStore';
         return $self->visit_ArrayLength($node) if $type eq 'ArrayLength';
 
+        # Hash operation nodes
+        return $self->visit_NewHash($node) if $type eq 'NewHash';
+        return $self->visit_HashLoad($node) if $type eq 'HashLoad';
+        return $self->visit_HashStore($node) if $type eq 'HashStore';
+
         # Unknown node type - return undef
         return undef;
     }
@@ -1163,6 +1168,64 @@ class Chalk::Target::XS {
             type => 'SV*',
             name => $result_var,
             init => "newSViv(av_len($array_var) + 1)",
+        );
+    }
+
+    # NewHash: create a new empty Perl hash (HV*)
+    method visit_NewHash($node) {
+        use Chalk::Target::XS::AST::VarDecl;
+
+        my $result_var = $self->alloc_temp($node->id);
+
+        return Chalk::Target::XS::AST::VarDecl->new(
+            type => 'HV*',
+            name => $result_var,
+            init => 'newHV()',
+        );
+    }
+
+    # HashLoad: read an element from a hash using hv_fetch
+    method visit_HashLoad($node) {
+        use Chalk::Target::XS::AST::VarDecl;
+
+        my $hash_id = $node->hash_id;
+        my $key_id = $node->key_id;
+
+        my $hash_var = $self->get_var($hash_id);
+        my $key_var = $self->get_var($key_id);
+
+        return undef unless defined $hash_var && defined $key_var;
+
+        my $result_var = $self->alloc_temp($node->id);
+
+        # hv_fetch with SvPV to get key string and length
+        # Negate klen for UTF-8 keys as required by Perl hash API
+        # Note: hv_fetch returns borrowed reference; caller must SvREFCNT_inc if storing
+        return Chalk::Target::XS::AST::VarDecl->new(
+            type => 'SV*',
+            name => $result_var,
+            init => "({ STRLEN klen; const char* key = SvPV($key_var, klen); if (SvUTF8($key_var)) klen = -klen; SV** elem = hv_fetch($hash_var, key, klen, 0); elem ? *elem : &PL_sv_undef; })",
+        );
+    }
+
+    # HashStore: write an element to a hash using hv_store
+    method visit_HashStore($node) {
+        use Chalk::Target::XS::AST::Statement;
+
+        my $hash_id = $node->hash_id;
+        my $key_id = $node->key_id;
+        my $value_id = $node->value_id;
+
+        my $hash_var = $self->get_var($hash_id);
+        my $key_var = $self->get_var($key_id);
+        my $value_var = $self->get_var($value_id);
+
+        return undef unless defined $hash_var && defined $key_var && defined $value_var;
+
+        # hv_store takes ownership of the SV, so we copy with newSVsv
+        # Use SvPV to get key string and length; negate klen for UTF-8 keys
+        return Chalk::Target::XS::AST::Statement->new(
+            code => "{ STRLEN klen; const char* key = SvPV($key_var, klen); if (SvUTF8($key_var)) klen = -klen; hv_store($hash_var, key, klen, newSVsv($value_var), 0); }",
         );
     }
 }

--- a/t/target/xs-array-ops.t
+++ b/t/target/xs-array-ops.t
@@ -1,0 +1,153 @@
+# ABOUTME: Test XS visitors for array operations (NewArray, ArrayLoad, ArrayStore, ArrayLength)
+# ABOUTME: Verifies correct AV* operations in generated XS code
+use 5.42.0;
+use Test::More;
+use lib 'lib';
+
+use Chalk::Target::XS;
+use Chalk::IR::Graph;
+use Chalk::IR::Node::NewArray;
+use Chalk::IR::Node::ArrayLoad;
+use Chalk::IR::Node::ArrayStore;
+use Chalk::IR::Node::ArrayLength;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Type::Integer;
+
+# Test 1: NewArray visitor
+subtest 'NewArray generates newAV()' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $new_array = Chalk::IR::Node::NewArray->new(inputs => []);
+    $graph->add_node($new_array);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+    my $xs_node = $xs->visit($new_array);
+
+    ok(defined $xs_node, 'NewArray visitor returns XS node');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'NewArray emits code');
+    like($code, qr/AV\s*\*/, 'NewArray declares AV* type');
+    like($code, qr/newAV\s*\(\s*\)/, 'NewArray uses newAV()');
+};
+
+# Test 2: ArrayLoad visitor
+subtest 'ArrayLoad generates av_fetch' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Create array and index nodes
+    my $array = Chalk::IR::Node::NewArray->new(inputs => []);
+    $graph->add_node($array);
+
+    my $index = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => Chalk::IR::Type::Integer->constant(0),
+    );
+    $graph->add_node($index);
+
+    my $load = Chalk::IR::Node::ArrayLoad->new(
+        inputs => [],
+        array => $array,
+        index => $index,
+    );
+    $graph->add_node($load);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    # Visit array first to bind it
+    $xs->visit($array);
+    # Visit index to bind it
+    $xs->visit($index);
+
+    my $xs_node = $xs->visit($load);
+    ok(defined $xs_node, 'ArrayLoad visitor returns XS node');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'ArrayLoad emits code');
+    like($code, qr/av_fetch/, 'ArrayLoad uses av_fetch');
+    like($code, qr/elem\s*\?\s*\*elem\s*:\s*&PL_sv_undef/, 'ArrayLoad handles NULL with undef fallback');
+};
+
+# Test 3: ArrayStore visitor
+subtest 'ArrayStore generates av_store' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $array = Chalk::IR::Node::NewArray->new(inputs => []);
+    $graph->add_node($array);
+
+    my $index = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => Chalk::IR::Type::Integer->constant(0),
+    );
+    $graph->add_node($index);
+
+    my $value = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => Chalk::IR::Type::Integer->constant(42),
+    );
+    $graph->add_node($value);
+
+    my $store = Chalk::IR::Node::ArrayStore->new(
+        inputs => [],
+        array => $array,
+        index => $index,
+        value => $value,
+    );
+    $graph->add_node($store);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    # Visit dependencies first
+    $xs->visit($array);
+    $xs->visit($index);
+    $xs->visit($value);
+
+    my $xs_node = $xs->visit($store);
+    ok(defined $xs_node, 'ArrayStore visitor returns XS node');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'ArrayStore emits code');
+    like($code, qr/av_store/, 'ArrayStore uses av_store');
+    like($code, qr/newSVsv/, 'ArrayStore uses newSVsv to copy value');
+};
+
+# Test 4: ArrayLength visitor
+subtest 'ArrayLength generates av_len' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $array = Chalk::IR::Node::NewArray->new(inputs => []);
+    $graph->add_node($array);
+
+    my $length = Chalk::IR::Node::ArrayLength->new(
+        inputs => [],
+        array => $array,
+    );
+    $graph->add_node($length);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    # Visit array first
+    $xs->visit($array);
+
+    my $xs_node = $xs->visit($length);
+    ok(defined $xs_node, 'ArrayLength visitor returns XS node');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'ArrayLength emits code');
+    like($code, qr/av_len/, 'ArrayLength uses av_len');
+    like($code, qr/\+\s*1/, 'ArrayLength adds 1 to av_len result');
+};
+
+done_testing();

--- a/t/target/xs-function-def.t
+++ b/t/target/xs-function-def.t
@@ -1,0 +1,132 @@
+# ABOUTME: Test XS visitor for FunctionDef (standalone function definitions)
+# ABOUTME: Verifies correct XSUB generation for non-method functions
+use 5.42.0;
+use Test::More;
+use lib 'lib';
+
+use Chalk::Target::XS;
+use Chalk::IR::Graph;
+use Chalk::IR::Node::FunctionDef;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Node::Return;
+use Chalk::IR::Type::Integer;
+
+# Test 1: FunctionDef visitor returns XSUB
+subtest 'FunctionDef generates XSUB' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Create a simple function: sub answer { return 42; }
+    my $constant = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => Chalk::IR::Type::Integer->constant(42),
+    );
+    $graph->add_node($constant);
+
+    my $return = Chalk::IR::Node::Return->new(
+        control => undef,
+        value   => $constant,
+    );
+    $graph->add_node($return);
+
+    my $func_def = Chalk::IR::Node::FunctionDef->new(
+        inputs     => [],
+        name       => 'answer',
+        parameters => [],
+    );
+    $func_def->set_body_node({ type => 'block', statements => [$return] });
+    $graph->add_node($func_def);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    my $xs_node = $xs->visit($func_def);
+    ok(defined $xs_node, 'FunctionDef visitor returns XS node');
+    isa_ok($xs_node, 'Chalk::Target::XS::AST::XSUB', 'FunctionDef returns XSUB');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'FunctionDef emits code');
+    like($code, qr/answer/, 'XSUB has function name');
+    like($code, qr/RETVAL/, 'XSUB has return value');
+};
+
+# Test 2: FunctionDef with parameters
+subtest 'FunctionDef with parameters' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Create a function: sub add { my ($a, $b) = @_; return $a + $b; }
+    # For this test, we just check parameter handling, not the body logic
+    my $constant = Chalk::IR::Node::Constant->new(
+        value => 0,
+        type  => Chalk::IR::Type::Integer->constant(0),
+    );
+    $graph->add_node($constant);
+
+    my $return = Chalk::IR::Node::Return->new(
+        control => undef,
+        value   => $constant,
+    );
+    $graph->add_node($return);
+
+    my $func_def = Chalk::IR::Node::FunctionDef->new(
+        inputs     => [],
+        name       => 'add',
+        parameters => ['$a', '$b'],
+    );
+    $func_def->set_body_node({ type => 'block', statements => [$return] });
+    $graph->add_node($func_def);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    my $xs_node = $xs->visit($func_def);
+    ok(defined $xs_node, 'FunctionDef with params returns XS node');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'FunctionDef with params emits code');
+    like($code, qr/add/, 'XSUB has function name');
+    like($code, qr/\ba\b/, 'XSUB includes first parameter');
+    like($code, qr/\bb\b/, 'XSUB includes second parameter');
+};
+
+# Test 3: FunctionDef differs from methods (no implicit self)
+subtest 'FunctionDef has no implicit self' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $constant = Chalk::IR::Node::Constant->new(
+        value => 1,
+        type  => Chalk::IR::Type::Integer->constant(1),
+    );
+    $graph->add_node($constant);
+
+    my $return = Chalk::IR::Node::Return->new(
+        control => undef,
+        value   => $constant,
+    );
+    $graph->add_node($return);
+
+    my $func_def = Chalk::IR::Node::FunctionDef->new(
+        inputs     => [],
+        name       => 'helper',
+        parameters => ['$x'],
+    );
+    $func_def->set_body_node({ type => 'block', statements => [$return] });
+    $graph->add_node($func_def);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    my $xs_node = $xs->visit($func_def);
+    my $code = $xs_node->emit();
+
+    # Functions should NOT have 'self' parameter unlike methods
+    unlike($code, qr/\bself\b/, 'FunctionDef has no implicit self parameter');
+    like($code, qr/\bx\b/, 'FunctionDef has explicit parameter');
+};
+
+done_testing();

--- a/t/target/xs-hash-ops.t
+++ b/t/target/xs-hash-ops.t
@@ -1,0 +1,125 @@
+# ABOUTME: Test XS visitors for hash operations (NewHash, HashLoad, HashStore)
+# ABOUTME: Verifies correct HV* operations in generated XS code
+use 5.42.0;
+use Test::More;
+use lib 'lib';
+
+use Chalk::Target::XS;
+use Chalk::IR::Graph;
+use Chalk::IR::Node::NewHash;
+use Chalk::IR::Node::HashLoad;
+use Chalk::IR::Node::HashStore;
+use Chalk::IR::Node::Constant;
+use Chalk::IR::Type::Integer;
+use Chalk::IR::Type::String;
+
+# Test 1: NewHash visitor
+subtest 'NewHash generates newHV()' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $new_hash = Chalk::IR::Node::NewHash->new(inputs => []);
+    $graph->add_node($new_hash);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+    my $xs_node = $xs->visit($new_hash);
+
+    ok(defined $xs_node, 'NewHash visitor returns XS node');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'NewHash emits code');
+    like($code, qr/HV\s*\*/, 'NewHash declares HV* type');
+    like($code, qr/newHV\s*\(\s*\)/, 'NewHash uses newHV()');
+};
+
+# Test 2: HashLoad visitor
+subtest 'HashLoad generates hv_fetch' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    # Create hash and key nodes
+    my $hash = Chalk::IR::Node::NewHash->new(inputs => []);
+    $graph->add_node($hash);
+
+    my $key = Chalk::IR::Node::Constant->new(
+        value => 'foo',
+        type  => Chalk::IR::Type::String->new(),
+    );
+    $graph->add_node($key);
+
+    my $load = Chalk::IR::Node::HashLoad->new(
+        inputs  => [],
+        hash_id => $hash->id,
+        key_id  => $key->id,
+    );
+    $graph->add_node($load);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    # Visit hash first to bind it
+    $xs->visit($hash);
+    # Visit key to bind it
+    $xs->visit($key);
+
+    my $xs_node = $xs->visit($load);
+    ok(defined $xs_node, 'HashLoad visitor returns XS node');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'HashLoad emits code');
+    like($code, qr/hv_fetch/, 'HashLoad uses hv_fetch');
+    like($code, qr/PL_sv_undef/, 'HashLoad handles missing key with undef fallback');
+    like($code, qr/SvUTF8/, 'HashLoad checks UTF-8 flag for key');
+};
+
+# Test 3: HashStore visitor
+subtest 'HashStore generates hv_store' => sub {
+    my $graph = Chalk::IR::Graph->new();
+
+    my $hash = Chalk::IR::Node::NewHash->new(inputs => []);
+    $graph->add_node($hash);
+
+    my $key = Chalk::IR::Node::Constant->new(
+        value => 'bar',
+        type  => Chalk::IR::Type::String->new(),
+    );
+    $graph->add_node($key);
+
+    my $value = Chalk::IR::Node::Constant->new(
+        value => 42,
+        type  => Chalk::IR::Type::Integer->constant(42),
+    );
+    $graph->add_node($value);
+
+    my $store = Chalk::IR::Node::HashStore->new(
+        inputs   => [],
+        hash_id  => $hash->id,
+        key_id   => $key->id,
+        value_id => $value->id,
+    );
+    $graph->add_node($store);
+
+    my $xs = Chalk::Target::XS->new(
+        graph       => $graph,
+        module_name => 'Test',
+    );
+
+    # Visit dependencies first
+    $xs->visit($hash);
+    $xs->visit($key);
+    $xs->visit($value);
+
+    my $xs_node = $xs->visit($store);
+    ok(defined $xs_node, 'HashStore visitor returns XS node');
+
+    my $code = $xs_node->emit();
+    ok(defined $code, 'HashStore emits code');
+    like($code, qr/hv_store/, 'HashStore uses hv_store');
+    like($code, qr/newSVsv/, 'HashStore uses newSVsv to copy value');
+    like($code, qr/SvUTF8/, 'HashStore checks UTF-8 flag for key');
+};
+
+done_testing();


### PR DESCRIPTION
## Summary

Implements XS visitors for array, hash, and function operations:

### Array Operations (#513)
- **NewArray**: generates `AV* tmp = newAV()`
- **ArrayLoad**: generates `av_fetch()` with NULL check and undef fallback
- **ArrayStore**: generates `av_store()` with `newSVsv()` for proper ownership transfer
- **ArrayLength**: generates `av_len() + 1` wrapped in `newSViv()` for IR pipeline compatibility

### Hash Operations (#514)
- **NewHash**: generates `HV* tmp = newHV()`
- **HashLoad**: generates `hv_fetch()` with SvPV key extraction and UTF-8 handling
- **HashStore**: generates `hv_store()` with `newSVsv()` copy and UTF-8 handling

### FunctionDef Visitor (#518)
- **visit_FunctionDef**: generates XSUB for standalone functions
- Unlike methods, functions have no implicit `$self` parameter
- Refactored `generate()` to use visitor instead of duplicating logic

### CI Improvements
- Simplified NYTProf workflow to unthreaded Perl only (saves resources)

## Key Implementation Details

- All array visitors support both legacy (`array_id`) and new (node reference) patterns
- Hash operations use `SvPV` to extract key string/length and negate `klen` for UTF-8 keys
- Borrowed reference semantics documented in comments
- FunctionDef refactoring establishes single source of truth for XSUB generation

## Files Changed

- `lib/Chalk/Target/XS.pm` - Added 8 new visitor methods + dispatch entries + refactored generate()
- `t/target/xs-array-ops.t` - New test file (4 subtests, 16 assertions)
- `t/target/xs-hash-ops.t` - New test file (3 subtests, 14 assertions)
- `t/target/xs-function-def.t` - New test file (3 subtests, 12 assertions)
- `.github/workflows/nytprof.yml` - Simplified to unthreaded only

## Test Plan

- [x] All array ops tests pass
- [x] All hash ops tests pass
- [x] All FunctionDef tests pass
- [x] No regressions in existing XS tests
- [x] Code review completed for all implementations

Closes #513
Closes #514
Closes #518