### PR TITLE
feat: Context annotation helpers for multiply reification (#710)

### DIFF
--- a/lib/Chalk/Bootstrap/Earley.pm
+++ b/lib/Chalk/Bootstrap/Earley.pm
@@ -124,14 +124,17 @@ class Chalk::Bootstrap::Earley {
     # predicted hashref so semirings can dispatch on them during multiply.
     # Each call returns a fresh Context object — unique refaddr preserves
     # hash-consing correctness even when two scans share the same value.
+    # The predicted hashref is snapshotted because the parser mutates its
+    # live %predicted_at during the position loop.
     method _make_scan_context($matched_text, $rule_name, $alt_idx, $predicted_at) {
         return Chalk::Bootstrap::Context->new(
             focus       => $matched_text,
+            rule        => $rule_name,
             annotations => {
                 rule_name    => $rule_name,
                 alt_idx      => $alt_idx,
                 matched_text => $matched_text,
-                predicted    => $predicted_at,
+                predicted    => { $predicted_at->%* },
             },
         );
     }
@@ -143,6 +146,7 @@ class Chalk::Bootstrap::Earley {
     method _make_complete_context($value, $rule_name, $alt_idx, $pos, $origin) {
         return Chalk::Bootstrap::Context->new(
             focus       => $value,
+            rule        => $rule_name,
             annotations => {
                 rule_name => $rule_name,
                 alt_idx   => $alt_idx,

--- a/lib/Chalk/Bootstrap/Earley.pm
+++ b/lib/Chalk/Bootstrap/Earley.pm
@@ -7,6 +7,7 @@ use experimental 'class';
 use Chalk::Bootstrap::Terminal;
 use Chalk::Bootstrap::CoreItemIndex;
 use Chalk::Bootstrap::LR0DFA;
+use Chalk::Bootstrap::Context;
 
 class Chalk::Bootstrap::Earley {
     # Ruby Slippers: the set of terminal patterns that are closing delimiters
@@ -117,6 +118,39 @@ class Chalk::Bootstrap::Earley {
     # Precomputed lookup: nonterminal name => arrayref of core item IDs where
     # the dot is immediately before that nonterminal.
     method waiting_core_ids() { return \%_waiting_core_ids; }
+
+    # Reify a scan event as an annotated Context. The focus is the matched
+    # text; annotations carry rule_name, alt_idx, matched_text, and the
+    # predicted hashref so semirings can dispatch on them during multiply.
+    # Each call returns a fresh Context object — unique refaddr preserves
+    # hash-consing correctness even when two scans share the same value.
+    method _make_scan_context($matched_text, $rule_name, $alt_idx, $predicted_at) {
+        return Chalk::Bootstrap::Context->new(
+            focus       => $matched_text,
+            annotations => {
+                rule_name    => $rule_name,
+                alt_idx      => $alt_idx,
+                matched_text => $matched_text,
+                predicted    => $predicted_at,
+            },
+        );
+    }
+
+    # Reify a completion event as an annotated Context. The focus is the
+    # completed value (may be an IR node or any semiring value); annotations
+    # carry rule_name, alt_idx, pos, and origin so semirings can dispatch
+    # on the completed symbol during multiply.
+    method _make_complete_context($value, $rule_name, $alt_idx, $pos, $origin) {
+        return Chalk::Bootstrap::Context->new(
+            focus       => $value,
+            annotations => {
+                rule_name => $rule_name,
+                alt_idx   => $alt_idx,
+                pos       => $pos,
+                origin    => $origin,
+            },
+        );
+    }
 
     # GC statistics accessor
     method gc_stats() {

--- a/paad/code-reviews/issue-710-context-annotation-helpers-2026-04-12-review.md
+++ b/paad/code-reviews/issue-710-context-annotation-helpers-2026-04-12-review.md
@@ -1,0 +1,72 @@
+# Agentic Code Review: issue-710-context-annotation-helpers
+
+**Date:** 2026-04-12
+**Branch:** issue-710-context-annotation-helpers -> pu
+**Commit (pre-fix):** d46f8f76
+**Commit (post-fix):** 9a9a0008
+**Files changed:** 2 | **Lines changed:** +144 / -0 (pre-fix)
+**Diff size category:** Small
+
+## Executive Summary
+
+Small additive commit adding two annotation helpers to Earley.pm as
+scaffolding for milestone 18. Review dispatched three focused agents
+(bug-hunt, alignment, simplify) since surface area was minimal. Two
+real findings confirmed and fixed; one agent-flagged redundancy
+(matched_text) kept as spec-required.
+
+## Critical Issues
+
+### [C1] predicted hashref stored by reference (aliasing risk)
+- **File:** `lib/Chalk/Bootstrap/Earley.pm:134`
+- **Bug:** `_make_scan_context` stored `$predicted_at` by reference. The
+  parser's `%predicted_at` (Earley.pm:554) is rebuilt per position and
+  mutated by `_predict` (Earley.pm:1160). Contexts aliasing the live
+  hash would observe post-reification mutations, breaking the comonad
+  invariant that annotations are immutable snapshots.
+- **Impact:** Would corrupt semiring dispatch in #711 once helpers are
+  wired to parser call sites.
+- **Fix:** Shallow-copy `{ $predicted_at->%* }` at reification time.
+- **Confidence:** High (verified at call sites)
+- **Status:** Fixed in 9a9a0008
+
+## Important Issues
+
+### [I1] Context rule field left undef
+- **File:** `lib/Chalk/Bootstrap/Earley.pm:127-152`
+- **Bug:** Both helpers stuffed rule_name into `annotations` but left
+  the Context's dedicated `rule :param` field at its undef default.
+- **Impact:** `$ctx->rule()` is consumed in 15+ places (SemanticAction,
+  Perl/Actions). When #711/#712 wire these helpers in, all those
+  consumers would see undef instead of the rule name.
+- **Fix:** Pass `rule => $rule_name` in both constructors.
+- **Confidence:** High (verified by grep of consumers)
+- **Status:** Fixed in 9a9a0008
+
+## Suggestions
+
+- matched_text duplication between `focus` and `annotations.matched_text`
+  was flagged but retained — issue #710's Component Overview explicitly
+  lists matched_text as an annotation. Duplication is spec-required.
+
+## Plan Alignment
+
+Issue #710 acceptance criteria fully met:
+- **Implemented:** All 4 tasks (scan helper, complete helper,
+  hash-consing uniqueness test, regression verification)
+- **Not yet implemented:** Semiring interface changes (deferred to
+  #711/#712/#713 by design — "No semiring interfaces changed yet")
+- **Deviations:** None
+
+## Review Metadata
+
+- **Agents dispatched:** Bug-hunt (combined logic/error/contract/
+  concurrency/security), Alignment, Simplify
+- **Scope:** 2 changed files + Context.pm + Earley.pm call sites for
+  predicted_at (lines 554-1225)
+- **Raw findings:** 3 + alignment/simplify notes
+- **Verified findings:** 2 Critical/Important + 1 retained-as-Suggestion
+- **Filtered out:** 0
+- **Steering files consulted:** CLAUDE.md (project), user CLAUDE.md
+- **Plan/design docs consulted:** Issue #710 spec, MEMORY.md
+  milestone17_status

--- a/t/bootstrap/multiply-reification.t
+++ b/t/bootstrap/multiply-reification.t
@@ -43,6 +43,7 @@ sub make_earley() {
 
     isa_ok($ctx, 'Chalk::Bootstrap::Context', 'scan context is a Context');
     is($ctx->extract, 'foo', 'focus is the matched text');
+    is($ctx->rule,    'Atom', 'Context rule field set to rule_name');
 
     my $ann = $ctx->annotations;
     is($ann->{rule_name}, 'Atom', 'annotations has rule_name');
@@ -53,6 +54,13 @@ sub make_earley() {
         { Start => 1, Atom => 1 },
         'annotations has predicted set',
     );
+
+    # predicted hashref is snapshotted, not aliased — parser mutates
+    # its live %predicted_at during the position loop and Contexts must
+    # observe the state at reification time.
+    $predicted->{Mutated} = 1;
+    ok(!exists $ctx->annotations->{predicted}{Mutated},
+        'predicted hashref is snapshotted (immune to caller mutation)');
 }
 
 # Task 2: Complete annotation helper
@@ -64,6 +72,7 @@ sub make_earley() {
 
     isa_ok($ctx, 'Chalk::Bootstrap::Context', 'complete context is a Context');
     is($ctx->extract, $ir_value, 'focus is the completed value');
+    is($ctx->rule,    'Block',   'Context rule field set to rule_name');
 
     my $ann = $ctx->annotations;
     is($ann->{rule_name}, 'Block', 'annotations has rule_name');

--- a/t/bootstrap/multiply-reification.t
+++ b/t/bootstrap/multiply-reification.t
@@ -1,0 +1,110 @@
+# ABOUTME: Tests for Earley annotation helpers that reify scan/complete events as Context objects.
+# ABOUTME: Issue #710 — first component of on_complete elimination via multiply reification.
+use 5.42.0;
+use utf8;
+use Test::More;
+use Scalar::Util qw(refaddr);
+
+use lib 'lib';
+use Chalk::Grammar::Rule;
+use Chalk::Grammar::Symbol;
+use Chalk::Bootstrap::Earley;
+use Chalk::Bootstrap::Semiring::Boolean;
+use Chalk::Bootstrap::Context;
+
+sub terminal($value) {
+    return Chalk::Grammar::Symbol->new(type => 'terminal', value => $value);
+}
+
+sub reference($value) {
+    return Chalk::Grammar::Symbol->new(type => 'reference', value => $value);
+}
+
+# Minimal grammar so we can construct an Earley instance
+sub make_earley() {
+    my @grammar = (
+        Chalk::Grammar::Rule->new(
+            name        => 'Start',
+            expressions => [[terminal('a')]],
+        ),
+    );
+    return Chalk::Bootstrap::Earley->new(
+        grammar  => \@grammar,
+        semiring => Chalk::Bootstrap::Semiring::Boolean->new(),
+    );
+}
+
+# Task 1: Scan annotation helper
+{
+    my $earley = make_earley();
+    my $predicted = { Start => 1, Atom => 1 };
+
+    my $ctx = $earley->_make_scan_context('foo', 'Atom', 2, $predicted);
+
+    isa_ok($ctx, 'Chalk::Bootstrap::Context', 'scan context is a Context');
+    is($ctx->extract, 'foo', 'focus is the matched text');
+
+    my $ann = $ctx->annotations;
+    is($ann->{rule_name}, 'Atom', 'annotations has rule_name');
+    is($ann->{alt_idx},   2,      'annotations has alt_idx');
+    is($ann->{matched_text}, 'foo', 'annotations has matched_text');
+    is_deeply(
+        $ann->{predicted},
+        { Start => 1, Atom => 1 },
+        'annotations has predicted set',
+    );
+}
+
+# Task 2: Complete annotation helper
+{
+    my $earley = make_earley();
+    my $ir_value = { kind => 'IRNode', name => 'Block' };
+
+    my $ctx = $earley->_make_complete_context($ir_value, 'Block', 0, 7, 3);
+
+    isa_ok($ctx, 'Chalk::Bootstrap::Context', 'complete context is a Context');
+    is($ctx->extract, $ir_value, 'focus is the completed value');
+
+    my $ann = $ctx->annotations;
+    is($ann->{rule_name}, 'Block', 'annotations has rule_name');
+    is($ann->{alt_idx},   0,       'annotations has alt_idx');
+    is($ann->{pos},       7,       'annotations has pos');
+    is($ann->{origin},    3,       'annotations has origin');
+}
+
+# Task 3: Hash-consing uniqueness — same value, different rule_names
+{
+    my $earley = make_earley();
+    my $value = 'shared';
+
+    my $ctx_a = $earley->_make_scan_context($value, 'RuleA', 0, {});
+    my $ctx_b = $earley->_make_scan_context($value, 'RuleB', 0, {});
+
+    isnt(
+        refaddr($ctx_a), refaddr($ctx_b),
+        'different rule_names produce different refaddrs (hash-consing safe)',
+    );
+    is($ctx_a->extract, $ctx_b->extract,
+        'same value is preserved across both contexts');
+    isnt(
+        $ctx_a->annotations->{rule_name},
+        $ctx_b->annotations->{rule_name},
+        'rule_names differ in annotations',
+    );
+}
+
+# Also verify complete contexts differ by rule_name
+{
+    my $earley = make_earley();
+    my $value = 'shared';
+
+    my $ctx_a = $earley->_make_complete_context($value, 'RuleA', 0, 1, 0);
+    my $ctx_b = $earley->_make_complete_context($value, 'RuleB', 0, 1, 0);
+
+    isnt(
+        refaddr($ctx_a), refaddr($ctx_b),
+        'complete contexts with different rule_names have different refaddrs',
+    );
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

Adds `_make_scan_context` and `_make_complete_context` helpers to
`Chalk::Bootstrap::Earley` for reifying scan/complete events as
annotated Context objects. First component of milestone 18
(on_complete elimination via multiply reification).

- **Scan helper:** wraps matched text with rule_name, alt_idx,
  matched_text, predicted annotations
- **Complete helper:** wraps completed value with rule_name, alt_idx,
  pos, origin annotations
- Each call produces a fresh Context (unique refaddr), preserving
  hash-consing correctness
- No existing call sites changed; helpers are scaffolding for
  subsequent issues #711/#712/#713

## Review

Agentic review found 2 real issues; both fixed in-branch:
- **Critical:** predicted hashref aliasing (live hash mutated by
  `_predict`) — fixed by shallow-copy snapshot
- **Important:** Context `rule` field left undef — fixed by passing
  `rule => \$rule_name`

Review report: `paad/code-reviews/issue-710-context-annotation-helpers-2026-04-12-review.md`

## Test plan

- [x] 19 new tests in `t/bootstrap/multiply-reification.t` all pass
- [x] `earley-boolean.t` regression (35/35)
- [x] `semiring-value-propagation.t` regression (clean)
- [x] `context.t` regression (43/43)
- [x] `earley-leo.t` regression

Related: #708 (parent milestone), #710 (this issue), #711/#712/#713 (blocked by this)