### PR TITLE
chore: ignore external tool state in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 t/bootstrap/.oracle-cache/
 .build/
 .worktrees/
+
+# External tool state (IDE/agent configs, submodule checkouts)
+.claire/
+.claude/
+perl-tests/


### PR DESCRIPTION
## Summary

Adds \`.claire/\`, \`.claude/\`, and \`perl-tests/\` to \`.gitignore\`. These
are external tool state — IDE/agent configuration directories and a
separate-repo checkout — that shouldn't appear in \`git status\` or be
accidentally committed.

## Test plan

- [x] \`.gitignore\` syntax valid
- [x] Existing ignored paths preserved
- [x] \`git status\` in worktree now omits these paths