### PR TITLE
feat: add Length and Slice nodes to Chalk IR for cross-load parity

### DIFF
--- a/lib/Chalk/IR/Node/Length.pm
+++ b/lib/Chalk/IR/Node/Length.pm
@@ -1,0 +1,12 @@
+# ABOUTME: Length operation node in the Chalk IR.
+# ABOUTME: Unary data node producing the length of its operand (string or array).
+use 5.42.0;
+use utf8;
+use experimental 'class';
+
+use Chalk::IR::Node::UnaryOp;
+
+class Chalk::IR::Node::Length :isa(Chalk::IR::Node::UnaryOp) {
+    method operation() { 'Length' }
+    method op_str()    { 'length' }
+}

--- a/lib/Chalk/IR/Node/Slice.pm
+++ b/lib/Chalk/IR/Node/Slice.pm
@@ -1,0 +1,11 @@
+# ABOUTME: Slice operation node in the Chalk IR.
+# ABOUTME: Aggregate data node taking a container and index list, producing a slice.
+use 5.42.0;
+use utf8;
+use experimental 'class';
+
+use Chalk::IR::Node::Aggregate;
+
+class Chalk::IR::Node::Slice :isa(Chalk::IR::Node::Aggregate) {
+    method operation() { 'Slice' }
+}

--- a/lib/Chalk/IR/NodeFactory.pm
+++ b/lib/Chalk/IR/NodeFactory.pm
@@ -50,6 +50,8 @@ use Chalk::IR::Node::Complement;
 use Chalk::IR::Node::Defined;
 use Chalk::IR::Node::UnaryPlus;
 use Chalk::IR::Node::Ref;
+use Chalk::IR::Node::Length;
+use Chalk::IR::Node::Slice;
 use Chalk::IR::Node::PadAccess;
 use Chalk::IR::Node::FieldAccess;
 use Chalk::IR::Node::StashAccess;
