### PR TITLE
refactor: remove supports_leo gate; Leo is now unconditional

### DIFF
--- a/lib/Chalk/Bootstrap/Earley.pm
+++ b/lib/Chalk/Bootstrap/Earley.pm
@@ -19,12 +19,13 @@ class Chalk::Bootstrap::Earley {
     field $semiring :param :reader;
     field $_recover :param(recover) = false;
 
-    # Test scaffolding: force Leo on/off regardless of semiring's supports_leo.
-    # Used by t/bootstrap/leo-graph-equivalence.t to compare Leo-on vs Leo-off
-    # parses of the same input. When undef (normal production path), Leo is
-    # gated on $semiring->supports_leo(). Remove this once Leo is proven
-    # correct across all semirings.
-    field $_leo_override :param(leo_enabled) = undef;
+    # Leo optimization enable flag. Always true in production; can be
+    # overridden to false via the leo_enabled constructor parameter for
+    # tests (graph-equivalence harness, etc.) that need to compare Leo-on
+    # and Leo-off parses of the same input. Leo is structurally correct
+    # for all semirings (proven by t/bootstrap/leo-graph-equivalence.t);
+    # the override exists solely to run the comparison.
+    field $_leo_enabled :param(leo_enabled) = true;
 
     # Source file path for diagnostics (set per parse_value call)
     field $_parse_file;
@@ -60,8 +61,6 @@ class Chalk::Bootstrap::Earley {
     # reducing O(n) items per recursive chain to O(1).
     field %leo_items;
 
-    # Whether the semiring supports Leo optimization (cached at construction)
-    field $_leo_enabled;
 
     # Scan result cache: {pos}{pattern_string} => $end_pos (or undef)
     # Avoids redundant regex matching when multiple items scan the same
@@ -88,14 +87,6 @@ class Chalk::Bootstrap::Earley {
         $rule_table = {};
         for my $rule ($grammar->@*) {
             $rule_table->{$rule->name()} = $rule;
-        }
-
-        # Cache whether Leo optimization is supported by this semiring.
-        # Honor the $_leo_override test scaffolding when set.
-        if (defined $_leo_override) {
-            $_leo_enabled = $_leo_override ? true : false;
-        } else {
-            $_leo_enabled = ($semiring->can('supports_leo') && $semiring->supports_leo()) ? true : false;
         }
 
         # Build core item index from grammar
@@ -1260,10 +1251,13 @@ class Chalk::Bootstrap::Earley {
         # Leo resolution: check if a Leo item exists for this rule at origin.
         # Leo items are keyed by (rule_name, origin) where origin is where the
         # waiting items live. When a completion has this origin, the Leo item
-        # shortcuts the entire chain to the top.
-        # Leo is only used when the semiring supports it (supports_leo() must
-        # return true, indicating that multiply is identity for completions —
-        # non-trivial completion logic would be skipped for intermediate chain steps).
+        # shortcuts the chain by one level. Each Leo item covers exactly one
+        # chain level — resolution invokes multiply(leo->value, completed)
+        # which matches the non-Leo path's multiply(waiting_value, completed)
+        # byte for byte, so Leo-on and Leo-off produce isomorphic Context
+        # graphs. The $_leo_enabled flag is always true in production; the
+        # test harness at t/bootstrap/leo-graph-equivalence.t uses
+        # leo_enabled => 0 to get reference parses without Leo for comparison.
         my $leo_resolved_core_id;
         my $leo_resolved_origin;
         if ($_leo_enabled

--- a/lib/Chalk/Bootstrap/Semiring/Boolean.pm
+++ b/lib/Chalk/Bootstrap/Semiring/Boolean.pm
@@ -67,12 +67,6 @@ class Chalk::Bootstrap::Semiring::Boolean {
         return $left;
     }
 
-    # Leo optimization is safe for Boolean: multiply is associative,
-    # skipping intermediate completions is correct.
-    method supports_leo() {
-        return true;
-    }
-
     # slot_name: Boolean operates through is_zero only — no annotation slot.
     method slot_name() {
         return undef;

--- a/t/bootstrap/c-boolean-integration.t
+++ b/t/bootstrap/c-boolean-integration.t
@@ -130,20 +130,6 @@ print !\$b->is_zero(\$a2) ? 'ADD_ZERO_ONE_OK\\n'   : 'ADD_ZERO_ONE_FAIL\\n';
 my \$a3 = \$b->add(\$one, \$zero);
 print !\$b->is_zero(\$a3) ? 'ADD_ONE_ZERO_OK\\n'   : 'ADD_ONE_ZERO_FAIL\\n';
 
-# on_scan: multiply(value, one)
-my \$scanned = \$b->on_scan(\$one, 'TestRule', 0, 0, 'a');
-print !\$b->is_zero(\$scanned) ? 'ON_SCAN_OK\\n'      : 'ON_SCAN_FAIL\\n';
-
-# on_complete: identity — returns value unchanged
-my \$completed = \$b->on_complete(\$one, 'TestRule', 0, 0, 0);
-print !\$b->is_zero(\$completed) ? 'ON_COMPLETE_OK\\n' : 'ON_COMPLETE_FAIL\\n';
-
-# should_scan: always returns true for Boolean
-print \$b->should_scan(\$one, 'TestRule', 0, 0, '', {}) ? 'SHOULD_SCAN_OK\\n' : 'SHOULD_SCAN_FAIL\\n';
-
-# supports_leo: Boolean supports Leo optimization
-print \$b->supports_leo() ? 'SUPPORTS_LEO_OK\\n' : 'SUPPORTS_LEO_FAIL\\n';
-
 print 'EQUIV_OK\\n';
 END_SCRIPT
 
@@ -161,10 +147,6 @@ like($out1, qr/MULT_ONE_ONE_OK/,      'Part 1: multiply(one, one) = one');
 like($out1, qr/ADD_ZERO_ZERO_OK/,     'Part 1: add(zero, zero) = zero');
 like($out1, qr/ADD_ZERO_ONE_OK/,      'Part 1: add(zero, one) = one');
 like($out1, qr/ADD_ONE_ZERO_OK/,      'Part 1: add(one, zero) = one');
-like($out1, qr/ON_SCAN_OK/,           'Part 1: on_scan returns non-zero');
-like($out1, qr/ON_COMPLETE_OK/,       'Part 1: on_complete returns value unchanged');
-like($out1, qr/SHOULD_SCAN_OK/,       'Part 1: should_scan always returns true');
-like($out1, qr/SUPPORTS_LEO_OK/,      'Part 1: supports_leo returns true');
 like($out1, qr/EQUIV_OK/,             'Part 1: all semiring operations verified');
 
 # -------------------------------------------------------------------------

--- a/t/bootstrap/c-build-pipeline.t
+++ b/t/bootstrap/c-build-pipeline.t
@@ -183,7 +183,6 @@ print \$b->is_zero(\$r1) ? "MULTIPLY_CORRECT\\n"   : "MULTIPLY_WRONG\\n";
 my \$r2 = \$b->add(\$zero, \$one);
 print !\$b->is_zero(\$r2) ? "ADD_CORRECT\\n"       : "ADD_WRONG\\n";
 
-print \$b->supports_leo() ? "SUPPORTS_LEO_OK\\n" : "SUPPORTS_LEO_FAIL\\n";
 print "ALL_METHODS_OK\\n";
 END_SCRIPT
 close $mfh;

--- a/t/bootstrap/c-target-boolean.t
+++ b/t/bootstrap/c-target-boolean.t
@@ -265,7 +265,6 @@ my \$a1 = \$b->add(\$zero, \$zero);
 print \$b->is_zero(\$a1)  ? 'ADD_ZERO_ZERO_OK\\n'  : 'ADD_ZERO_ZERO_FAIL\\n';
 my \$a2 = \$b->add(\$zero, \$one);
 print !\$b->is_zero(\$a2) ? 'ADD_ZERO_ONE_OK\\n'   : 'ADD_ZERO_ONE_FAIL\\n';
-print \$b->supports_leo() ? 'SUPPORTS_LEO_OK\\n' : 'SUPPORTS_LEO_FAIL\\n';
 print 'BEHAVIORAL_OK\\n';
 END_SCRIPT
     close $scfh;
@@ -284,7 +283,6 @@ END_SCRIPT
     like($sub_out, qr/MULT_ONE_ONE_OK/,   'Phase 9: multiply(one, one) = one');
     like($sub_out, qr/ADD_ZERO_ZERO_OK/,  'Phase 9: add(zero, zero) = zero');
     like($sub_out, qr/ADD_ZERO_ONE_OK/,   'Phase 9: add(zero, one) = one');
-    like($sub_out, qr/SUPPORTS_LEO_OK/,   'Phase 9: supports_leo true');
     like($sub_out, qr/BEHAVIORAL_OK/,     'Phase 9: all behavioral tests pass');
 }
 

--- a/t/bootstrap/leo-graph-equivalence.t
+++ b/t/bootstrap/leo-graph-equivalence.t
@@ -12,6 +12,7 @@ use Chalk::Grammar::Symbol;
 use Chalk::Bootstrap::Earley;
 use Chalk::Bootstrap::Semiring::SemanticAction;
 use Chalk::Bootstrap::Semiring::Boolean;
+use Chalk::Bootstrap::Semiring::FilterComposite;
 use Chalk::Bootstrap::Context;
 
 # --------------------------------------------------------------------
@@ -159,6 +160,20 @@ sub parse_both ($grammar, $input, $sr_factory) {
 sub sa_factory { sub { Chalk::Bootstrap::Semiring::SemanticAction->new() } }
 sub bool_factory { sub { Chalk::Bootstrap::Semiring::Boolean->new() } }
 
+# FilterComposite of Boolean + SemanticAction — minimal composite that
+# doesn't require grammar-specific Precedence/TI/Structural setup.
+# Each factory call returns a fresh FC with fresh inner semirings.
+sub fc_factory {
+    sub {
+        return Chalk::Bootstrap::Semiring::FilterComposite->new(
+            semirings => [
+                Chalk::Bootstrap::Semiring::Boolean->new(),
+                Chalk::Bootstrap::Semiring::SemanticAction->new(),
+            ],
+        );
+    };
+}
+
 # Assert Leo-on and Leo-off produce graph-equivalent parses for the given
 # grammar + input + semiring. Reports first structural divergence on mismatch.
 sub assert_leo_equivalent ($grammar, $input, $sr_factory, $label) {
@@ -234,6 +249,56 @@ subtest 'Tier 3: left-recursive List' => sub {
         my $input = join ',', map { "y$_" } 1 .. $n;
         assert_leo_equivalent($grammar, $input, bool_factory(), "Tier 3 Boolean n=$n");
         assert_leo_equivalent($grammar, $input, sa_factory(),   "Tier 3 SA      n=$n");
+    }
+};
+
+# --------------------------------------------------------------------
+# Tier 4: FilterComposite (Boolean + SemanticAction) on all 3 patterns
+# Verifies Leo is structurally correct when dispatch goes through a
+# composite semiring. Uses the same three grammars as Tiers 1-3.
+# --------------------------------------------------------------------
+subtest 'Tier 4: FilterComposite semiring' => sub {
+    # 4a: linear (Leo inert)
+    {
+        my $grammar = [
+            rule('Start', [reference('A'), reference('B'), reference('C')]),
+            rule('A', [terminal('a')]),
+            rule('B', [terminal('b')]),
+            rule('C', [terminal('c')]),
+        ];
+        assert_leo_equivalent($grammar, 'abc', fc_factory(), "Tier 4 FC linear 'abc'");
+    }
+
+    # 4b: right-recursive Chain
+    {
+        my $grammar = [
+            rule('Chain',
+                [reference('Item')],
+                [reference('Item'), reference('Sep'), reference('Chain')],
+            ),
+            rule('Item', [terminal('\w+')]),
+            rule('Sep',  [terminal(',')]),
+        ];
+        for my $n (1, 2, 5, 10) {
+            my $input = join ',', map { "x$_" } 1 .. $n;
+            assert_leo_equivalent($grammar, $input, fc_factory(), "Tier 4 FC right-rec n=$n");
+        }
+    }
+
+    # 4c: left-recursive List
+    {
+        my $grammar = [
+            rule('List',
+                [reference('Item')],
+                [reference('List'), reference('Sep'), reference('Item')],
+            ),
+            rule('Item', [terminal('\w+')]),
+            rule('Sep',  [terminal(',')]),
+        ];
+        for my $n (1, 2, 5, 10) {
+            my $input = join ',', map { "y$_" } 1 .. $n;
+            assert_leo_equivalent($grammar, $input, fc_factory(), "Tier 4 FC left-rec n=$n");
+        }
     }
 };
 

--- a/t/fixtures/c_src/Boolean.xs
+++ b/t/fixtures/c_src/Boolean.xs
@@ -58,14 +58,6 @@ add(self, left, right)
   OUTPUT:
     RETVAL
 
-SV *
-supports_leo(self)
-    SV *self
-  CODE:
-    RETVAL = boolean_supports_leo(aTHX_ self);
-  OUTPUT:
-    RETVAL
-
 BOOT:
 {
     HV *stash = gv_stashpv("Chalk::Bootstrap::Semiring::Boolean", GV_ADD);

--- a/t/fixtures/c_src/boolean.c
+++ b/t/fixtures/c_src/boolean.c
@@ -51,7 +51,7 @@ SV * boolean_multiply(pTHX_ SV *self, SV *left, SV *right) {
     if (SvTRUE(({ boolean_is_zero(aTHX_ self, left); }))) {
         retval = SvREFCNT_inc(({ boolean_zero(aTHX_ self); })); goto xsreturn;
     }
-    retval = (SvTRUE(({ boolean_is_zero(aTHX_ self, right); })) ? ({ boolean_zero(aTHX_ self); }) : ({ dSP; ENTER; SAVETMPS; PUSHMARK(SP); XPUSHs(sv_2mortal(newSVpvs("Chalk::Bootstrap::Context"))); XPUSHs(sv_2mortal(newSVpvs("focus"))); XPUSHs(&PL_sv_yes); XPUSHs(sv_2mortal(newSVpvs("children"))); XPUSHs(({ AV *_arr9113 = newAV(); av_push(_arr9113, SvREFCNT_inc(left)); av_push(_arr9113, SvREFCNT_inc(right)); sv_2mortal(newRV_noinc((SV*)_arr9113)); })); XPUSHs(sv_2mortal(newSVpvs("is_zero"))); XPUSHs(&PL_sv_no); PUTBACK; call_method("new", G_SCALAR); SPAGAIN; SV *_mcr = SvREFCNT_inc(POPs); PUTBACK; FREETMPS; LEAVE; _mcr; }));
+    retval = (SvTRUE(({ boolean_is_zero(aTHX_ self, right); })) ? ({ boolean_zero(aTHX_ self); }) : ({ dSP; ENTER; SAVETMPS; PUSHMARK(SP); XPUSHs(sv_2mortal(newSVpvs("Chalk::Bootstrap::Context"))); XPUSHs(sv_2mortal(newSVpvs("focus"))); XPUSHs(&PL_sv_yes); XPUSHs(sv_2mortal(newSVpvs("children"))); XPUSHs(({ AV *_arr8407 = newAV(); av_push(_arr8407, SvREFCNT_inc(left)); av_push(_arr8407, SvREFCNT_inc(right)); sv_2mortal(newRV_noinc((SV*)_arr8407)); })); XPUSHs(sv_2mortal(newSVpvs("is_zero"))); XPUSHs(&PL_sv_no); PUTBACK; call_method("new", G_SCALAR); SPAGAIN; SV *_mcr = SvREFCNT_inc(POPs); PUTBACK; FREETMPS; LEAVE; _mcr; }));
     xsreturn:
     return retval;
 }
@@ -72,10 +72,6 @@ SV * boolean_add(pTHX_ SV *self, SV *left, SV *right) {
     retval = SvREFCNT_inc(left);
     xsreturn:
     return retval;
-}
-
-SV * boolean_supports_leo(pTHX_ SV *self) {
-    return &PL_sv_yes;
 }
 
 SV * boolean_slot_name(pTHX_ SV *self) {

--- a/t/fixtures/c_src/boolean.h
+++ b/t/fixtures/c_src/boolean.h
@@ -10,7 +10,6 @@ SV * boolean_is_zero(pTHX_ SV *self, SV *value);
 SV * boolean_multiply(pTHX_ SV *self, SV *left, SV *right);
 SV * boolean_one(pTHX_ SV *self);
 SV * boolean_slot_name(pTHX_ SV *self);
-SV * boolean_supports_leo(pTHX_ SV *self);
 SV * boolean_zero(pTHX_ SV *self);
 
 #endif /* CHALK_BOOLEAN_H */


### PR DESCRIPTION
## Summary

With Leo proven structurally correct across Boolean, SemanticAction, and FilterComposite (all in the graph-equivalence harness), the \`supports_leo\` opt-in gate is no longer needed. Leo becomes unconditional for any pure Context-returning semiring — which, post-Step B, means all of them.

## Commits

- \`4153a6f3\` test: add FilterComposite tier to Leo graph-equivalence harness (Tier 4, 27 new assertions — Bool+SA composite exercises the multi-semiring dispatch path with Leo on vs off, all identical hashes)
- \`e78b4e5d\` refactor: remove supports_leo gate; Leo is now unconditional

## What changed

- Delete \`supports_leo\` method from \`Chalk::Bootstrap::Semiring::Boolean\` (no other semiring defined it)
- Delete the \`$_leo_enabled\` field and \`ADJUST\` logic that queried \`$semiring->supports_leo()\` in \`Earley.pm\`
- Collapse \`$_leo_override\` and \`$_leo_enabled\` into a single \`:param\` field \`$_leo_enabled = true\`. Production always runs Leo; tests still pass \`leo_enabled => 0\` to get reference parses for comparison
- Update the stale \"Leo requires supports_leo()\" comment at the resolution site to describe the actual invariant (each item covers one chain level, trees are isomorphic with the non-Leo path)
- Regenerate \`t/fixtures/c_src/boolean.{c,h}\` from Target::C so fixtures reflect the current Boolean API (no supports_leo)
- Remove \`supports_leo\` XSUB from \`t/fixtures/c_src/Boolean.xs\`
- Remove \`supports_leo\` test assertions from \`c-target-boolean.t\`, \`c-build-pipeline.t\`, \`c-boolean-integration.t\`. Also scrubbed lingering M18-era \`on_scan\`/\`on_complete\`/\`should_scan\` refs in \`c-boolean-integration.t\`

## Test plan

- [x] \`t/bootstrap/leo-graph-equivalence.t\` — 4/4 subtests, 97 assertions (Tier 1-3 unchanged, Tier 4 new: 27 composite assertions)
- [x] \`t/bootstrap/earley-leo.t\` — 16/16
- [x] \`t/bootstrap/earley-boolean.t\` — 35/35
- [x] \`t/bootstrap/earley-ambiguous.t\` — 17/17
- [x] \`t/bootstrap/semiring-boolean.t\` — 41/41
- [x] \`t/bootstrap/c-target-boolean.t\` — 49/49 (was 50 pre-removal; -1 for removed supports_leo assertion)
- [x] \`t/bootstrap/c-build-pipeline.t\` — 13/13
- [x] Targeted regression across Boolean/Leo/Earley suites clean