### PR TITLE
feat: Implement All and Any IR nodes for ListOp (#386)

### DIFF
--- a/lib/Chalk/Grammar/Chalk/Rule/ListOp.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/ListOp.pm
@@ -8,6 +8,8 @@ class Chalk::Grammar::Chalk::Rule::ListOp :isa(Chalk::GrammarRule) {
     method evaluate($context) {
         use Chalk::IR::Node::Map;
         use Chalk::IR::Node::Filter;
+        use Chalk::IR::Node::All;
+        use Chalk::IR::Node::Any;
         use Chalk::IR::Node::Constant;
         use Chalk::Grammar::Chalk::Type::Str;
 
@@ -74,9 +76,20 @@ class Chalk::Grammar::Chalk::Rule::ListOp :isa(Chalk::GrammarRule) {
                 list  => $list,
             );
         }
+        elsif ($keyword eq 'all') {
+            return Chalk::IR::Node::All->new(
+                block => $block,
+                list  => $list,
+            );
+        }
+        elsif ($keyword eq 'any') {
+            return Chalk::IR::Node::Any->new(
+                block => $block,
+                list  => $list,
+            );
+        }
         else {
-            # For 'all', 'any' - pass through for now (future enhancement)
-            # Return a Map as placeholder
+            # Unknown list operation - return Map as fallback
             return Chalk::IR::Node::Map->new(
                 block => $block,
                 list  => $list,

--- a/lib/Chalk/IR/Node/All.pm
+++ b/lib/Chalk/IR/Node/All.pm
@@ -1,0 +1,76 @@
+# ABOUTME: All node for testing if all elements satisfy a predicate
+# ABOUTME: Represents all { block } @list in the IR graph
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+
+class Chalk::IR::Node::All {
+    field $block :param :reader;        # Block/predicate to test each element
+    field $list :param :reader;         # List to test
+    field $source_info :param :reader = undef;
+    field $transform_chain :reader = [];
+
+    # Dependency tracking for peephole re-optimization
+    field $_deps = [];
+
+    method add_dep($dependent_node_id) {
+        push $_deps->@*, $dependent_node_id;
+    }
+
+    method get_deps() {
+        return $_deps->@*;
+    }
+
+    method id() { refaddr($self) }
+
+    method inputs() {
+        my @inputs;
+        push @inputs, $block->id if defined $block && $block->can('id');
+        push @inputs, $list->id if defined $list && $list->can('id');
+        return \@inputs;
+    }
+
+    method op() { 'All' }
+
+    method to_hash() {
+        my $block_id = (defined $block && $block->can('id')) ? $block->id : undef;
+        my $list_id = (defined $list && $list->can('id')) ? $list->id : undef;
+
+        return {
+            id     => $self->id,
+            op     => 'All',
+            inputs => $self->inputs,
+            attributes => {
+                block_id => $block_id,
+                list_id  => $list_id,
+            },
+        };
+    }
+
+    method execute($context) {
+        # Execute the all operation:
+        # 1. Get the list value
+        # 2. Apply block to each element
+        # 3. Return true if all elements satisfy predicate, false otherwise
+
+        # For now, return undef as placeholder
+        # Full implementation requires CEK machine integration
+        return undef;
+    }
+
+    method attributes() {
+        return $self->to_hash()->{attributes};
+    }
+
+    method peephole($graph = undef) {
+        # All cannot be constant-folded without knowing block behavior
+        # Return self as-is
+        return $self;
+    }
+
+    method record_transform(@args) {
+        return;
+    }
+}
+
+1;

--- a/lib/Chalk/IR/Node/Any.pm
+++ b/lib/Chalk/IR/Node/Any.pm
@@ -1,0 +1,76 @@
+# ABOUTME: Any node for testing if any element satisfies a predicate
+# ABOUTME: Represents any { block } @list in the IR graph
+use 5.42.0;
+use experimental qw(class);
+use utf8;
+
+class Chalk::IR::Node::Any {
+    field $block :param :reader;        # Block/predicate to test each element
+    field $list :param :reader;         # List to test
+    field $source_info :param :reader = undef;
+    field $transform_chain :reader = [];
+
+    # Dependency tracking for peephole re-optimization
+    field $_deps = [];
+
+    method add_dep($dependent_node_id) {
+        push $_deps->@*, $dependent_node_id;
+    }
+
+    method get_deps() {
+        return $_deps->@*;
+    }
+
+    method id() { refaddr($self) }
+
+    method inputs() {
+        my @inputs;
+        push @inputs, $block->id if defined $block && $block->can('id');
+        push @inputs, $list->id if defined $list && $list->can('id');
+        return \@inputs;
+    }
+
+    method op() { 'Any' }
+
+    method to_hash() {
+        my $block_id = (defined $block && $block->can('id')) ? $block->id : undef;
+        my $list_id = (defined $list && $list->can('id')) ? $list->id : undef;
+
+        return {
+            id     => $self->id,
+            op     => 'Any',
+            inputs => $self->inputs,
+            attributes => {
+                block_id => $block_id,
+                list_id  => $list_id,
+            },
+        };
+    }
+
+    method execute($context) {
+        # Execute the any operation:
+        # 1. Get the list value
+        # 2. Apply block to each element
+        # 3. Return true if any element satisfies predicate, false otherwise
+
+        # For now, return undef as placeholder
+        # Full implementation requires CEK machine integration
+        return undef;
+    }
+
+    method attributes() {
+        return $self->to_hash()->{attributes};
+    }
+
+    method peephole($graph = undef) {
+        # Any cannot be constant-folded without knowing block behavior
+        # Return self as-is
+        return $self;
+    }
+
+    method record_transform(@args) {
+        return;
+    }
+}
+
+1;

--- a/t/grammar/listop.t
+++ b/t/grammar/listop.t
@@ -12,6 +12,8 @@ use Chalk::Grammar::Token;
 use Chalk::Grammar::Chalk::Rule::ListOp;
 use Chalk::IR::Node::Map;
 use Chalk::IR::Node::Filter;
+use Chalk::IR::Node::All;
+use Chalk::IR::Node::Any;
 use Chalk::IR::Node::Constant;
 use Chalk::Grammar::Chalk::Type::Str;
 use Chalk::EvalContext;
@@ -129,6 +131,72 @@ subtest 'Map node has correct block and list' => sub {
     ok($result->isa('Chalk::IR::Node::Map'), 'Result is Map');
     ok(defined($result->block), 'Map has block');
     ok(defined($result->list), 'Map has list');
+};
+
+subtest 'ListOp generates All node for all keyword' => sub {
+    my $block = make_identifier('block_placeholder');
+    my $list = make_identifier('list_placeholder');
+    my $context = mock_listop_context('all', $block, $list);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ListOp->new(
+        lhs => 'ListOp',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(defined($result), 'Result is defined');
+    ok(blessed($result), 'Result is blessed');
+    ok($result->isa('Chalk::IR::Node::All'),
+       'Result is All node for all keyword') or diag "Got: " . (ref($result) || "'$result'");
+};
+
+subtest 'ListOp generates Any node for any keyword' => sub {
+    my $block = make_identifier('block_placeholder');
+    my $list = make_identifier('list_placeholder');
+    my $context = mock_listop_context('any', $block, $list);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ListOp->new(
+        lhs => 'ListOp',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok(defined($result), 'Result is defined');
+    ok(blessed($result), 'Result is blessed');
+    ok($result->isa('Chalk::IR::Node::Any'),
+       'Result is Any node for any keyword') or diag "Got: " . (ref($result) || "'$result'");
+};
+
+subtest 'All node has correct block and list' => sub {
+    my $block = make_identifier('my_block');
+    my $list = make_identifier('my_list');
+    my $context = mock_listop_context('all', $block, $list);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ListOp->new(
+        lhs => 'ListOp',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok($result->isa('Chalk::IR::Node::All'), 'Result is All');
+    ok(defined($result->block), 'All has block');
+    ok(defined($result->list), 'All has list');
+};
+
+subtest 'Any node has correct block and list' => sub {
+    my $block = make_identifier('my_block');
+    my $list = make_identifier('my_list');
+    my $context = mock_listop_context('any', $block, $list);
+
+    my $rule = Chalk::Grammar::Chalk::Rule::ListOp->new(
+        lhs => 'ListOp',
+        rhs => []
+    );
+    my $result = $rule->evaluate($context);
+
+    ok($result->isa('Chalk::IR::Node::Any'), 'Result is Any');
+    ok(defined($result->block), 'Any has block');
+    ok(defined($result->list), 'Any has list');
 };
 
 done_testing();

--- a/t/ir/all-node.t
+++ b/t/ir/all-node.t
@@ -1,0 +1,89 @@
+# ABOUTME: Tests for All IR node
+# ABOUTME: Verifies All node structure, inputs, and serialization
+
+use v5.42;
+use Test::More;
+use FindBin qw($RealBin);
+
+use lib "$RealBin/../../lib";
+use Chalk::IR::Graph;
+use Chalk::IR::Node::All;
+use Chalk::IR::Node::Constant;
+use Chalk::Grammar::Chalk::Type::Str;
+use Chalk::Grammar::Chalk::Type::Int;
+use Scalar::Util 'blessed';
+
+# Create fresh graph for tests
+my $graph = Chalk::IR::Graph->new();
+
+# Create a mock block and list for testing
+my $mock_block = Chalk::IR::Node::Constant->new(
+    value => 'block_placeholder',
+    type => Chalk::Grammar::Chalk::Type::Str->new()
+);
+
+my $mock_list = Chalk::IR::Node::Constant->new(
+    value => 'list_placeholder',
+    type => Chalk::Grammar::Chalk::Type::Str->new()
+);
+
+subtest 'All node basic structure' => sub {
+    my $all = Chalk::IR::Node::All->new(
+        block => $mock_block,
+        list  => $mock_list,
+    );
+
+    ok(defined($all), 'All node is defined');
+    ok(blessed($all), 'All node is blessed');
+    ok($all->isa('Chalk::IR::Node::All'), 'All node has correct type');
+};
+
+subtest 'All node op method' => sub {
+    my $all = Chalk::IR::Node::All->new(
+        block => $mock_block,
+        list  => $mock_list,
+    );
+
+    is($all->op(), 'All', 'op() returns All');
+};
+
+subtest 'All node accessors' => sub {
+    my $all = Chalk::IR::Node::All->new(
+        block => $mock_block,
+        list  => $mock_list,
+    );
+
+    ok(defined($all->block), 'block accessor works');
+    ok(defined($all->list), 'list accessor works');
+    is($all->block->id, $mock_block->id, 'block is correct');
+    is($all->list->id, $mock_list->id, 'list is correct');
+};
+
+subtest 'All node to_hash' => sub {
+    my $all = Chalk::IR::Node::All->new(
+        block => $mock_block,
+        list  => $mock_list,
+    );
+
+    my $hash = $all->to_hash();
+    is($hash->{op}, 'All', 'to_hash op is All');
+    is($hash->{id}, $all->id, 'to_hash id matches');
+    ok(defined($hash->{attributes}), 'to_hash has attributes');
+    is($hash->{attributes}{block_id}, $mock_block->id, 'attributes has block_id');
+    is($hash->{attributes}{list_id}, $mock_list->id, 'attributes has list_id');
+};
+
+subtest 'All node inputs' => sub {
+    my $all = Chalk::IR::Node::All->new(
+        block => $mock_block,
+        list  => $mock_list,
+    );
+
+    my $inputs = $all->inputs();
+    ok(ref($inputs) eq 'ARRAY', 'inputs returns arrayref');
+    is(scalar(@$inputs), 2, 'inputs has 2 elements');
+    is($inputs->[0], $mock_block->id, 'First input is block id');
+    is($inputs->[1], $mock_list->id, 'Second input is list id');
+};
+
+done_testing();

--- a/t/ir/any-node.t
+++ b/t/ir/any-node.t
@@ -1,0 +1,89 @@
+# ABOUTME: Tests for Any IR node
+# ABOUTME: Verifies Any node structure, inputs, and serialization
+
+use v5.42;
+use Test::More;
+use FindBin qw($RealBin);
+
+use lib "$RealBin/../../lib";
+use Chalk::IR::Graph;
+use Chalk::IR::Node::Any;
+use Chalk::IR::Node::Constant;
+use Chalk::Grammar::Chalk::Type::Str;
+use Chalk::Grammar::Chalk::Type::Int;
+use Scalar::Util 'blessed';
+
+# Create fresh graph for tests
+my $graph = Chalk::IR::Graph->new();
+
+# Create a mock block and list for testing
+my $mock_block = Chalk::IR::Node::Constant->new(
+    value => 'block_placeholder',
+    type => Chalk::Grammar::Chalk::Type::Str->new()
+);
+
+my $mock_list = Chalk::IR::Node::Constant->new(
+    value => 'list_placeholder',
+    type => Chalk::Grammar::Chalk::Type::Str->new()
+);
+
+subtest 'Any node basic structure' => sub {
+    my $any = Chalk::IR::Node::Any->new(
+        block => $mock_block,
+        list  => $mock_list,
+    );
+
+    ok(defined($any), 'Any node is defined');
+    ok(blessed($any), 'Any node is blessed');
+    ok($any->isa('Chalk::IR::Node::Any'), 'Any node has correct type');
+};
+
+subtest 'Any node op method' => sub {
+    my $any = Chalk::IR::Node::Any->new(
+        block => $mock_block,
+        list  => $mock_list,
+    );
+
+    is($any->op(), 'Any', 'op() returns Any');
+};
+
+subtest 'Any node accessors' => sub {
+    my $any = Chalk::IR::Node::Any->new(
+        block => $mock_block,
+        list  => $mock_list,
+    );
+
+    ok(defined($any->block), 'block accessor works');
+    ok(defined($any->list), 'list accessor works');
+    is($any->block->id, $mock_block->id, 'block is correct');
+    is($any->list->id, $mock_list->id, 'list is correct');
+};
+
+subtest 'Any node to_hash' => sub {
+    my $any = Chalk::IR::Node::Any->new(
+        block => $mock_block,
+        list  => $mock_list,
+    );
+
+    my $hash = $any->to_hash();
+    is($hash->{op}, 'Any', 'to_hash op is Any');
+    is($hash->{id}, $any->id, 'to_hash id matches');
+    ok(defined($hash->{attributes}), 'to_hash has attributes');
+    is($hash->{attributes}{block_id}, $mock_block->id, 'attributes has block_id');
+    is($hash->{attributes}{list_id}, $mock_list->id, 'attributes has list_id');
+};
+
+subtest 'Any node inputs' => sub {
+    my $any = Chalk::IR::Node::Any->new(
+        block => $mock_block,
+        list  => $mock_list,
+    );
+
+    my $inputs = $any->inputs();
+    ok(ref($inputs) eq 'ARRAY', 'inputs returns arrayref');
+    is(scalar(@$inputs), 2, 'inputs has 2 elements');
+    is($inputs->[0], $mock_block->id, 'First input is block id');
+    is($inputs->[1], $mock_list->id, 'Second input is list id');
+};
+
+done_testing();


### PR DESCRIPTION
## Summary

Implements `All` and `Any` IR nodes for ListOp operations, completing the IR node support for list operations (`map`, `grep`, `all`, `any`).

## Changes

### New Files
- `lib/Chalk/IR/Node/All.pm` - IR node for `all { } @list` operations
- `lib/Chalk/IR/Node/Any.pm` - IR node for `any { } @list` operations  
- `t/ir/all-node.t` - Comprehensive tests for All IR node (5 subtests)
- `t/ir/any-node.t` - Comprehensive tests for Any IR node (5 subtests)

### Modified Files
- `lib/Chalk/Grammar/Chalk/Rule/ListOp.pm` - Updated to generate All/Any nodes instead of Map placeholder
- `t/grammar/listop.t` - Added tests for all/any keyword generation

## Implementation Details

Both `All` and `Any` IR nodes follow the same pattern as existing `Map` and `Filter` nodes:
- `block` and `list` fields with readers
- Proper `id()`, `op()`, `inputs()`, `to_hash()`, and `attributes()` methods
- Dependency tracking for peephole optimization
- Placeholder `execute()` method for future CEK machine integration
- ABOUTME comments

## Test Plan

- [x] All IR node tests pass (5 subtests)
- [x] Any IR node tests pass (5 subtests)
- [x] ListOp grammar tests pass (7 subtests)

## Stats

- 6 files changed
- 413 insertions(+), 2 deletions(-)

## Related Issues

- Fixes #386