@@ -85,8 +87,8 @@ my %DATA_CLASSES = map { $_ => "Chalk::IR::Node::$_" } qw(
     StrEq StrNe StrLt StrGt StrLe StrGe StrCmp
     And Or BitAnd BitOr BitXor LeftShift RightShift
     Assign Repeat Match NotMatch DefinedOr Xor Range Yada IsaOp
-    Not Negate Complement Defined UnaryPlus Ref
-    PadAccess FieldAccess StashAccess Subscript
+    Not Negate Complement Defined UnaryPlus Ref Length
+    PadAccess FieldAccess StashAccess Subscript Slice
     Call HashRef ArrayRef Interpolate AnonSub
     RegexMatch RegexSubst TryCatch
     PostfixDeref CompoundAssign BacktickExpr Stringify VarDecl

--- a/t/bootstrap/cross-load-son-json.t
+++ b/t/bootstrap/cross-load-son-json.t
@@ -214,7 +214,85 @@ sub _load_named_methods {
 }
 
 # =============================================================================
-# Test 6: Schema incompatibility report
+# Test 6: Length node — sub { length(shift) }
+# B::SoN lowers length() to a Length data node with a single input.
+# Verifies: Length node round-trips through Chalk::IR NodeFactory.
+# =============================================================================
+
+{
+    my $json = _run_son_json('sub lenny { my $s = shift; length($s) }');
+    ok(defined $json, 'Test 6: B::SoN produced JSON for length sub');
+
+  SKIP: {
+        skip 'no B::SoN JSON produced', 2 unless defined $json;
+
+        require JSON::PP;
+        my $data = eval { JSON::PP->new->decode($json) };
+        # Scan all methods to find one that actually contains a Length node.
+        my ($length_method) = grep {
+            grep { $_->{op} eq 'Length' } $data->{methods}{$_}{nodes}->@*
+        } sort keys $data->{methods}->%*;
+
+      SKIP: {
+            skip 'no Length node produced by B::SoN', 2 unless defined $length_method;
+
+            my $loaded = _load_named_methods($json, $length_method);
+            ok(defined $loaded, 'Test 6: from_json loaded length-bearing method');
+
+          SKIP: {
+                skip 'load failed', 1 unless defined $loaded;
+
+                my $g    = $loaded->{$length_method};
+                my %seen = map { $_->operation() => 1 } $g->nodes()->@*;
+
+                ok($seen{Length}, 'Test 6: Length node present');
+            }
+        }
+    }
+}
+
+# =============================================================================
+# Test 7: Slice node — sub { my @a = (1..10); @a[2,3,4] }
+# B::SoN lowers array/hash slice operations to a Slice data node with
+# (container, indices...) inputs.
+# Verifies: Slice node round-trips through Chalk::IR NodeFactory.
+# =============================================================================
+
+{
+    my $json = _run_son_json('sub slicer { my @a = (1..10); @a[2,3,4] }');
+    ok(defined $json, 'Test 7: B::SoN produced JSON for slice sub');
+
+  SKIP: {
+        skip 'no B::SoN JSON produced', 3 unless defined $json;
+
+        require JSON::PP;
+        my $data = eval { JSON::PP->new->decode($json) };
+        # B::SoN often loses the sub name for slice-heavy bodies; scan all
+        # methods to find one that actually contains a Slice node.
+        my ($slice_method) = grep {
+            grep { $_->{op} eq 'Slice' } $data->{methods}{$_}{nodes}->@*
+        } sort keys $data->{methods}->%*;
+
+      SKIP: {
+            skip 'no Slice node produced by B::SoN', 2 unless defined $slice_method;
+
+            my $loaded = _load_named_methods($json, $slice_method);
+            ok(defined $loaded, 'Test 7: from_json loaded slice-bearing method');
+
+          SKIP: {
+                skip 'load failed', 1 unless defined $loaded;
+
+                my $g    = $loaded->{$slice_method};
+                my %seen = map { $_->operation() => 1 } $g->nodes()->@*;
+
+                ok($seen{Slice}, 'Test 7: Slice node present');
+            }
+        }
+    }
+}
+
+# =============================================================================
+# Test 8: Schema incompatibility report
 # Documents node types that appear in B::SoN output but are not supported
 # by Chalk::IR::NodeFactory, verifying no regressions as coverage expands.
 # =============================================================================
@@ -228,7 +306,7 @@ sub _load_named_methods {
         StrEq StrNe StrLt StrGt StrLe StrGe StrCmp
         And Or BitAnd BitOr BitXor LeftShift RightShift
         Assign Repeat Match NotMatch DefinedOr Xor Range Yada IsaOp
-        Not Negate Complement Defined UnaryPlus Ref
+        Not Negate Complement Defined UnaryPlus Ref Length Slice
         PadAccess FieldAccess StashAccess Subscript
         Call HashRef ArrayRef Interpolate AnonSub
         RegexMatch RegexSubst TryCatch
@@ -266,7 +344,7 @@ sub _load_named_methods {
 
         # All node types in B::SoN output should now be supported by Chalk.
         ok(!@unsupported,
-            'Test 6: all B::SoN node types supported by Chalk NodeFactory')
+            'Test 8: all B::SoN node types supported by Chalk NodeFactory')
             or diag "Unsupported ops: @unsupported";
     }
 }


### PR DESCRIPTION
## Summary

- Add `Chalk::IR::Node::Length` (UnaryOp) and `Chalk::IR::Node::Slice` (Aggregate).
- Register both in `NodeFactory` so `cross-load-son-json.t`'s schema contract goes green.
- Add round-trip tests for both node types through B::SoN → JSON → Chalk IR.

## Why

`t/bootstrap/cross-load-son-json.t` was failing on `Unsupported ops: Length Slice` — B::SoN had added these ops (from `length/av2arylen` and `aslice/hslice/lslice/etc.` lowerings) but Chalk's NodeFactory didn't recognize them. This was the first unexpected divergence surfaced by the SoN-comparison work and is an orthogonal, easily-fixable gap.

Length is unary (single input, no extra fields). Slice is aggregate (container + index list). Neither carries metadata beyond `inputs`, so `Serialize::JSON` needs no changes.

## Test plan

- [x] `t/bootstrap/cross-load-son-json.t` — all 31 tests pass (was 24/25 before)
- [x] Test 6: round-trip Length through B::SoN → JSON → Chalk; verify Length node present
- [x] Test 7: round-trip Slice through B::SoN → JSON → Chalk; verify Slice node present
- [x] Test 8: schema contract — all B::SoN ops now supported by Chalk NodeFactory
- [x] `t/bootstrap/son-compare.t` — 6/6 pilot pass (no regression)
- [x] Pre-existing failures (`concise-*.t`, `bootstrap-validation.t`, `c-data-model-classes.t`) verified unchanged via `git stash` comparison

## Not in scope

Broader NodeFactory issues found during this session are filed as #720 (Click-style direct-construction rewrite). Full-lib SoN comparison expansion is blocked until #720 lands.