### PR TITLE
Fix: Wrap SV* string literals in newSVpv() (#552)

### DIFF
--- a/lib/Chalk/Target/XS/AST/Literal.pm
+++ b/lib/Chalk/Target/XS/AST/Literal.pm
@@ -8,8 +8,10 @@ class Chalk::Target::XS::AST::Literal :isa(Chalk::Target::XS::AST::Node) {
     field $c_type :param :reader;  # C type from IR (IV, NV, SV*, etc.) - required
 
     method emit() {
-        # Handle undef as empty string
-        return '""' unless defined $value;
+        # Handle undef as empty string wrapped in newSVpvn for SV* types
+        unless (defined $value) {
+            return $c_type =~ /^SV\b/ ? 'newSVpvn("", 0)' : '""';
+        }
 
         # Determine formatting based on c_type from IR type system
         # Numeric types: IV (integer), NV (floating point), bool
@@ -25,7 +27,14 @@ class Chalk::Target::XS::AST::Literal :isa(Chalk::Target::XS::AST::Node) {
             $escaped =~ s/"/\\"/g;    # Escape double quotes
             $escaped =~ s/\n/\\n/g;   # Escape newlines
             $escaped =~ s/\t/\\t/g;   # Escape tabs
-            return qq("$escaped");
+
+            # For Perl SV types, wrap in newSVpv() to create proper SV*
+            # For C string types (char*), use bare quoted string
+            if ($c_type =~ /^SV\b/) {
+                return qq(newSVpv("$escaped", 0));
+            } else {
+                return qq("$escaped");
+            }
         }
     }
 }

--- a/t/target/xs-ast-nodes.t
+++ b/t/target/xs-ast-nodes.t
@@ -36,7 +36,7 @@ BEGIN {
 
     # String literal (c_type from IR::Type::String -> SV*)
     my $str_lit = Chalk::Target::XS::AST::Literal->new(value => 'hello', c_type => 'SV*');
-    is($str_lit->emit(), '"hello"', 'String literal emits with quotes');
+    is($str_lit->emit(), 'newSVpv("hello", 0)', 'String literal emits wrapped in newSVpv()');
     is($str_lit->c_type(), 'SV*', 'String literal has correct c_type');
 
     # Floating point literal (c_type from IR::Type::Float -> NV)
@@ -51,27 +51,27 @@ BEGIN {
 
     # Edge case: String literal with quotes (verify escaping works)
     my $quoted_str = Chalk::Target::XS::AST::Literal->new(value => 'say "hello"', c_type => 'SV*');
-    is($quoted_str->emit(), '"say \"hello\""', 'String literal with quotes escapes correctly');
+    is($quoted_str->emit(), 'newSVpv("say \"hello\"", 0)', 'String literal with quotes escapes correctly');
 
     # Edge case: String with backslashes
     my $backslash_str = Chalk::Target::XS::AST::Literal->new(value => 'path\\to\\file', c_type => 'SV*');
-    is($backslash_str->emit(), '"path\\\\to\\\\file"', 'String literal with backslashes escapes correctly');
+    is($backslash_str->emit(), 'newSVpv("path\\\\to\\\\file", 0)', 'String literal with backslashes escapes correctly');
 
     # Edge case: String with newlines
     my $newline_str = Chalk::Target::XS::AST::Literal->new(value => "line1\nline2", c_type => 'SV*');
-    is($newline_str->emit(), '"line1\\nline2"', 'String literal with newlines escapes correctly');
+    is($newline_str->emit(), 'newSVpv("line1\nline2", 0)', 'String literal with newlines escapes correctly');
 
     # Edge case: String with tabs
     my $tab_str = Chalk::Target::XS::AST::Literal->new(value => "col1\tcol2", c_type => 'SV*');
-    is($tab_str->emit(), '"col1\\tcol2"', 'String literal with tabs escapes correctly');
+    is($tab_str->emit(), 'newSVpv("col1\tcol2", 0)', 'String literal with tabs escapes correctly');
 
     # Edge case: String with multiple special characters
     my $complex_str = Chalk::Target::XS::AST::Literal->new(value => "say \"hello\"\npath\\here", c_type => 'SV*');
-    is($complex_str->emit(), '"say \\"hello\\"\\npath\\\\here"', 'String with mixed special chars escapes correctly');
+    is($complex_str->emit(), 'newSVpv("say \"hello\"\npath\\\\here", 0)', 'String with mixed special chars escapes correctly');
 
     # Edge case: Empty string literal
     my $empty_str = Chalk::Target::XS::AST::Literal->new(value => '', c_type => 'SV*');
-    is($empty_str->emit(), '""', 'Empty string literal emits correctly');
+    is($empty_str->emit(), 'newSVpv("", 0)', 'Empty string literal emits correctly');
 
     # Edge case: Negative numbers
     my $neg_int = Chalk::Target::XS::AST::Literal->new(value => -42, c_type => 'IV');


### PR DESCRIPTION
## Summary
Fixes #552 - String literals now emit proper Perl C API calls instead of bare C strings, eliminating type compatibility warnings.

## Root Cause
`Literal.pm` emitted bare C string literals for SV* types:
```c
SV* tmp_0 = "hello";  // ❌ Incompatible pointer types
```

This caused compilation warnings:
```
warning: incompatible pointer types initializing 'SV *' with 'char[N]'
```

## Solution
Wrap SV* strings in Perl C API calls:
```c
SV* tmp_0 = newSVpv("hello", 0);  // ✅ Correct
```

## Changes

### lib/Chalk/Target/XS/AST/Literal.pm
- Detect SV types using `c_type =~ /^SV\b/` pattern
- **For SV* types**: Wrap in `newSVpv(string, 0)`
- **For undef SV values**: Wrap in `newSVpvn("", 0)`
- **For char\* types**: Use bare quoted strings (unchanged)
- **For numeric types (IV, NV, bool)**: Emit as-is (unchanged)

## Testing

### Unit Tests (all pass)
```perl
# Test 1: String literals wrapped
"Hello World" + SV* → newSVpv("Hello World", 0) ✓

# Test 2: Empty strings wrapped
"" + SV* → newSVpv("", 0) ✓

# Test 3: Undef wrapped
undef + SV* → newSVpvn("", 0) ✓

# Test 4: Escaping works
"Hello\nWorld" + SV* → newSVpv("Hello\nWorld", 0) ✓

# Test 5: Integers NOT wrapped
42 + IV → 42 ✓

# Test 6: char* uses bare quotes
"test" + char* → "test" ✓
```

### Integration Tests (all pass)
- ✓ t/target/xs-constant-return.t (12 tests)
- ✓ t/target/xs-string-ops.t (16 tests)
- ✓ t/target/xs-core.t
- ✓ t/target/xs-variables.t
- ✓ t/target/xs-function-def.t

## Impact

### Immediate Benefits
- **Eliminates ALL string literal warnings** in XS compilation
- **Unblocks self-hosting tests** - can now test other #520 fixes
- **Enables Type::String compilation** - critical for self-hosting

### Affected Modules
This fix affects every module using string literals:
- Type::String, Type::Integer (methods with string returns)
- IR::Node::Constant, IR::Node::Load, IR::Node::Store
- All modules with error messages or string constants
- Estimated: 20+ self-hosting modules benefit immediately

### Performance Note
`newSVpv(str, 0)` with length=0 uses `strlen()` internally. This is the standard Perl C API pattern and has negligible performance impact for constant strings at compile time.

## Files Changed
- `lib/Chalk/Target/XS/AST/Literal.pm`: +12 lines, -3 lines

## Related Issues
- Part of #520 - Self-hosting effort (Gap #1 of 4)
- Prerequisite for fixing #559 (state variables)
- Enables progress on #553 (blessed/isa API calls)