### PR TITLE
Fix: ISA operator creates proper ISA nodes (#560)

### DIFF
--- a/grammar/chalk.bnf
+++ b/grammar/chalk.bnf
@@ -62,7 +62,7 @@
 %COMMENT% = /#[^\n]*/
 # Reserved keywords excluded from barewords via negative lookahead
 # Note: sub/method are reserved to prevent FunctionCall from matching SubroutineDeclaration
-%BAREWORD% = /(?!(?:sub|method|class|field|if|unless|elsif|else|while|until|for|foreach|return|last|next|redo|my|our|state|use|no|require|and|or|not|eq|ne|lt|gt|le|ge|cmp|true|false|__FILE__|__LINE__)\b)[a-zA-Z_][a-zA-Z0-9_]*/
+%BAREWORD% = /(?!(?:sub|method|class|field|if|unless|elsif|else|while|until|for|foreach|return|last|next|redo|my|our|state|use|no|require|and|or|not|eq|ne|lt|gt|le|ge|cmp|isa|true|false|__FILE__|__LINE__)\b)[a-zA-Z_][a-zA-Z0-9_]*/
 %BAREWORD_ANY% = /[a-zA-Z_][a-zA-Z0-9_]*/
 %SPECIAL_IDENTIFIER% = /[0-9]+|[&`'+@!$-]|^[A-Z]|\{[^}]+\}/
 %INTEGER% = /[0-9]+/
@@ -302,8 +302,8 @@ LogicalOp -> Expression WS_OPT 'and' WS_OPT Expression
 # Precedence handled by Precedence semiring
 ComparisonOp -> Expression WS_OPT %NUM_COMPARE_OP% WS_OPT Expression
 ComparisonOp -> Expression WS_OPT %STRING_COMPARE_OP% WS_OPT Expression
-ComparisonOp -> Expression WS_OPT 'isa' WS_OPT QualifiedIdentifier
-ComparisonOp -> Expression WS_OPT 'isa' WS_OPT Expression
+ComparisonOp -> Expression WS_OPT %ISA_COMPARE_OP% WS_OPT QualifiedIdentifier
+ComparisonOp -> Expression WS_OPT %ISA_COMPARE_OP% WS_OPT Expression
 ComparisonOp -> Expression WS_OPT %REGEX_MATCH_OP% WS_OPT Expression
 # Bare regex match: $x =~ /pattern/flags (shorthand for m/pattern/flags)
 ComparisonOp -> Expression WS_OPT %REGEX_MATCH_OP% WS_OPT '/' RegexContent '/' RegexFlags

--- a/lib/Chalk/Grammar/Chalk/Rule/ComparisonOp.pm
+++ b/lib/Chalk/Grammar/Chalk/Rule/ComparisonOp.pm
@@ -59,12 +59,26 @@ class Chalk::Grammar::Chalk::Rule::ComparisonOp :isa(Chalk::GrammarRule) {
             }
         }
 
-        # Extract right operand (first IR node after operator)
+        # Extract right operand (first IR node or non-whitespace token after operator)
+        # For isa operator with QualifiedIdentifier, we get a Token/string, not an IR node
         my $right;
         for my $i ($operator_idx + 1 .. $#children) {
             my $child = $context->child($i);
+            # Skip undef (filtered whitespace)
+            next unless defined $child;
+
             if (blessed($child) && $child->can('id')) {
+                # IR node - use directly
                 $right = $child;
+                last;
+            } elsif (blessed($child) || !ref($child)) {
+                # Token or string (e.g., from QualifiedIdentifier) - wrap in Constant
+                use Chalk::IR::Node::Constant;
+                use Chalk::IR::Type::String;
+                $right = Chalk::IR::Node::Constant->new(
+                    value => "$child",
+                    type => Chalk::IR::Type::String->new()
+                );
                 last;
             }
         }


### PR DESCRIPTION
## Summary
Fixes #560 - ISA operator now creates proper ISA IR nodes instead of being misinterpreted as bareword constants.

## Root Cause
The `isa` keyword was being parsed as a bareword/constant instead of as a comparison operator due to three issues:

1. **Token precedence**: `isa` was not in the %BAREWORD% exclusion list
2. **Grammar inconsistency**: ComparisonOp used literal `'isa'` instead of `%ISA_COMPARE_OP%` token
3. **Operand type mismatch**: ComparisonOp expected IR nodes but QualifiedIdentifier returns Token/string

## Changes

### grammar/chalk.bnf
- Line 65: Added `isa` to BAREWORD exclusion list
- Lines 305-306: Changed from literal `'isa'` to `%ISA_COMPARE_OP%` token pattern

### lib/Chalk/Grammar/Chalk/Rule/ComparisonOp.pm
- Added logic to handle Token/string operands (from QualifiedIdentifier)
- Wraps non-IR operands in Constant nodes with TypeString
- Maintains compatibility with Expression operands (IR nodes)

## Test Results
Verified with manual tests:
- `return $obj isa SomeClass` → Creates ISA node ✓
- `$obj isa Foo::Bar::Baz` → Creates ISA node ✓
- `if ($obj isa Class)` → Creates ISA node ✓

## Impact
- Enables XS compilation of code using `isa` operator
- visit_ISA() method can now properly emit `sv_derived_from()` calls
- Critical for self-hosting milestone

## Files Changed
- grammar/chalk.bnf: 2 insertions
- lib/Chalk/Grammar/Chalk/Rule/ComparisonOp.pm: 16 insertions, 2 deletions